### PR TITLE
Add RDB frame configuration scaffolding

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -174,6 +174,31 @@ configEnum rdb_version_check_enum[] = {{"strict", RDB_VERSION_CHECK_STRICT},
                                        {"relaxed", RDB_VERSION_CHECK_RELAXED},
                                        {NULL, 0}};
 
+configEnum rdb_compression_mode_enum[] = {{"legacy", RDB_FR_MODE_LEGACY},
+                                          {"block", RDB_FR_MODE_BLOCK},
+                                          {"auto", RDB_FR_MODE_AUTO},
+                                          {NULL, 0}};
+
+configEnum rdb_compression_file_mode_enum[] = {{"legacy", RDB_FR_FILE_MODE_LEGACY},
+                                               {"block", RDB_FR_FILE_MODE_BLOCK},
+                                               {NULL, 0}};
+
+configEnum rdb_compression_codec_enum[] = {{"raw", RDB_FR_CODEC_RAW},
+                                           {"lz4", RDB_FR_CODEC_LZ4},
+                                           {"zstd", RDB_FR_CODEC_ZSTD},
+                                           {NULL, 0}};
+
+configEnum rdb_compression_checksum_enum[] = {{"crc64", RDB_FR_CHECKSUM_CRC64},
+                                              {"none", RDB_FR_CHECKSUM_NONE},
+                                              {NULL, 0}};
+
+static int applyRdbFrameConfig(const char **err) {
+    UNUSED(err);
+    serverLog(LL_NOTICE,
+              "RDB framing configuration updated. Changes apply to the next BGSAVE / next full resync.");
+    return 1;
+}
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0},                                 /* normal */
@@ -3184,6 +3209,16 @@ standardConfig static_configs[] = {
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
+    createEnumConfig("rdb-compression-mode", NULL, MODIFIABLE_CONFIG, rdb_compression_mode_enum,
+                     server.rdb_frame_config.mode, RDB_FR_MODE_AUTO, NULL, applyRdbFrameConfig),
+    createEnumConfig("rdb-compression-file-mode", NULL, MODIFIABLE_CONFIG, rdb_compression_file_mode_enum,
+                     server.rdb_frame_config.file_mode, RDB_FR_FILE_MODE_LEGACY, NULL, applyRdbFrameConfig),
+    createEnumConfig("rdb-compression-codec", NULL, MODIFIABLE_CONFIG, rdb_compression_codec_enum,
+                     server.rdb_frame_config.codec, RDB_FR_CODEC_ZSTD, NULL, applyRdbFrameConfig),
+    createSizeTConfig("rdb-compression-block-bytes", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX,
+                      server.rdb_frame_config.block_bytes, 262144, MEMORY_CONFIG, NULL, applyRdbFrameConfig),
+    createEnumConfig("rdb-compression-checksum", NULL, MODIFIABLE_CONFIG, rdb_compression_checksum_enum,
+                     server.rdb_frame_config.checksum, RDB_FR_CHECKSUM_CRC64, NULL, applyRdbFrameConfig),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),

--- a/src/rdb_frame.h
+++ b/src/rdb_frame.h
@@ -1,0 +1,36 @@
+/*
+ * RDB frame format definitions.
+ *
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RDB_FRAME_H
+#define RDB_FRAME_H
+
+#include <stdint.h>
+
+#define RDB_FR_MAGIC0 'R'
+#define RDB_FR_MAGIC1 'B'
+#define RDB_FR_MAGIC2 'C'
+#define RDB_FR_MAGIC3 1 /* version */
+
+/* Supported frame codecs. */
+#define RDB_FR_CODEC_RAW 0
+#define RDB_FR_CODEC_LZ4 1
+#define RDB_FR_CODEC_ZSTD 2
+
+/* Frame flags. */
+#define RDB_FR_FLAG_LAST 1
+
+typedef struct __attribute__((packed)) RdbFrameBlockHdr {
+    uint8_t magic[4];   /* RBC\1 */
+    uint8_t codec;      /* 0=RAW,1=LZ4,2=ZSTD */
+    uint8_t flags;      /* bit0: last-block */
+    uint32_t raw_len_le; /* uncompressed bytes */
+    uint32_t cmp_len_le; /* compressed bytes */
+    uint64_t crc64_le;   /* over header (except crc) + payload */
+} RdbFrameBlockHdr;
+
+#endif /* RDB_FRAME_H */

--- a/src/server.h
+++ b/src/server.h
@@ -101,6 +101,7 @@ typedef struct serverObject robj;
 #include "sha1.h"
 #include "endianconv.h"
 #include "crc64.h"
+#include "rdb_frame.h"
 
 struct hdr_histogram;
 
@@ -656,6 +657,19 @@ typedef enum {
 #define RDB_CHILD_TYPE_NONE 0
 #define RDB_CHILD_TYPE_DISK 1   /* RDB is written to disk. */
 #define RDB_CHILD_TYPE_SOCKET 2 /* RDB is written to replica socket. */
+
+/* RDB frame configuration modes. */
+#define RDB_FR_MODE_LEGACY 0
+#define RDB_FR_MODE_BLOCK 1
+#define RDB_FR_MODE_AUTO 2
+
+/* RDB frame file output modes. */
+#define RDB_FR_FILE_MODE_LEGACY 0
+#define RDB_FR_FILE_MODE_BLOCK 1
+
+/* RDB frame checksum options. */
+#define RDB_FR_CHECKSUM_CRC64 0
+#define RDB_FR_CHECKSUM_NONE 1
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes. */
@@ -1547,6 +1561,14 @@ typedef struct rdbSaveInfo {
 
 #define RDB_SAVE_INFO_INIT {-1, 0, "0000000000000000000000000000000000000000", -1}
 
+typedef struct rdb_frame_opts {
+    int mode;           /* legacy|block|auto */
+    int file_mode;      /* legacy|block */
+    int codec;          /* RAW/LZ4/ZSTD */
+    size_t block_bytes; /* target block size */
+    int checksum;       /* crc64|none */
+} rdb_frame_opts;
+
 struct malloc_stats {
     size_t zmalloc_used;
     size_t process_rss;
@@ -1964,6 +1986,7 @@ struct valkeyServer {
     char *rdb_filename;                   /* Name of RDB file */
     int rdb_compression;                  /* Use compression in RDB? */
     int rdb_checksum;                     /* Use RDB checksum? */
+    rdb_frame_opts rdb_frame_config;      /* Configured RDB framing options. */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
                                              the instance does not use persistence. */
     time_t lastsave;                      /* Unix time of last successful save */


### PR DESCRIPTION
## Summary
- add the rdb_frame.h header that defines the block header format and codec identifiers
- extend server state with rdb_frame_opts and expose new rdb framing options via CONFIG
- log when rdb framing CONFIG options are updated so users know the changes apply on the next BGSAVE/full resync

## Testing
- make -j4

------
https://chatgpt.com/codex/tasks/task_e_68c9b672cce4832ba7c9dd35bbbbbe28