### PR TITLE
Add RDB codec abstraction with LZ4/LZF support

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -31,6 +31,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/db.c
     ${CMAKE_SOURCE_DIR}/src/replication.c
     ${CMAKE_SOURCE_DIR}/src/rdb.c
+    ${CMAKE_SOURCE_DIR}/src/rdb_codec.c
     ${CMAKE_SOURCE_DIR}/src/t_string.c
     ${CMAKE_SOURCE_DIR}/src/t_list.c
     ${CMAKE_SOURCE_DIR}/src/t_set.c

--- a/cmake/Modules/ValkeySetup.cmake
+++ b/cmake/Modules/ValkeySetup.cmake
@@ -329,7 +329,7 @@ if (PYTHON_EXE)
 
     # Rule for generating test_files.h
     message(STATUS "Adding target generate_test_files_h")
-    file(GLOB UNIT_TEST_SRCS "${CMAKE_SOURCE_DIR}/src/unit/*.c")
+    file(GLOB UNIT_TEST_SRCS "${CMAKE_SOURCE_DIR}/src/unit/*.c" "${CMAKE_SOURCE_DIR}/tests/unit/*.c")
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/test_files_generated
         DEPENDS "${UNIT_TEST_SRCS};${CMAKE_SOURCE_DIR}/utils/generate-unit-test-header.py"

--- a/src/Makefile
+++ b/src/Makefile
@@ -423,7 +423,7 @@ ENGINE_NAME=valkey
 SERVER_NAME=$(ENGINE_NAME)-server$(PROG_SUFFIX)
 ENGINE_SENTINEL_NAME=$(ENGINE_NAME)-sentinel$(PROG_SUFFIX)
 ENGINE_TRACE_OBJ=trace/trace.o trace/trace_commands.o trace/trace_db.o trace/trace_cluster.o trace/trace_server.o trace/trace_rdb.o trace/trace_aof.o
-ENGINE_SERVER_OBJ=threads_mngr.o adlist.o vector.o quicklist.o ae.o anet.o dict.o hashtable.o kvstore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o lz4.o pqsort.o zipmap.o sha1.o ziplist.o release.o memory_prefetch.o io_threads.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_legacy.o cluster_slot_stats.o crc16.o cluster_migrateslots.o endianconv.o commandlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o allocator_defrag.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script.o functions.o commands.o strl.o connection.o unix.o logreqres.o rdma.o scripting_engine.o entry.o vset.o lua/script_lua.o lua/function_lua.o lua/engine_lua.o lua/debug_lua.o
+ENGINE_SERVER_OBJ=threads_mngr.o adlist.o vector.o quicklist.o ae.o anet.o dict.o hashtable.o kvstore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o lz4.o pqsort.o zipmap.o sha1.o ziplist.o release.o memory_prefetch.o io_threads.o networking.o util.o object.o db.o replication.o rdb.o rdb_codec.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_legacy.o cluster_slot_stats.o crc16.o cluster_migrateslots.o endianconv.o commandlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o allocator_defrag.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script.o functions.o commands.o strl.o connection.o unix.o logreqres.o rdma.o scripting_engine.o entry.o vset.o lua/script_lua.o lua/function_lua.o lua/engine_lua.o lua/debug_lua.o
 ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)
 ENGINE_CLI_OBJ=anet.o adlist.o dict.o valkey-cli.o zmalloc.o release.o ae.o serverassert.o crcspeed.o crccombine.o crc64.o siphash.o crc16.o monotonic.o cli_common.o mt19937-64.o strl.o cli_commands.o sds.o util.o sha256.o
@@ -432,8 +432,9 @@ ENGINE_BENCHMARK_OBJ=ae.o anet.o valkey-benchmark.o adlist.o dict.o zmalloc.o se
 ENGINE_CHECK_RDB_NAME=$(ENGINE_NAME)-check-rdb$(PROG_SUFFIX)
 ENGINE_CHECK_AOF_NAME=$(ENGINE_NAME)-check-aof$(PROG_SUFFIX)
 ENGINE_LIB_NAME=lib$(ENGINE_NAME).a
-ENGINE_TEST_FILES:=$(wildcard unit/*.c)
-ENGINE_TEST_OBJ:=$(sort $(patsubst unit/%.c,unit/%.o,$(ENGINE_TEST_FILES)))
+ENGINE_TEST_DIRS:=unit ../tests/unit
+ENGINE_TEST_FILES:=$(foreach dir,$(ENGINE_TEST_DIRS),$(wildcard $(dir)/*.c))
+ENGINE_TEST_OBJ:=$(sort $(patsubst %.c,%.o,$(ENGINE_TEST_FILES)))
 ENGINE_UNIT_TESTS:=$(ENGINE_NAME)-unit-tests$(PROG_SUFFIX)
 ALL_SOURCES=$(sort $(patsubst %.o,%.c,$(ENGINE_SERVER_OBJ) $(ENGINE_CLI_OBJ) $(ENGINE_BENCHMARK_OBJ)))
 
@@ -565,7 +566,7 @@ fmtargs.h: ../utils/generate-fmtargs.py
 	$(QUITE_GEN)$(PYTHON) ../utils/generate-fmtargs.py >> $@.tmp
 	$(QUITE_GEN)mv $@.tmp $@
 
-unit/test_files.h: unit/*.c ../utils/generate-unit-test-header.py
+unit/test_files.h: unit/*.c ../tests/unit/*.c ../utils/generate-unit-test-header.py
 	$(QUIET_GEN)$(PYTHON) ../utils/generate-unit-test-header.py
 
 unit/test_main.o: unit/test_files.h
@@ -574,7 +575,7 @@ endif
 commands.c: $(COMMANDS_DEF_FILENAME).def
 
 clean:
-	rm -rf $(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(ENGINE_UNIT_TESTS) $(ENGINE_LIB_NAME) unit/*.o unit/*.d lua/*.o lua/*.d trace/*.o trace/*.d *.o *.gcda *.gcno *.gcov valkey.info lcov-html Makefile.dep *.so
+	 rm -rf $(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(ENGINE_UNIT_TESTS) $(ENGINE_LIB_NAME) unit/*.o unit/*.d ../tests/unit/*.o ../tests/unit/*.d lua/*.o lua/*.d trace/*.o trace/*.d *.o *.gcda *.gcno *.gcov valkey.info lcov-html Makefile.dep *.so
 	rm -f $(DEP)
 
 .PHONY: clean

--- a/src/rdb_codec.c
+++ b/src/rdb_codec.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "rdb_codec.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+#include "lzf.h"
+#include "lz4.h"
+#include "zmalloc.h"
+
+#ifndef C_OK
+#define C_OK 0
+#endif
+#ifndef C_ERR
+#define C_ERR -1
+#endif
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
+
+struct rdb_codec_ctx {
+    rdb_codec_t codec;
+    LZ4_stream_t *lz4_stream;
+};
+
+static int rdbCodecEnsureOutputBuffer(sds *buf) {
+    if (*buf == NULL) {
+        *buf = sdsempty();
+        if (*buf == NULL) return C_ERR;
+    } else {
+        sdsclear(*buf);
+    }
+    return C_OK;
+}
+
+static int rdbCodecEnsureCapacity(sds *buf, size_t needed) {
+    if (needed == 0) return C_OK;
+    size_t avail = sdsalloc(*buf);
+    if (avail >= needed) return C_OK;
+    size_t add = needed - avail;
+    *buf = sdsMakeRoomFor(*buf, add);
+    return *buf ? C_OK : C_ERR;
+}
+
+static int rdbCodecStoreRaw(const void *src, size_t src_len, sds *dst, rdb_codec_t *actual_codec) {
+    if (src_len > 0) {
+        *dst = sdscpylen(*dst, src, src_len);
+        if (*dst == NULL) return C_ERR;
+    } else {
+        sdsclear(*dst);
+    }
+    if (actual_codec) *actual_codec = RDBC_RAW;
+    return C_OK;
+}
+
+static int rdbCodecShouldFallback(size_t cmp_len, size_t src_len) {
+    if (src_len == 0) return 1;
+    size_t threshold = src_len - (src_len >> 6);
+    return cmp_len >= threshold;
+}
+
+static int rdbCodecCompressLZ4(rdb_codec_ctx *ctx, const void *src, size_t src_len, sds *dst, rdb_codec_t *actual_codec) {
+    UNUSED(ctx);
+    if (src_len > (size_t)LZ4_MAX_INPUT_SIZE || src_len > (size_t)INT_MAX) {
+        return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+    }
+
+    int input_size = (int)src_len;
+    int bound = LZ4_compressBound(input_size);
+    if (bound <= 0) return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+    if (rdbCodecEnsureCapacity(dst, (size_t)bound) == C_ERR) return C_ERR;
+
+    char *out = *dst;
+    int cmp_len = LZ4_compress_default(src, out, input_size, bound);
+    if (cmp_len <= 0) return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+
+    if (rdbCodecShouldFallback((size_t)cmp_len, src_len)) {
+        return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+    }
+
+    sdssetlen(*dst, (size_t)cmp_len);
+    out[cmp_len] = '\0';
+    if (actual_codec) *actual_codec = RDBC_LZ4;
+    return C_OK;
+}
+
+static int rdbCodecCompressLZF(const void *src, size_t src_len, sds *dst, rdb_codec_t *actual_codec) {
+    size_t capacity = src_len > 0 ? src_len : 1;
+    if (rdbCodecEnsureCapacity(dst, capacity) == C_ERR) return C_ERR;
+    char *out = *dst;
+
+    size_t cmp_len = lzf_compress(src, src_len, out, capacity);
+    if (cmp_len == 0 || rdbCodecShouldFallback(cmp_len, src_len)) {
+        return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+    }
+
+    sdssetlen(*dst, cmp_len);
+    out[cmp_len] = '\0';
+    if (actual_codec) *actual_codec = RDBC_LZF;
+    return C_OK;
+}
+
+static int rdbCodecDecompressRaw(const void *src, size_t src_len, sds *dst) {
+    return rdbCodecStoreRaw(src, src_len, dst, NULL);
+}
+
+static int rdbCodecDecompressLZF(const void *src, size_t src_len, sds *dst) {
+    if (src_len == 0) {
+        sdsclear(*dst);
+        return C_OK;
+    }
+
+    size_t desired = sdsalloc(*dst);
+    if (desired < src_len) desired = src_len;
+    if (desired == 0) desired = src_len ? src_len : 64;
+
+    for (size_t attempt = 0; attempt < 16; attempt++) {
+        if (desired == 0) desired = 64;
+        if (rdbCodecEnsureCapacity(dst, desired) == C_ERR) return C_ERR;
+        char *buf = *dst;
+        size_t capacity = sdsalloc(*dst);
+
+        errno = 0;
+        size_t out_len = lzf_decompress(src, src_len, buf, capacity);
+        if (out_len > 0 || (out_len == 0 && errno == 0)) {
+            sdssetlen(*dst, out_len);
+            buf[out_len] = '\0';
+            return C_OK;
+        }
+        if (errno != E2BIG) break;
+        if (capacity >= SIZE_MAX) break;
+        desired = capacity >= SIZE_MAX / 2 ? SIZE_MAX : capacity * 2;
+        if (desired == capacity) break;
+    }
+
+    return C_ERR;
+}
+
+static int rdbCodecDecompressLZ4(const void *src, size_t src_len, sds *dst) {
+    if (src_len == 0) {
+        sdsclear(*dst);
+        return C_OK;
+    }
+    if (src_len > (size_t)INT_MAX) return C_ERR;
+
+    size_t desired = sdsalloc(*dst);
+    if (desired < src_len) desired = src_len;
+    if (desired == 0) {
+        if (src_len > SIZE_MAX / 4) desired = (size_t)INT_MAX;
+        else desired = src_len * 4;
+        if (desired < src_len) desired = src_len;
+    }
+    if (desired == 0) desired = 64;
+    if (desired > (size_t)INT_MAX) desired = (size_t)INT_MAX;
+
+    for (size_t attempt = 0; attempt < 16; attempt++) {
+        if (desired == 0) desired = 64;
+        if (desired > (size_t)INT_MAX) desired = (size_t)INT_MAX;
+        if (rdbCodecEnsureCapacity(dst, desired) == C_ERR) return C_ERR;
+        char *buf = *dst;
+        size_t capacity = sdsalloc(*dst);
+        int dest_capacity = capacity > (size_t)INT_MAX ? INT_MAX : (int)capacity;
+
+        int result = LZ4_decompress_safe(src, buf, (int)src_len, dest_capacity);
+        if (result >= 0) {
+            sdssetlen(*dst, (size_t)result);
+            buf[result] = '\0';
+            return C_OK;
+        }
+        if (dest_capacity == INT_MAX) break;
+        size_t new_desired = capacity >= SIZE_MAX / 2 ? SIZE_MAX : capacity * 2;
+        if (new_desired > (size_t)INT_MAX) new_desired = (size_t)INT_MAX;
+        if (new_desired <= capacity) break;
+        desired = new_desired;
+    }
+
+    return C_ERR;
+}
+
+rdb_codec_ctx *rdbCodecCreate(rdb_codec_t codec) {
+    rdb_codec_ctx *ctx = zmalloc(sizeof(*ctx));
+    if (ctx == NULL) return NULL;
+    ctx->codec = codec;
+    ctx->lz4_stream = NULL;
+
+    if (codec == RDBC_LZ4) {
+        ctx->lz4_stream = LZ4_createStream();
+        if (ctx->lz4_stream == NULL) {
+            zfree(ctx);
+            return NULL;
+        }
+    }
+
+    return ctx;
+}
+
+void rdbCodecFree(rdb_codec_ctx *ctx) {
+    if (ctx == NULL) return;
+    if (ctx->lz4_stream) LZ4_freeStream(ctx->lz4_stream);
+    zfree(ctx);
+}
+
+int rdbCodecCompress(rdb_codec_ctx *ctx,
+                     const void *src, size_t src_len,
+                     sds *dst, rdb_codec_t *actual_codec) {
+    if (ctx == NULL || dst == NULL || (src == NULL && src_len > 0)) return C_ERR;
+    if (rdbCodecEnsureOutputBuffer(dst) == C_ERR) return C_ERR;
+
+    if (ctx->codec == RDBC_RAW || src_len == 0) {
+        return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+    }
+
+    switch (ctx->codec) {
+    case RDBC_LZ4:
+        return rdbCodecCompressLZ4(ctx, src, src_len, dst, actual_codec);
+    case RDBC_LZF:
+        return rdbCodecCompressLZF(src, src_len, dst, actual_codec);
+    default:
+        return rdbCodecStoreRaw(src, src_len, dst, actual_codec);
+    }
+}
+
+int rdbCodecDecompress(rdb_codec_t codec,
+                       const void *src, size_t src_len,
+                       sds *dst) {
+    if (dst == NULL || (src == NULL && src_len > 0)) return C_ERR;
+    if (rdbCodecEnsureOutputBuffer(dst) == C_ERR) return C_ERR;
+
+    switch (codec) {
+    case RDBC_RAW:
+        return rdbCodecDecompressRaw(src, src_len, dst);
+    case RDBC_LZ4:
+        return rdbCodecDecompressLZ4(src, src_len, dst);
+    case RDBC_LZF:
+        return rdbCodecDecompressLZF(src, src_len, dst);
+    default:
+        return C_ERR;
+    }
+}

--- a/src/rdb_codec.h
+++ b/src/rdb_codec.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef VALKEY_RDB_CODEC_H
+#define VALKEY_RDB_CODEC_H
+
+#include <stddef.h>
+#include "sds.h"
+
+typedef enum {
+    RDBC_RAW = 0,
+    RDBC_LZ4 = 1,
+    RDBC_LZF = 2
+} rdb_codec_t;
+
+typedef struct rdb_codec_ctx rdb_codec_ctx;
+
+rdb_codec_ctx *rdbCodecCreate(rdb_codec_t codec);
+void rdbCodecFree(rdb_codec_ctx *ctx);
+
+/* Compress 'src' -> grows 'dst' as needed; may return RAW passthrough if ratio poor. */
+int rdbCodecCompress(rdb_codec_ctx *ctx,
+                     const void *src, size_t src_len,
+                     sds *dst, rdb_codec_t *actual_codec);
+
+/* Decompress depending on 'codec' -> into 'dst' (sds). */
+int rdbCodecDecompress(rdb_codec_t codec,
+                       const void *src, size_t src_len,
+                       sds *dst);
+
+#endif /* VALKEY_RDB_CODEC_H */

--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(valkey-unit-tests)
 
-file(GLOB UNIT_TEST_SRCS "${CMAKE_CURRENT_LIST_DIR}/*.c")
+file(GLOB UNIT_TEST_SRCS "${CMAKE_CURRENT_LIST_DIR}/*.c" "${CMAKE_CURRENT_LIST_DIR}/../../tests/unit/*.c")
 set(UNIT_TEST_SRCS "${UNIT_TEST_SRCS}")
 
 get_valkey_server_linker_option(VALKEY_SERVER_LDFLAGS)

--- a/src/unit/test_files.h
+++ b/src/unit/test_files.h
@@ -6,6 +6,8 @@ typedef struct unitTest {
     unitTestProc *proc;
 } unitTest;
 
+int test_rdb_codec_roundtrip(int argc, char **argv, int flags);
+int test_rdb_codec_raw_fallback(int argc, char **argv, int flags);
 int test_popcount(int argc, char **argv, int flags);
 int test_crc64(int argc, char **argv, int flags);
 int test_crc64combine(int argc, char **argv, int flags);
@@ -252,6 +254,7 @@ int test_zipmapIterateThroughElements(int argc, char *argv[], int flags);
 int test_zmallocAllocReallocCallocAndFree(int argc, char **argv, int flags);
 int test_zmallocAllocZeroByteAndFree(int argc, char **argv, int flags);
 
+unitTest __rdb_codec_unit_c[] = {{"test_rdb_codec_roundtrip", test_rdb_codec_roundtrip}, {"test_rdb_codec_raw_fallback", test_rdb_codec_raw_fallback}, {NULL, NULL}};
 unitTest __test_bitops_c[] = {{"test_popcount", test_popcount}, {NULL, NULL}};
 unitTest __test_crc64_c[] = {{"test_crc64", test_crc64}, {NULL, NULL}};
 unitTest __test_crc64combine_c[] = {{"test_crc64combine", test_crc64combine}, {NULL, NULL}};
@@ -280,6 +283,7 @@ struct unitTestSuite {
     char *filename;
     unitTest *tests;
 } unitTestSuite[] = {
+    {"rdb_codec_unit.c", __rdb_codec_unit_c},
     {"test_bitops.c", __test_bitops_c},
     {"test_crc64.c", __test_crc64_c},
     {"test_crc64combine.c", __test_crc64combine_c},

--- a/tests/unit/rdb_codec_unit.c
+++ b/tests/unit/rdb_codec_unit.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <string.h>
+#include <stdint.h>
+
+#include "../../src/unit/test_help.h"
+#include "../../src/rdb_codec.h"
+
+#ifndef C_OK
+#define C_OK 0
+#endif
+#ifndef C_ERR
+#define C_ERR -1
+#endif
+
+#define PATTERN_COUNT 10
+
+static sds createRepeatingPattern(const char *seed, size_t repeat) {
+    size_t seed_len = strlen(seed);
+    size_t total = seed_len * repeat;
+    sds s = sdsnewlen(SDS_NOINIT, total);
+    char *ptr = s;
+    for (size_t i = 0; i < repeat; i++) {
+        memcpy(ptr + (i * seed_len), seed, seed_len);
+    }
+    ptr[total] = '\0';
+    return s;
+}
+
+static void buildTestPatterns(sds patterns[PATTERN_COUNT]) {
+    patterns[0] = sdsempty();
+    patterns[1] = sdsnew("short string for codec tests");
+
+    patterns[2] = sdsnewlen(SDS_NOINIT, 256);
+    memset(patterns[2], 'a', sdslen(patterns[2]));
+    patterns[2][sdslen(patterns[2])] = '\0';
+
+    patterns[3] = createRepeatingPattern("0123456789abcdef", 64);
+
+    patterns[4] = sdsnewlen(SDS_NOINIT, 512);
+    for (size_t i = 0; i < sdslen(patterns[4]); i++) {
+        patterns[4][i] = (char)('A' + (i % 26));
+    }
+    patterns[4][sdslen(patterns[4])] = '\0';
+
+    patterns[5] = createRepeatingPattern("The quick brown fox jumps over the lazy dog. ", 40);
+
+    patterns[6] = sdsnewlen(SDS_NOINIT, 2048);
+    memset(patterns[6], 0, sdslen(patterns[6]));
+    patterns[6][sdslen(patterns[6])] = '\0';
+
+    patterns[7] = sdsnewlen(SDS_NOINIT, 1536);
+    for (size_t i = 0; i < sdslen(patterns[7]); i++) {
+        patterns[7][i] = (char)((i * 7) & 0xff);
+    }
+    patterns[7][sdslen(patterns[7])] = '\0';
+
+    patterns[8] = createRepeatingPattern("VALKEY", 300);
+
+    patterns[9] = sdsnewlen(SDS_NOINIT, 1024);
+    for (size_t i = 0; i < sdslen(patterns[9]); i++) {
+        patterns[9][i] = (char)((i * 17 + 3) & 0xff);
+    }
+    patterns[9][sdslen(patterns[9])] = '\0';
+}
+
+int test_rdb_codec_roundtrip(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    sds patterns[PATTERN_COUNT];
+    buildTestPatterns(patterns);
+
+    rdb_codec_ctx *raw = rdbCodecCreate(RDBC_RAW);
+    rdb_codec_ctx *lz4 = rdbCodecCreate(RDBC_LZ4);
+    rdb_codec_ctx *lzf = rdbCodecCreate(RDBC_LZF);
+    TEST_ASSERT(raw && lz4 && lzf);
+
+    rdb_codec_ctx *contexts[] = {raw, lz4, lzf};
+    sds compressed = NULL;
+    sds plain = NULL;
+
+    for (size_t pattern_index = 0; pattern_index < PATTERN_COUNT; pattern_index++) {
+        sds pattern = patterns[pattern_index];
+        size_t pattern_len = sdslen(pattern);
+        for (size_t codec_index = 0; codec_index < sizeof(contexts) / sizeof(contexts[0]); codec_index++) {
+            rdb_codec_ctx *ctx = contexts[codec_index];
+            rdb_codec_t actual = RDBC_RAW;
+            TEST_ASSERT(rdbCodecCompress(ctx, pattern, pattern_len, &compressed, &actual) == C_OK);
+            TEST_ASSERT(compressed != NULL);
+
+            TEST_ASSERT(rdbCodecDecompress(actual, compressed, sdslen(compressed), &plain) == C_OK);
+            TEST_ASSERT(sdslen(plain) == pattern_len);
+            if (pattern_len > 0) {
+                TEST_ASSERT(memcmp(plain, pattern, pattern_len) == 0);
+            }
+        }
+    }
+
+    if (compressed) sdsfree(compressed);
+    if (plain) sdsfree(plain);
+    rdbCodecFree(raw);
+    rdbCodecFree(lz4);
+    rdbCodecFree(lzf);
+    for (size_t i = 0; i < PATTERN_COUNT; i++) {
+        sdsfree(patterns[i]);
+    }
+    return 0;
+}
+
+int test_rdb_codec_raw_fallback(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    rdb_codec_ctx *lz4 = rdbCodecCreate(RDBC_LZ4);
+    rdb_codec_ctx *lzf = rdbCodecCreate(RDBC_LZF);
+    TEST_ASSERT(lz4 && lzf);
+
+    sds compressed = NULL;
+    sds plain = NULL;
+    const size_t len = 1024;
+    sds pattern = sdsnewlen(SDS_NOINIT, len);
+    rdb_codec_ctx *contexts[] = {lz4, lzf};
+
+    for (size_t codec_index = 0; codec_index < sizeof(contexts) / sizeof(contexts[0]); codec_index++) {
+        rdb_codec_ctx *ctx = contexts[codec_index];
+        int fallback_triggered = 0;
+        uint64_t seed = 0x123456789abcdef0ULL + codec_index * 0x9e3779b97f4a7c15ULL;
+        for (size_t attempt = 0; attempt < 32; attempt++) {
+            uint64_t state = seed + attempt * 0xd1342543de82ef95ULL;
+            for (size_t i = 0; i < len; i++) {
+                state = state * 6364136223846793005ULL + 1;
+                pattern[i] = (char)(state >> 32);
+            }
+            pattern[len] = '\0';
+
+            rdb_codec_t actual = RDBC_RAW;
+            TEST_ASSERT(rdbCodecCompress(ctx, pattern, len, &compressed, &actual) == C_OK);
+            if (actual == RDBC_RAW) {
+                TEST_ASSERT(rdbCodecDecompress(actual, compressed, sdslen(compressed), &plain) == C_OK);
+                TEST_ASSERT(sdslen(plain) == len);
+                TEST_ASSERT(memcmp(plain, pattern, len) == 0);
+                fallback_triggered = 1;
+                break;
+            }
+        }
+        TEST_ASSERT(fallback_triggered);
+    }
+
+    if (compressed) sdsfree(compressed);
+    if (plain) sdsfree(plain);
+    sdsfree(pattern);
+    rdbCodecFree(lz4);
+    rdbCodecFree(lzf);
+    return 0;
+}

--- a/utils/generate-unit-test-header.py
+++ b/utils/generate-unit-test-header.py
@@ -2,7 +2,12 @@
 import os
 import re
 
-UNIT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + '/../src/unit')
+BASE_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+UNIT_DIR = os.path.abspath(BASE_DIR + '/../src/unit')
+EXTRA_UNIT_DIR = os.path.abspath(BASE_DIR + '/../tests/unit')
+UNIT_DIRS = [UNIT_DIR]
+if os.path.isdir(EXTRA_UNIT_DIR):
+    UNIT_DIRS.append(EXTRA_UNIT_DIR)
 TEST_FILE = UNIT_DIR + '/test_files.h'
 TEST_PROTOTYPE = r'(int (test_[a-zA-Z0-9_]*)\(.*\)).*{'
 
@@ -10,19 +15,20 @@ if __name__ == '__main__':
     with open(TEST_FILE, 'w') as output:
         # Find each test file and collect the test names.
         test_suites = []
-        for root, dirs, files in os.walk(UNIT_DIR):
-            for file in files:
-                file_path = UNIT_DIR + '/' + file
-                if not file.endswith('.c') or file == 'test_main.c':
-                    continue
-                tests = []
-                with open(file_path, 'r') as f:
-                    for line in f:
-                        match = re.match(TEST_PROTOTYPE, line)
-                        if match:
-                            function = match.group(1)
-                            test_name = match.group(2)
-                            tests.append((test_name, function))
+        for unit_dir in UNIT_DIRS:
+            for root, dirs, files in os.walk(unit_dir):
+                for file in files:
+                    if not file.endswith('.c') or file == 'test_main.c':
+                        continue
+                    file_path = os.path.join(root, file)
+                    tests = []
+                    with open(file_path, 'r') as f:
+                        for line in f:
+                            match = re.match(TEST_PROTOTYPE, line)
+                            if match:
+                                function = match.group(1)
+                                test_name = match.group(2)
+                                tests.append((test_name, function))
                     test_suites.append({'file': file, 'tests': tests})
         test_suites.sort(key=lambda test_suite: test_suite['file'])
         output.write("""/* Do not modify this file, it's automatically generated from utils/generate-unit-test-header.py */


### PR DESCRIPTION
## Summary
- add an rdb_codec API and implementation covering raw, LZ4, and LZF with automatic raw fallbacks
- hook the new codec into the build system and extend unit-test discovery to include tests/unit sources
- add unit coverage for codec round-trips and raw fallback behavior

## Testing
- make test-unit

------
https://chatgpt.com/codex/tasks/task_e_68c9fe3f23d0832b840761062ad6bd42