### PR TITLE
Support loading framed RDB files

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -30,6 +30,8 @@
 #include "server.h"
 #include "bio.h"
 #include "rio.h"
+#include "rio_decompress.h"
+#include "rdb_frame.h"
 #include "functions.h"
 #include "module.h"
 
@@ -1438,12 +1440,19 @@ int loadSingleAppendOnlyFile(char *filename) {
      * or old style RDB-preamble AOF). In that case we need to load the RDB file
      * and later continue loading the AOF tail if it is an old style RDB-preamble AOF. */
     char sig[6]; /* "REDIS" or "VALKEY" */
-    if (fread(sig, 1, 6, fp) != 6 || (memcmp(sig, "REDIS0", 6) != 0 && memcmp(sig, "VALKEY", 6) != 0)) {
+    size_t siglen = fread(sig, 1, sizeof(sig), fp);
+    int is_rdb_magic = siglen == sizeof(sig) &&
+                       (memcmp(sig, "REDIS0", sizeof(sig)) == 0 || memcmp(sig, "VALKEY", sizeof(sig)) == 0);
+    int is_frame_magic = siglen >= 4 && rdbFrameHasMagicPrefix((unsigned char *)sig, siglen);
+    if (!is_rdb_magic && !is_frame_magic) {
         /* Not in RDB format, seek back at 0 offset. */
         if (fseek(fp, 0, SEEK_SET) == -1) goto readerr;
     } else {
         /* RDB format. Pass loading the RDB functions. */
         rio rdb;
+        rio *reader;
+        rio_decompress decomp;
+        int using_decompress = 0;
         int old_style = !strcmp(filename, server.aof_filename);
         if (old_style)
             serverLog(LL_NOTICE, "Reading RDB preamble from AOF file...");
@@ -1451,8 +1460,19 @@ int loadSingleAppendOnlyFile(char *filename) {
             serverLog(LL_NOTICE, "Reading RDB base file on AOF loading...");
 
         if (fseek(fp, 0, SEEK_SET) == -1) goto readerr;
+        clearerr(fp);
         rioInitWithFile(&rdb, fp);
-        if (rdbLoadRio(&rdb, RDBFLAGS_AOF_PREAMBLE, NULL) != C_OK) {
+        reader = &rdb;
+        if (is_frame_magic) {
+            if (rioInitDecompress(&decomp, &rdb) == C_ERR) {
+                serverLog(LL_WARNING, "Error initializing RDB decompressor for %s: %s", filename, strerror(errno));
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+            reader = &decomp.rio_itf;
+            using_decompress = 1;
+        }
+        if (rdbLoadRio(reader, RDBFLAGS_AOF_PREAMBLE, NULL) != C_OK) {
             if (old_style)
                 serverLog(LL_WARNING, "Error reading the RDB preamble of the AOF file %s, AOF loading aborted",
                           filename);
@@ -1460,12 +1480,14 @@ int loadSingleAppendOnlyFile(char *filename) {
                 serverLog(LL_WARNING, "Error reading the RDB base file %s, AOF loading aborted", filename);
 
             ret = AOF_FAILED;
+            if (using_decompress) sdsfree(decomp.rawbuf);
             goto cleanup;
         } else {
             loadingAbsProgress(ftello(fp));
             last_progress_report_size = ftello(fp);
             if (old_style) serverLog(LL_NOTICE, "Reading the remaining AOF tail...");
         }
+        if (using_decompress) sdsfree(decomp.rawbuf);
     }
 
     /* Read the actual AOF file, in REPL format, command by command. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -46,6 +46,8 @@
 #include "module.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
+#include "rio_decompress.h"
+#include "rdb_frame.h"
 
 #include <math.h>
 #include <fcntl.h>
@@ -3525,6 +3527,9 @@ eoferr:
 int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     FILE *fp;
     rio rdb;
+    rio *reader;
+    rio_decompress decomp;
+    int use_decompress = 0;
     int retval;
     struct stat sb;
     int rdb_fd;
@@ -3540,12 +3545,36 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     if (fstat(fileno(fp), &sb) == -1) sb.st_size = 0;
 
     startLoadingFile(sb.st_size, filename, rdbflags);
-    rioInitWithFile(&rdb, fp);
 
-    retval = rdbLoadRio(&rdb, rdbflags, rsi);
+    unsigned char frame_hdr[4];
+    size_t hdr_len = fread(frame_hdr, 1, sizeof(frame_hdr), fp);
+    if (fseeko(fp, 0, SEEK_SET) == -1) {
+        serverLog(LL_WARNING, "Unable to rewind RDB file %s: %s", filename, strerror(errno));
+        fclose(fp);
+        stopLoading(0);
+        return RDB_FAILED;
+    }
+    clearerr(fp);
+
+    rioInitWithFile(&rdb, fp);
+    reader = &rdb;
+
+    if (hdr_len == sizeof(frame_hdr) && rdbFrameHasMagicPrefix(frame_hdr, hdr_len)) {
+        if (rioInitDecompress(&decomp, &rdb) == C_ERR) {
+            serverLog(LL_WARNING, "Failed to initialize RDB decompressor for %s: %s", filename, strerror(errno));
+            fclose(fp);
+            stopLoading(0);
+            return RDB_FAILED;
+        }
+        reader = &decomp.rio_itf;
+        use_decompress = 1;
+    }
+
+    retval = rdbLoadRio(reader, rdbflags, rsi);
 
     fclose(fp);
     stopLoading(retval == C_OK);
+    if (use_decompress) sdsfree(decomp.rawbuf);
     /* Reclaim the cache backed by rdb */
     if (retval == C_OK && !(rdbflags & RDBFLAGS_KEEP_CACHE)) {
         /* TODO: maybe we could combine the fopen and open into one in the future */

--- a/src/rdb_frame.h
+++ b/src/rdb_frame.h
@@ -10,6 +10,7 @@
 #define RDB_FRAME_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #define RDB_FR_MAGIC0 'R'
 #define RDB_FR_MAGIC1 'B'
@@ -32,5 +33,10 @@ typedef struct __attribute__((packed)) RdbFrameBlockHdr {
     uint32_t cmp_len_le; /* compressed bytes */
     uint64_t crc64_le;   /* over header (except crc) + payload */
 } RdbFrameBlockHdr;
+
+static inline int rdbFrameHasMagicPrefix(const unsigned char *buf, size_t len) {
+    return len >= 4 && buf[0] == RDB_FR_MAGIC0 && buf[1] == RDB_FR_MAGIC1 && buf[2] == RDB_FR_MAGIC2 &&
+           buf[3] == RDB_FR_MAGIC3;
+}
 
 #endif /* RDB_FRAME_H */

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -29,6 +29,7 @@
  */
 
 #include "server.h"
+#include "rdb_frame.h"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -359,9 +360,11 @@ int fileIsRDB(char *filepath) {
     }
 
     if (size >= 8) { /* There must be at least room for the RDB header. */
-        char sig[5];
-        int rdb_file = fread(sig, sizeof(sig), 1, fp) == 1 && memcmp(sig, "REDIS", sizeof(sig)) == 0;
-        if (rdb_file) {
+        unsigned char sig[5];
+        size_t got = fread(sig, 1, sizeof(sig), fp);
+        int rdb_file = got == sizeof(sig) && memcmp(sig, "REDIS", sizeof(sig)) == 0;
+        int frame_file = got >= 4 && rdbFrameHasMagicPrefix(sig, got);
+        if (rdb_file || frame_file) {
             fclose(fp);
             return 1;
         }

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -30,11 +30,14 @@
 #include "mt19937-64.h"
 #include "server.h"
 #include "rdb.h"
+#include "rio_decompress.h"
+#include "rdb_frame.h"
 #include "module.h"
 #include "hdr_histogram.h"
 #include "fpconv_dtoa.h"
 
 #include <stdarg.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -601,7 +604,10 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     int type, rdbver;
     char buf[1024];
     long long expiretime;
-    static rio rdb; /* Pointed by global struct riostate. */
+    static rio base_rio; /* Pointed by global struct riostate. */
+    rio *rdb;
+    rio_decompress decomp;
+    int using_decompress = 0;
     struct stat sb;
 
     now = mstime();
@@ -611,10 +617,29 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     if (fstat(fileno(fp), &sb) == -1) sb.st_size = 0;
 
     startLoadingFile(sb.st_size, rdbfilename, RDBFLAGS_NONE);
-    rioInitWithFile(&rdb, fp);
-    rdbstate.rio = &rdb;
-    rdb.update_cksum = rdbLoadProgressCallback;
-    if (rioRead(&rdb, buf, 9) == 0) goto eoferr;
+
+    unsigned char frame_hdr[4];
+    size_t hdr_len = fread(frame_hdr, 1, sizeof(frame_hdr), fp);
+    if (fseeko(fp, 0, SEEK_SET) == -1) {
+        rdbCheckError("Unable to rewind RDB file %s: %s", rdbfilename, strerror(errno));
+        goto err;
+    }
+    clearerr(fp);
+
+    rioInitWithFile(&base_rio, fp);
+    rdb = &base_rio;
+    if (hdr_len == sizeof(frame_hdr) && rdbFrameHasMagicPrefix(frame_hdr, hdr_len)) {
+        if (rioInitDecompress(&decomp, &base_rio) == C_ERR) {
+            rdbCheckError("Failed to initialize RDB decompressor: %s", strerror(errno));
+            goto err;
+        }
+        rdb = &decomp.rio_itf;
+        using_decompress = 1;
+    }
+
+    rdbstate.rio = rdb;
+    rdb->update_cksum = rdbLoadProgressCallback;
+    if (rioRead(rdb, buf, 9) == 0) goto eoferr;
     buf[9] = '\0';
     bool is_valkey_magic = false, is_redis_magic = false;
     if (memcmp(buf, "REDIS0", 6) == 0) {
@@ -644,7 +669,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
 
         /* Read type. */
         rdbstate.doing = RDB_CHECK_DOING_READ_TYPE;
-        if ((type = rdbLoadType(&rdb)) == -1) goto eoferr;
+        if ((type = rdbLoadType(rdb)) == -1) goto eoferr;
 
         /* Handle special types. */
         if (type == RDB_OPCODE_EXPIRETIME) {
@@ -652,25 +677,25 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             /* EXPIRETIME: load an expire associated with the next key
              * to load. Note that after loading an expire we need to
              * load the actual type, and continue. */
-            expiretime = rdbLoadTime(&rdb);
+            expiretime = rdbLoadTime(rdb);
             expiretime *= 1000;
-            if (rioGetReadError(&rdb)) goto eoferr;
+            if (rioGetReadError(rdb)) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_EXPIRETIME_MS) {
             /* EXPIRETIME_MS: milliseconds precision expire times introduced
              * with RDB v3. Like EXPIRETIME but no with more precision. */
             rdbstate.doing = RDB_CHECK_DOING_READ_EXPIRE;
-            expiretime = rdbLoadMillisecondTime(&rdb, rdbver);
-            if (rioGetReadError(&rdb)) goto eoferr;
+            expiretime = rdbLoadMillisecondTime(rdb, rdbver);
+            if (rioGetReadError(rdb)) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_FREQ) {
             /* FREQ: LFU frequency. */
             uint8_t byte;
-            if (rioRead(&rdb, &byte, 1) == 0) goto eoferr;
+            if (rioRead(rdb, &byte, 1) == 0) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_IDLE) {
             /* IDLE: LRU idle time. */
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_EOF) {
             /* EOF: End of file, exit the main loop. */
@@ -678,7 +703,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         } else if (type == RDB_OPCODE_SELECTDB) {
             /* SELECTDB: Select the specified database. */
             rdbstate.doing = RDB_CHECK_DOING_READ_LEN;
-            if ((dbid = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((dbid = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             rdbCheckInfo("Selecting DB ID %llu", (unsigned long long)dbid);
             selected_dbid = dbid;
             if (selected_dbid > rdbstate.databases) {
@@ -691,14 +716,14 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
              * selected data base, in order to avoid useless rehashing. */
             uint64_t db_size, expires_size;
             rdbstate.doing = RDB_CHECK_DOING_READ_LEN;
-            if ((db_size = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
-            if ((expires_size = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((db_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((expires_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_SLOT_INFO) {
             /* Hint used in foreign RDB versions. */
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_AUX) {
             /* AUX: generic string-string fields. Use to add state to RDB
@@ -708,8 +733,8 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
              * An AUX field is composed of two strings: key and value. */
             robj *auxkey, *auxval;
             rdbstate.doing = RDB_CHECK_DOING_READ_AUX;
-            if ((auxkey = rdbLoadStringObject(&rdb)) == NULL) goto eoferr;
-            if ((auxval = rdbLoadStringObject(&rdb)) == NULL) {
+            if ((auxkey = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
+            if ((auxval = rdbLoadStringObject(rdb)) == NULL) {
                 decrRefCount(auxkey);
                 goto eoferr;
             }
@@ -725,9 +750,9 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             /* AUX: Auxiliary data for modules. */
             uint64_t moduleid, when_opcode, when;
             rdbstate.doing = RDB_CHECK_DOING_READ_MODULE_AUX;
-            if ((moduleid = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
-            if ((when_opcode = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
-            if ((when = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((moduleid = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((when_opcode = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((when = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             if (when_opcode != RDB_MODULE_OPCODE_UINT) {
                 rdbCheckError("bad when_opcode");
                 goto err;
@@ -737,7 +762,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             moduleTypeNameByID(name, moduleid);
             rdbCheckInfo("MODULE AUX for: %s", name);
 
-            robj *o = rdbLoadCheckModuleValue(&rdb, name);
+            robj *o = rdbLoadCheckModuleValue(rdb, name);
             decrRefCount(o);
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {
@@ -746,7 +771,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         } else if (type == RDB_OPCODE_FUNCTION2) {
             sds err = NULL;
             rdbstate.doing = RDB_CHECK_DOING_READ_FUNCTIONS;
-            if (rdbFunctionLoad(&rdb, rdbver, NULL, 0, &err) != C_OK) {
+            if (rdbFunctionLoad(rdb, rdbver, NULL, 0, &err) != C_OK) {
                 rdbCheckError("Failed loading library, %s", err);
                 sdsfree(err);
                 goto err;
@@ -771,12 +796,12 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
 
         /* Read key */
         rdbstate.doing = RDB_CHECK_DOING_READ_KEY;
-        if ((key = rdbLoadStringObject(&rdb)) == NULL) goto eoferr;
+        if ((key = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
         rdbstate.key = key;
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type, &rdb, key->ptr, selected_dbid, NULL)) == NULL) goto eoferr;
+        if ((val = rdbLoadObject(type, rdb, key->ptr, selected_dbid, NULL)) == NULL) goto eoferr;
         if (rdbCheckStats) {
             int max_stats_num = (rdbstate.databases + 1) * OBJ_TYPE_MAX;
             if (max_stats_num > rdbstate.stats_num) {
@@ -797,10 +822,10 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     }
     /* Verify the checksum if RDB version is >= 5 */
     if (rdbver >= 5 && server.rdb_checksum) {
-        uint64_t cksum, expected = rdb.cksum;
+        uint64_t cksum, expected = rdb->cksum;
 
         rdbstate.doing = RDB_CHECK_DOING_CHECK_SUM;
-        if (rioRead(&rdb, &cksum, 8) == 0) goto eoferr;
+        if (rioRead(rdb, &cksum, 8) == 0) goto eoferr;
         memrev64ifbe(&cksum);
         if (cksum == 0) {
             rdbCheckInfo("RDB file was saved with checksum disabled: no check performed.");
@@ -812,6 +837,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         }
     }
 
+    if (using_decompress) sdsfree(decomp.rawbuf);
     if (closefile) fclose(fp);
     stopLoading(1);
     return 0;
@@ -823,6 +849,7 @@ eoferr: /* unexpected end of file is handled here with a fatal exit */
         rdbCheckError("Unexpected EOF reading RDB file");
     }
 err:
+    if (using_decompress) sdsfree(decomp.rawbuf);
     if (closefile) fclose(fp);
     stopLoading(0);
     return 1;


### PR DESCRIPTION
## Summary
- detect RDB frame headers via a shared helper
- wrap RDB file and AOF preamble loading with the rio decompression filter when framed data is detected
- teach valkey-check tools to recognize and consume framed RDB inputs

## Testing
- make -C src valkey-server

------
https://chatgpt.com/codex/tasks/task_e_68ca3e4ad4d4832bb364bf3c73e31d77