### PR TITLE
Replace RDB frame zstd codec with LZF

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -185,7 +185,7 @@ configEnum rdb_compression_file_mode_enum[] = {{"legacy", RDB_FR_FILE_MODE_LEGAC
 
 configEnum rdb_compression_codec_enum[] = {{"raw", RDB_FR_CODEC_RAW},
                                            {"lz4", RDB_FR_CODEC_LZ4},
-                                           {"zstd", RDB_FR_CODEC_ZSTD},
+                                           {"lzf", RDB_FR_CODEC_LZF},
                                            {NULL, 0}};
 
 configEnum rdb_compression_checksum_enum[] = {{"crc64", RDB_FR_CHECKSUM_CRC64},
@@ -3214,7 +3214,7 @@ standardConfig static_configs[] = {
     createEnumConfig("rdb-compression-file-mode", NULL, MODIFIABLE_CONFIG, rdb_compression_file_mode_enum,
                      server.rdb_frame_config.file_mode, RDB_FR_FILE_MODE_LEGACY, NULL, applyRdbFrameConfig),
     createEnumConfig("rdb-compression-codec", NULL, MODIFIABLE_CONFIG, rdb_compression_codec_enum,
-                     server.rdb_frame_config.codec, RDB_FR_CODEC_ZSTD, NULL, applyRdbFrameConfig),
+                     server.rdb_frame_config.codec, RDB_FR_CODEC_LZ4, NULL, applyRdbFrameConfig),
     createSizeTConfig("rdb-compression-block-bytes", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX,
                       server.rdb_frame_config.block_bytes, 262144, MEMORY_CONFIG, NULL, applyRdbFrameConfig),
     createEnumConfig("rdb-compression-checksum", NULL, MODIFIABLE_CONFIG, rdb_compression_checksum_enum,

--- a/src/rdb_frame.h
+++ b/src/rdb_frame.h
@@ -20,14 +20,14 @@
 /* Supported frame codecs. */
 #define RDB_FR_CODEC_RAW 0
 #define RDB_FR_CODEC_LZ4 1
-#define RDB_FR_CODEC_ZSTD 2
+#define RDB_FR_CODEC_LZF 2
 
 /* Frame flags. */
 #define RDB_FR_FLAG_LAST 1
 
 typedef struct __attribute__((packed)) RdbFrameBlockHdr {
     uint8_t magic[4];   /* RBC\1 */
-    uint8_t codec;      /* 0=RAW,1=LZ4,2=ZSTD */
+    uint8_t codec;      /* 0=RAW,1=LZ4,2=LZF */
     uint8_t flags;      /* bit0: last-block */
     uint32_t raw_len_le; /* uncompressed bytes */
     uint32_t cmp_len_le; /* compressed bytes */

--- a/src/rio_compress.c
+++ b/src/rio_compress.c
@@ -39,6 +39,8 @@ static uint8_t rioCompressCodecToFrame(rdb_codec_t codec) {
         return RDB_FR_CODEC_RAW;
     case RDBC_LZ4:
         return RDB_FR_CODEC_LZ4;
+    case RDBC_LZF:
+        return RDB_FR_CODEC_LZF;
     default:
         break;
     }
@@ -123,6 +125,8 @@ static rdb_codec_t rioCompressSelectCodec(int frame_codec) {
         return RDBC_RAW;
     case RDB_FR_CODEC_LZ4:
         return RDBC_LZ4;
+    case RDB_FR_CODEC_LZF:
+        return RDBC_LZF;
     default:
         break;
     }
@@ -179,6 +183,9 @@ int rioCompressFlush(rio_compress *rc, int last) {
             payload = rc->rawbuf;
             payload_len = raw_len;
         } else if (actual_codec == RDBC_LZ4) {
+            payload = rc->cmpbuf;
+            payload_len = sdslen(rc->cmpbuf);
+        } else if (actual_codec == RDBC_LZF) {
             payload = rc->cmpbuf;
             payload_len = sdslen(rc->cmpbuf);
         } else {

--- a/src/rio_decompress.c
+++ b/src/rio_decompress.c
@@ -61,6 +61,9 @@ static int rioDecompressFrameCodecToCodec(uint8_t frame_codec, rdb_codec_t *code
     case RDB_FR_CODEC_LZ4:
         *codec = RDBC_LZ4;
         return C_OK;
+    case RDB_FR_CODEC_LZF:
+        *codec = RDBC_LZF;
+        return C_OK;
     default:
         break;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1564,7 +1564,7 @@ typedef struct rdbSaveInfo {
 typedef struct rdb_frame_opts {
     int mode;           /* legacy|block|auto */
     int file_mode;      /* legacy|block */
-    int codec;          /* RAW/LZ4/ZSTD */
+    int codec;          /* RAW/LZ4/LZF */
     size_t block_bytes; /* target block size */
     int checksum;       /* crc64|none */
 } rdb_frame_opts;

--- a/src/unit/test_rio_compress.c
+++ b/src/unit/test_rio_compress.c
@@ -113,6 +113,9 @@ int test_rio_compress(int argc, char **argv, int flags) {
         case RDB_FR_CODEC_LZ4:
             block_codec = RDBC_LZ4;
             break;
+        case RDB_FR_CODEC_LZF:
+            block_codec = RDBC_LZF;
+            break;
         default:
             TEST_ASSERT_MESSAGE("Unsupported codec in frame header", 0);
             block_codec = RDBC_RAW;


### PR DESCRIPTION
## Summary
- replace the RDB frame zstd codec with an LZF option
- update compression/decompression flows and configuration to cover the LZF codec
- extend the rio compression unit test codec handling for LZF frames

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cb76315568832b8c1efb5b28cbd8e8