### PR TITLE
Emit RDB framing preface when framing is enabled

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -175,12 +175,16 @@ static sds build_rdb_framing_preface(client *replica) {
     return sdscatfmt(sdsempty(), "+RDBFRAMED codec=%s blk=%u checksum=%s\r\n", codec, blk, checksum);
 }
 
-static void decide_framing_for_replica(client *slave) {
+static void decide_framing_for_replica(client *slave, int disk_transfer) {
     slave->replx.rdb_framing_enabled = 0;
     slave->replx.rdb_blk_selected = 0;
     slave->replx.rdb_codec_selected = RDBC_RAW;
 
-    if (server.rdb_frame_config.mode == RDB_FR_MODE_LEGACY) return;
+    if (disk_transfer) {
+        if (server.rdb_frame_config.file_mode != RDB_FR_FILE_MODE_BLOCK) return;
+    } else if (server.rdb_frame_config.mode == RDB_FR_MODE_LEGACY) {
+        return;
+    }
     if (!slave->replx.rdb_framing_advertised) return;
     if (!slave->replx.rdb_codec_mask) return;
 
@@ -1051,7 +1055,7 @@ int startBgsaveForReplication(int mincapa, int req) {
                 client *replica = ln->value;
                 if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START &&
                     replica->repl_data->replica_req == req)
-                    decide_framing_for_replica(replica);
+                    decide_framing_for_replica(replica, 0);
             }
             retval = rdbSaveToReplicasSockets(req, rsiptr);
         } else {
@@ -2039,7 +2043,7 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
                     close(repldbfd);
                     continue;
                 }
-                decide_framing_for_replica(replica);
+                decide_framing_for_replica(replica, 1);
                 replica->repl_data->repldbfd = repldbfd;
                 replica->repl_data->repldboff = 0;
                 replica->repl_data->repldbsize = buf.st_size;

--- a/src/replication.c
+++ b/src/replication.c
@@ -161,6 +161,20 @@ static int pick_codec(uint8_t master_mask, uint8_t replica_mask) {
     return -1;
 }
 
+static sds build_rdb_framing_preface(client *replica) {
+    if (!replica->replx.rdb_framing_enabled) return NULL;
+
+    const char *codec =
+        replica->replx.rdb_codec_selected == RDBC_LZ4
+            ? "lz4"
+            : replica->replx.rdb_codec_selected == RDBC_LZF ? "lzf" : "raw";
+    unsigned int blk = replica->replx.rdb_blk_selected ? replica->replx.rdb_blk_selected : 65536;
+    const char *checksum =
+        server.rdb_frame_config.checksum == RDB_FR_CHECKSUM_CRC64 ? "crc64" : "none";
+
+    return sdscatfmt(sdsempty(), "+RDBFRAMED codec=%s blk=%u checksum=%s\r\n", codec, blk, checksum);
+}
+
 static void decide_framing_for_replica(client *slave) {
     slave->replx.rdb_framing_enabled = 0;
     slave->replx.rdb_blk_selected = 0;
@@ -2030,7 +2044,14 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
                 replica->repl_data->repldboff = 0;
                 replica->repl_data->repldbsize = buf.st_size;
                 replica->repl_data->repl_state = REPLICA_STATE_SEND_BULK;
-                replica->repl_data->replpreamble = sdscatprintf(sdsempty(), "$%lld\r\n", (unsigned long long)replica->repl_data->repldbsize);
+                sds preamble = sdsempty();
+                sds preface = build_rdb_framing_preface(replica);
+                if (preface) {
+                    preamble = sdscatsds(preamble, preface);
+                    sdsfree(preface);
+                }
+                preamble = sdscatprintf(preamble, "$%lld\r\n", (unsigned long long)replica->repl_data->repldbsize);
+                replica->repl_data->replpreamble = preamble;
 
                 /* When repl_state changes to REPLICA_STATE_SEND_BULK, we will release
                  * the resources in freeClient. */

--- a/tests/integration/repl_preface_line.tcl
+++ b/tests/integration/repl_preface_line.tcl
@@ -55,4 +55,41 @@ start_server {tags {"repl"}} {
 
         close $fd
     }
+
+    test "Replication stream omits framing preface when snapshot is legacy" {
+        $master config set rdb-compression-mode auto
+        $master config set rdb-compression-file-mode legacy
+
+        set fd [socket $master_host $master_port]
+        fconfigure $fd -translation binary -encoding binary -buffering none
+
+        repl_preface_send_command $fd {PING}
+        set line [gets $fd]
+        assert_equal "+PONG" [string trimright $line "\r"]
+
+        repl_preface_send_command $fd {REPLCONF listening-port 0}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {REPLCONF rdb-framing yes}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {REPLCONF rdb-codecs raw,lzf,lz4}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {REPLCONF rdb-blkmax 262144}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {PSYNC ? -1}
+        set fullresync [string trimright [gets $fd] "\r"]
+        assert {[regexp {^\+FULLRESYNC} $fullresync]}
+
+        set first_line [string trimright [gets $fd] "\r"]
+        assert {[regexp {^\$[0-9]+$} $first_line]}
+
+        close $fd
+    }
 }

--- a/tests/integration/repl_preface_line.tcl
+++ b/tests/integration/repl_preface_line.tcl
@@ -1,0 +1,58 @@
+start_server {tags {"repl"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set save ""
+    $master config set repl-diskless-sync no
+    $master config set rdb-compression-mode block
+    $master config set rdb-compression-file-mode block
+    $master config set rdb-compression-codec raw
+
+    proc repl_preface_send_command {fd args} {
+        if {[llength $args] == 1} {
+            set args [lindex $args 0]
+        }
+
+        set cmd "*[llength $args]\r\n"
+        foreach arg $args {
+            append cmd "$" [string length $arg] "\r\n" $arg "\r\n"
+        }
+        puts -nonewline $fd $cmd
+        flush $fd
+    }
+
+    test "Replication stream includes framing preface when enabled" {
+        set fd [socket $master_host $master_port]
+        fconfigure $fd -translation binary -encoding binary -buffering none
+
+        repl_preface_send_command $fd {PING}
+        set line [gets $fd]
+        assert_equal "+PONG" [string trimright $line "\r"]
+
+        repl_preface_send_command $fd {REPLCONF listening-port 0}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {REPLCONF rdb-framing yes}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {REPLCONF rdb-codecs raw,lzf,lz4}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {REPLCONF rdb-blkmax 262144}
+        set reply [gets $fd]
+        assert_equal "+OK" [string trimright $reply "\r"]
+
+        repl_preface_send_command $fd {PSYNC ? -1}
+        set fullresync [string trimright [gets $fd] "\r"]
+        assert {[regexp {^\+FULLRESYNC} $fullresync]}
+
+        set preface_line [string trimright [gets $fd] "\r"]
+        assert {[regexp {^\+RDBFRAMED codec=(raw|lzf|lz4) blk=[0-9]+ checksum=(crc64|none)$} $preface_line]}
+
+        close $fd
+    }
+}


### PR DESCRIPTION
## Summary
- add a helper that constructs the +RDBFRAMED preface for replicas that negotiated framed RDB transfer and prepend it to the disk-based sync preamble
- leave the bulk length line intact so legacy replicas continue receiving the expected payload format
- add an integration test that negotiates framing and asserts the first line of the RDB stream matches the framing announcement format

## Testing
- ./runtest --single tests/integration/repl_preface_line.tcl

------
https://chatgpt.com/codex/tasks/task_e_68cc74ee22ac832bb0f014f0b03147c9