### PR TITLE
Send RDB framing preface before bulk sync and add test

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -161,6 +161,37 @@ static int pick_codec(uint8_t master_mask, uint8_t replica_mask) {
     return -1;
 }
 
+static const char *replicationRdbCodecName(uint8_t codec) {
+    switch (codec) {
+    case RDBC_LZF: return "lzf";
+    case RDBC_LZ4: return "lz4";
+    default: break;
+    }
+    return "raw";
+}
+
+static const char *replicationRdbChecksumName(int checksum) {
+    switch (checksum) {
+    case RDB_FR_CHECKSUM_NONE: return "none";
+    case RDB_FR_CHECKSUM_CRC64:
+    default: break;
+    }
+    return "crc64";
+}
+
+static sds replicationBuildFramingPreface(client *replica) {
+    if (!replica || !replica->replx.rdb_framing_enabled) return NULL;
+
+    uint32_t blk = replica->replx.rdb_blk_selected;
+    if (blk == 0) blk = 65536; /* Safety fallback. */
+
+    return sdscatfmt(sdsempty(),
+                     "+RDBFRAMED codec=%s blk=%u checksum=%s\r\n",
+                     replicationRdbCodecName(replica->replx.rdb_codec_selected),
+                     (unsigned)blk,
+                     replicationRdbChecksumName(server.rdb_frame_config.checksum));
+}
+
 static void decide_framing_for_replica(client *slave) {
     slave->replx.rdb_framing_enabled = 0;
     slave->replx.rdb_blk_selected = 0;
@@ -876,6 +907,20 @@ int replicationSetupReplicaForFullResync(client *replica, long long offset) {
         if (connWrite(replica->conn, buf, buflen) != buflen) {
             freeClientAsync(replica);
             return C_ERR;
+        }
+    }
+
+    if (replica->replx.rdb_framing_enabled) {
+        sds preface = replicationBuildFramingPreface(replica);
+        if (preface) {
+            ssize_t len = sdslen(preface);
+            if (connWrite(replica->conn, preface, len) != len) {
+                sdsfree(preface);
+                freeClientAsync(replica);
+                return C_ERR;
+            }
+            server.stat_net_repl_output_bytes += len;
+            sdsfree(preface);
         }
     }
     return C_OK;
@@ -2030,7 +2075,9 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
                 replica->repl_data->repldboff = 0;
                 replica->repl_data->repldbsize = buf.st_size;
                 replica->repl_data->repl_state = REPLICA_STATE_SEND_BULK;
-                replica->repl_data->replpreamble = sdscatprintf(sdsempty(), "$%lld\r\n", (unsigned long long)replica->repl_data->repldbsize);
+                sds preamble = replicationBuildFramingPreface(replica);
+                if (preamble == NULL) preamble = sdsempty();
+                replica->repl_data->replpreamble = sdscatprintf(preamble, "$%lld\r\n", (unsigned long long)replica->repl_data->repldbsize);
 
                 /* When repl_state changes to REPLICA_STATE_SEND_BULK, we will release
                  * the resources in freeClient. */

--- a/tests/integration/repl_preface_line.tcl
+++ b/tests/integration/repl_preface_line.tcl
@@ -1,0 +1,56 @@
+# Verify that replicas which negotiate framed RDB transfers receive the
+# +RDBFRAMED preface line before the bulk payload begins.
+
+proc replication_preface_fetch {host port} {
+    set repl [valkey_deferring_client_by_addr $host $port]
+
+    $repl ping
+    assert_equal "PONG" [$repl read]
+
+    $repl replconf listening-port 0
+    assert_equal "OK" [$repl read]
+
+    $repl replconf capa eof
+    assert_equal "OK" [$repl read]
+
+    $repl replconf rdb-framing yes
+    assert_equal "OK" [$repl read]
+
+    $repl replconf rdb-codecs raw,lzf,lz4
+    assert_equal "OK" [$repl read]
+
+    $repl psync replicationid -1
+    set full [$repl read]
+    assert_match {FULLRESYNC * *} $full
+
+    set preface [$repl read]
+    $repl close
+
+    return $preface
+}
+
+start_server {tags {"repl" "external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    test {preface line precedes disk-based RDB transfer} {
+        $master config set repl-diskless-sync no
+        $master config set repl-diskless-sync-delay 0
+
+        set preface [replication_preface_fetch $master_host $master_port]
+        assert {[regexp {^RDBFRAMED codec=(raw|lzf|lz4) blk=[0-9]+ checksum=(crc64|none)$} $preface]}
+
+        waitForBgsave r
+    }
+
+    test {preface line precedes diskless RDB transfer} {
+        $master config set repl-diskless-sync yes
+        $master config set repl-diskless-sync-delay 0
+
+        set preface [replication_preface_fetch $master_host $master_port]
+        assert {[regexp {^RDBFRAMED codec=(raw|lzf|lz4) blk=[0-9]+ checksum=(crc64|none)$} $preface]}
+
+        waitForBgsave r
+    }
+}


### PR DESCRIPTION
## Summary
- emit the +RDBFRAMED preface once a replica negotiates framed RDB transfers and account for it in both diskless and disk-based paths
- build the preface line via new helpers so the disk-based preamble includes it ahead of the bulk length header
- add an integration test that exercises full resyncs (disk and diskless) and asserts the framing preface is sent

## Testing
- ./runtest --single integration/repl_preface_line

------
https://chatgpt.com/codex/tasks/task_e_68cc74ee22ac832bb0f014f0b03147c9