### PR TITLE
Refactor RDB frame helpers and expand replication tests

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1624,8 +1624,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     rdb_frame_opts local_frame_opts;
     if (server.rdb_frame_config.file_mode == RDB_FR_FILE_MODE_BLOCK) {
         local_frame_opts = server.rdb_frame_config;
-        size_t block_bytes = local_frame_opts.block_bytes ? local_frame_opts.block_bytes : 262144;
-        if (block_bytes < 65536) block_bytes = 65536;
+        size_t block_bytes = rdbFrameBlockSizeOrDefault(local_frame_opts.block_bytes, 262144, 65536);
         local_frame_opts.block_bytes = block_bytes;
 
         const char *codec = rdbFrameCodecToString(local_frame_opts.codec);

--- a/src/rdb_frame.c
+++ b/src/rdb_frame.c
@@ -103,6 +103,26 @@ ssize_t rdbFrameFormatConfigLine(char *buf, size_t buf_len, int codec, size_t bl
     return len;
 }
 
+int rdbFrameCodecFromRdbCodecOrDefault(int codec, int default_frame_codec) {
+    int frame_codec = rdbFrameCodecFromRdbCodec(codec);
+    if (frame_codec >= 0) return frame_codec;
+    if (rdbFrameCodecToString(default_frame_codec) == NULL) return RDB_FR_CODEC_RAW;
+    return default_frame_codec;
+}
+
+int rdbFrameChecksumOrDefault(int checksum, int default_checksum) {
+    if (rdbFrameChecksumToString(checksum) != NULL) return checksum;
+    if (rdbFrameChecksumToString(default_checksum) == NULL) return RDB_FR_CHECKSUM_CRC64;
+    return default_checksum;
+}
+
+size_t rdbFrameBlockSizeOrDefault(size_t requested_block, size_t default_block, size_t min_block) {
+    size_t block = requested_block ? requested_block : default_block;
+    if (block == 0) block = min_block ? min_block : default_block;
+    if (min_block && block < min_block) block = min_block;
+    return block;
+}
+
 rdbFrameParseResult rdbFrameParseConfigTriplet(char *buf,
                                                const char **codec_token,
                                                const char **blk_token,

--- a/src/rdb_frame.h
+++ b/src/rdb_frame.h
@@ -64,4 +64,10 @@ rdbFrameParseResult rdbFrameParseConfigTriplet(char *buf,
                                                const char **blk_token,
                                                const char **checksum_token);
 
+int rdbFrameCodecFromRdbCodecOrDefault(int codec, int default_frame_codec);
+int rdbFrameChecksumOrDefault(int checksum, int default_checksum);
+size_t rdbFrameBlockSizeOrDefault(size_t requested_block,
+                                  size_t default_block,
+                                  size_t min_block);
+
 #endif /* RDB_FRAME_H */

--- a/src/replication.c
+++ b/src/replication.c
@@ -165,20 +165,23 @@ static int pick_codec(uint8_t master_mask, uint8_t replica_mask) {
 static sds build_rdb_framing_preface(client *replica) {
     if (!replica->replx.rdb_framing_enabled) return NULL;
 
-    size_t blk = replica->replx.rdb_blk_selected ? replica->replx.rdb_blk_selected : 65536;
-    int frame_codec = rdbFrameCodecFromRdbCodec(replica->replx.rdb_codec_selected);
-    if (frame_codec < 0) frame_codec = RDB_FR_CODEC_RAW;
-    int checksum = server.rdb_frame_config.checksum;
-    if (rdbFrameChecksumToString(checksum) == NULL) checksum = RDB_FR_CHECKSUM_CRC64;
+    size_t blk = rdbFrameBlockSizeOrDefault(replica->replx.rdb_blk_selected, 65536, 65536);
+    int frame_codec = rdbFrameCodecFromRdbCodecOrDefault(replica->replx.rdb_codec_selected, RDB_FR_CODEC_RAW);
+    int checksum = rdbFrameChecksumOrDefault(server.rdb_frame_config.checksum, RDB_FR_CHECKSUM_CRC64);
 
     char config_line[128];
     ssize_t len = rdbFrameFormatConfigLine(config_line, sizeof(config_line), frame_codec, blk, checksum);
     if (len < 0) {
-        len = rdbFrameFormatConfigLine(config_line, sizeof(config_line), RDB_FR_CODEC_RAW, blk, RDB_FR_CHECKSUM_CRC64);
+        frame_codec = RDB_FR_CODEC_RAW;
+        checksum = RDB_FR_CHECKSUM_CRC64;
+        len = rdbFrameFormatConfigLine(config_line, sizeof(config_line), frame_codec, blk, checksum);
         if (len < 0) return NULL;
     }
 
-    return sdscatfmt(sdsempty(), "+RDBFRAMED %s\r\n", config_line);
+    sds preface = sdsempty();
+    if (preface == NULL) return NULL;
+    preface = sdscatfmt(preface, "+RDBFRAMED %s\r\n", config_line);
+    return preface;
 }
 
 static void decide_framing_for_replica(client *slave, int disk_transfer) {
@@ -198,20 +201,19 @@ static void decide_framing_for_replica(client *slave, int disk_transfer) {
     int codec = pick_codec(master_mask, slave->replx.rdb_codec_mask);
     if (codec < 0) return;
 
-    size_t configured_block = server.rdb_frame_config.block_bytes;
-    if (configured_block == 0) configured_block = 65536;
+    size_t configured_block = rdbFrameBlockSizeOrDefault(server.rdb_frame_config.block_bytes, 65536, 65536);
     if (configured_block > (size_t)UINT32_MAX) configured_block = UINT32_MAX;
     uint32_t blk = (uint32_t)configured_block;
 
     if (slave->replx.rdb_blkmax && slave->replx.rdb_blkmax < blk) blk = slave->replx.rdb_blkmax;
-    if (blk < 65536) blk = 65536;
+    blk = (uint32_t)rdbFrameBlockSizeOrDefault(blk, 65536, 65536);
 
     slave->replx.rdb_codec_selected = (uint8_t)codec;
     slave->replx.rdb_blk_selected = blk;
     slave->replx.rdb_framing_enabled = 1;
 
-    int frame_codec = rdbFrameCodecFromRdbCodec(codec);
-    const char *codec_name = frame_codec >= 0 ? rdbFrameCodecToString(frame_codec) : NULL;
+    int frame_codec = rdbFrameCodecFromRdbCodecOrDefault(codec, RDB_FR_CODEC_RAW);
+    const char *codec_name = rdbFrameCodecToString(frame_codec);
     if (codec_name == NULL) codec_name = "raw";
     serverLog(LL_NOTICE, "Selected framed RDB for replica %s: codec=%s blk=%u",
               getClientPeerId(slave), codec_name, blk);

--- a/src/rio_compress.c
+++ b/src/rio_compress.c
@@ -191,8 +191,7 @@ int rioCompressFlush(rio_compress *rc, int last) {
     hdr.magic[1] = RDB_FR_MAGIC1;
     hdr.magic[2] = RDB_FR_MAGIC2;
     hdr.magic[3] = RDB_FR_MAGIC3;
-    int frame_codec = rdbFrameCodecFromRdbCodec(actual_codec);
-    if (frame_codec < 0) frame_codec = RDB_FR_CODEC_RAW;
+    int frame_codec = rdbFrameCodecFromRdbCodecOrDefault(actual_codec, RDB_FR_CODEC_RAW);
     hdr.codec = (uint8_t)frame_codec;
     hdr.flags = last ? RDB_FR_FLAG_LAST : 0;
     hdr.raw_len_le = (uint32_t)raw_len;

--- a/tests/integration/repl_preface_line.tcl
+++ b/tests/integration/repl_preface_line.tcl
@@ -22,8 +22,8 @@ start_server {tags {"repl"}} {
         flush $fd
     }
 
-    test "Replication stream includes framing preface when enabled" {
-        set fd [socket $master_host $master_port]
+    proc repl_preface_handshake_preface {host port codec_line {blkmax 262144}} {
+        set fd [socket $host $port]
         fconfigure $fd -translation binary -encoding binary -buffering none
 
         repl_preface_send_command $fd {PING}
@@ -38,11 +38,11 @@ start_server {tags {"repl"}} {
         set reply [gets $fd]
         assert_equal "+OK" [string trimright $reply "\r"]
 
-        repl_preface_send_command $fd {REPLCONF rdb-codecs raw,lzf,lz4}
+        repl_preface_send_command $fd [list REPLCONF rdb-codecs $codec_line]
         set reply [gets $fd]
         assert_equal "+OK" [string trimright $reply "\r"]
 
-        repl_preface_send_command $fd {REPLCONF rdb-blkmax 262144}
+        repl_preface_send_command $fd [list REPLCONF rdb-blkmax $blkmax]
         set reply [gets $fd]
         assert_equal "+OK" [string trimright $reply "\r"]
 
@@ -51,9 +51,13 @@ start_server {tags {"repl"}} {
         assert {[regexp {^\+FULLRESYNC} $fullresync]}
 
         set preface_line [string trimright [gets $fd] "\r"]
-        assert {[regexp {^\+RDBFRAMED codec=(raw|lzf|lz4) blk=[0-9]+ checksum=(crc64|none)$} $preface_line]}
-
         close $fd
+        return $preface_line
+    }
+
+    test "Replication stream includes framing preface when enabled" {
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=(raw|lzf|lz4) blk=[0-9]+ checksum=(crc64|none)$} $preface_line]}
     }
 
     test "Replication stream omits framing preface when snapshot is legacy" {
@@ -91,5 +95,38 @@ start_server {tags {"repl"}} {
         assert {[regexp {^\$[0-9]+$} $first_line]}
 
         close $fd
+
+        $master config set rdb-compression-mode block
+        $master config set rdb-compression-file-mode block
+    }
+
+    test "Replication preface uses configured lzf codec when available" {
+        $master config set rdb-compression-mode block
+        $master config set rdb-compression-file-mode block
+        $master config set rdb-compression-codec lzf
+        $master config set rdb-compression-checksum crc64
+
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=lzf blk=[0-9]+ checksum=crc64$} $preface_line]}
+    }
+
+    test "Replication preface uses configured raw codec when selected" {
+        $master config set rdb-compression-mode block
+        $master config set rdb-compression-file-mode block
+        $master config set rdb-compression-codec raw
+        $master config set rdb-compression-checksum crc64
+
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=raw blk=[0-9]+ checksum=crc64$} $preface_line]}
+    }
+
+    test "Replication preface uses configured checksum option" {
+        $master config set rdb-compression-mode block
+        $master config set rdb-compression-file-mode block
+        $master config set rdb-compression-codec lz4
+        $master config set rdb-compression-checksum none
+
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=lz4 blk=[0-9]+ checksum=none$} $preface_line]}
     }
 }


### PR DESCRIPTION
## Summary
- Introduce shared helpers to normalize RDB frame codec, checksum, and block size defaults
- Use the new helpers throughout replication and compression paths to remove duplicate logic and improve preface creation
- Expand the replication framing integration test suite with reusable handshake helper and new codec/checksum coverage

## Testing
- ./runtest --single tests/integration/repl_preface_line.tcl

------
https://chatgpt.com/codex/tasks/task_e_68cec41b84b8832b917a3075770b4879