### PR TITLE
Add extensive RDB frame mode tests

### DIFF
--- a/src/unit/test_files.h
+++ b/src/unit/test_files.h
@@ -18,6 +18,9 @@ int test_rdb_frame_has_magic_prefix(int argc, char **argv, int flags);
 int test_rdb_frame_parse_triplet_whitespace(int argc, char **argv, int flags);
 int test_rdb_frame_parse_triplet_empty_values(int argc, char **argv, int flags);
 int test_rdb_frame_parse_triplet_null_args(int argc, char **argv, int flags);
+int test_rdb_frame_codec_defaults(int argc, char **argv, int flags);
+int test_rdb_frame_checksum_defaults(int argc, char **argv, int flags);
+int test_rdb_frame_block_defaults(int argc, char **argv, int flags);
 int test_popcount(int argc, char **argv, int flags);
 int test_crc64(int argc, char **argv, int flags);
 int test_crc64combine(int argc, char **argv, int flags);
@@ -267,7 +270,7 @@ int test_zmallocAllocReallocCallocAndFree(int argc, char **argv, int flags);
 int test_zmallocAllocZeroByteAndFree(int argc, char **argv, int flags);
 
 unitTest __rdb_codec_unit_c[] = {{"test_rdb_codec_roundtrip", test_rdb_codec_roundtrip}, {"test_rdb_codec_raw_fallback", test_rdb_codec_raw_fallback}, {NULL, NULL}};
-unitTest __rdb_frame_unit_c[] = {{"test_rdb_frame_codec_helpers", test_rdb_frame_codec_helpers}, {"test_rdb_frame_checksum_helpers", test_rdb_frame_checksum_helpers}, {"test_rdb_frame_parse_triplet_success", test_rdb_frame_parse_triplet_success}, {"test_rdb_frame_parse_triplet_errors", test_rdb_frame_parse_triplet_errors}, {"test_rdb_frame_format_line", test_rdb_frame_format_line}, {"test_rdb_frame_codec_cross_conversion", test_rdb_frame_codec_cross_conversion}, {"test_rdb_frame_has_magic_prefix", test_rdb_frame_has_magic_prefix}, {"test_rdb_frame_parse_triplet_whitespace", test_rdb_frame_parse_triplet_whitespace}, {"test_rdb_frame_parse_triplet_empty_values", test_rdb_frame_parse_triplet_empty_values}, {"test_rdb_frame_parse_triplet_null_args", test_rdb_frame_parse_triplet_null_args}, {NULL, NULL}};
+unitTest __rdb_frame_unit_c[] = {{"test_rdb_frame_codec_helpers", test_rdb_frame_codec_helpers}, {"test_rdb_frame_checksum_helpers", test_rdb_frame_checksum_helpers}, {"test_rdb_frame_parse_triplet_success", test_rdb_frame_parse_triplet_success}, {"test_rdb_frame_parse_triplet_errors", test_rdb_frame_parse_triplet_errors}, {"test_rdb_frame_format_line", test_rdb_frame_format_line}, {"test_rdb_frame_codec_cross_conversion", test_rdb_frame_codec_cross_conversion}, {"test_rdb_frame_has_magic_prefix", test_rdb_frame_has_magic_prefix}, {"test_rdb_frame_parse_triplet_whitespace", test_rdb_frame_parse_triplet_whitespace}, {"test_rdb_frame_parse_triplet_empty_values", test_rdb_frame_parse_triplet_empty_values}, {"test_rdb_frame_parse_triplet_null_args", test_rdb_frame_parse_triplet_null_args}, {"test_rdb_frame_codec_defaults", test_rdb_frame_codec_defaults}, {"test_rdb_frame_checksum_defaults", test_rdb_frame_checksum_defaults}, {"test_rdb_frame_block_defaults", test_rdb_frame_block_defaults}, {NULL, NULL}};
 unitTest __test_bitops_c[] = {{"test_popcount", test_popcount}, {NULL, NULL}};
 unitTest __test_crc64_c[] = {{"test_crc64", test_crc64}, {NULL, NULL}};
 unitTest __test_crc64combine_c[] = {{"test_crc64combine", test_crc64combine}, {NULL, NULL}};

--- a/tests/integration/rdb_frame_file.tcl
+++ b/tests/integration/rdb_frame_file.tcl
@@ -1,0 +1,64 @@
+start_server {tags {"rdb"}} {
+    set master [srv 0 client]
+
+    $master config set save ""
+    $master config set rdb-compression-mode block
+    $master config set rdb-compression-file-mode block
+
+    proc read_frame_header {client} {
+        set dir [lindex [$client config get dir] 1]
+        set dump_path [file join $dir dump.rdb]
+        set fd [open $dump_path r]
+        fconfigure $fd -translation binary -encoding binary
+        set preamble [read $fd 7]
+        set header_line [gets $fd]
+        close $fd
+        binary scan $preamble c* preamble_bytes
+        return [dict create preamble $preamble_bytes header $header_line]
+    }
+
+    test "Framed RDB file encodes configured codec and block size" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-codec lzf
+        $master config set rdb-compression-block-bytes 131072
+
+        $master flushall
+        $master set frame:key value
+        assert_equal OK [$master save]
+
+        set header [read_frame_header $master]
+        assert_equal {86 75 70 82 77 1 10} [dict get $header preamble]
+        assert {[regexp {^codec=lzf blk=131072 checksum=crc64$} [dict get $header header]]}
+    }
+
+    test "Framed RDB file header updates after codec and checksum changes" {
+        $master config set rdb-compression-mode auto
+        $master config set rdb-compression-checksum none
+        $master config set rdb-compression-codec raw
+        $master config set rdb-compression-block-bytes 1048576
+
+        $master set frame:key2 v2
+        assert_equal OK [$master save]
+
+        set header [read_frame_header $master]
+        assert_equal {86 75 70 82 77 1 10} [dict get $header preamble]
+        assert {[regexp {^codec=raw blk=1048576 checksum=none$} [dict get $header header]]}
+
+        $master config set rdb-compression-mode block
+    }
+
+    test "Framed RDB file enforces minimum block size" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-codec lz4
+        $master config set rdb-compression-block-bytes 4096
+
+        $master set frame:key3 v3
+        assert_equal OK [$master save]
+
+        set header [read_frame_header $master]
+        assert_equal {86 75 70 82 77 1 10} [dict get $header preamble]
+        assert {[regexp {^codec=lz4 blk=65536 checksum=crc64$} [dict get $header header]]}
+
+        $master config set rdb-compression-block-bytes 262144
+    }
+}

--- a/tests/integration/repl_preface_line.tcl
+++ b/tests/integration/repl_preface_line.tcl
@@ -129,4 +129,61 @@ start_server {tags {"repl"}} {
         set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
         assert {[regexp {^\+RDBFRAMED codec=lz4 blk=[0-9]+ checksum=none$} $preface_line]}
     }
+
+    test "Replication preface updates after codec changes" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-block-bytes 262144
+
+        foreach codec {raw lzf lz4} {
+            $master config set rdb-compression-codec $codec
+            set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+            set pattern [format {^\+RDBFRAMED codec=%s blk=[0-9]+ checksum=crc64$} $codec]
+            assert {[regexp $pattern $preface_line]}
+        }
+    }
+
+    test "Replication preface falls back to raw when replica lacks configured codec" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-codec lz4
+
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw"]
+        assert {[regexp {^\+RDBFRAMED codec=raw blk=[0-9]+ checksum=crc64$} $preface_line]}
+
+        $master config set rdb-compression-codec raw
+    }
+
+    test "Replication preface respects replica block limit" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-codec lz4
+        $master config set rdb-compression-block-bytes 524288
+
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4" 65536]
+        assert {[regexp {^\+RDBFRAMED codec=lz4 blk=65536 checksum=crc64$} $preface_line]}
+
+        $master config set rdb-compression-block-bytes 262144
+    }
+
+    test "Replication preface enforces minimum block size" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-codec raw
+        $master config set rdb-compression-block-bytes 32768
+
+        set preface_line [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=raw blk=65536 checksum=crc64$} $preface_line]}
+
+        $master config set rdb-compression-block-bytes 262144
+    }
+
+    test "Replication preface stays framed when switching between block and auto modes" {
+        $master config set rdb-compression-checksum crc64
+        $master config set rdb-compression-codec lzf
+        $master config set rdb-compression-mode auto
+
+        set auto_preface [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=lzf blk=[0-9]+ checksum=crc64$} $auto_preface]}
+
+        $master config set rdb-compression-mode block
+        set block_preface [repl_preface_handshake_preface $master_host $master_port "raw,lzf,lz4"]
+        assert {[regexp {^\+RDBFRAMED codec=lzf blk=[0-9]+ checksum=crc64$} $block_preface]}
+    }
 }

--- a/tests/unit/rdb_frame_unit.c
+++ b/tests/unit/rdb_frame_unit.c
@@ -197,3 +197,41 @@ int test_rdb_frame_parse_triplet_null_args(int argc, char **argv, int flags) {
     TEST_ASSERT(rdbFrameParseConfigTriplet(base_checksum, &codec, &blk, NULL) == RDB_FRAME_PARSE_INVALID_FORMAT);
     return 0;
 }
+
+int test_rdb_frame_codec_defaults(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    TEST_ASSERT(rdbFrameCodecFromRdbCodecOrDefault(RDBC_RAW, RDB_FR_CODEC_LZ4) == RDB_FR_CODEC_RAW);
+    TEST_ASSERT(rdbFrameCodecFromRdbCodecOrDefault(RDBC_LZ4, RDB_FR_CODEC_RAW) == RDB_FR_CODEC_LZ4);
+    TEST_ASSERT(rdbFrameCodecFromRdbCodecOrDefault(RDBC_LZF, RDB_FR_CODEC_RAW) == RDB_FR_CODEC_LZF);
+    TEST_ASSERT(rdbFrameCodecFromRdbCodecOrDefault(-1, RDB_FR_CODEC_LZF) == RDB_FR_CODEC_LZF);
+    TEST_ASSERT(rdbFrameCodecFromRdbCodecOrDefault(-1, -1) == RDB_FR_CODEC_RAW);
+    return 0;
+}
+
+int test_rdb_frame_checksum_defaults(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    TEST_ASSERT(rdbFrameChecksumOrDefault(RDB_FR_CHECKSUM_CRC64, RDB_FR_CHECKSUM_NONE) == RDB_FR_CHECKSUM_CRC64);
+    TEST_ASSERT(rdbFrameChecksumOrDefault(RDB_FR_CHECKSUM_NONE, RDB_FR_CHECKSUM_CRC64) == RDB_FR_CHECKSUM_NONE);
+    TEST_ASSERT(rdbFrameChecksumOrDefault(-1, RDB_FR_CHECKSUM_NONE) == RDB_FR_CHECKSUM_NONE);
+    TEST_ASSERT(rdbFrameChecksumOrDefault(-1, -1) == RDB_FR_CHECKSUM_CRC64);
+    return 0;
+}
+
+int test_rdb_frame_block_defaults(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    TEST_ASSERT(rdbFrameBlockSizeOrDefault(131072, 262144, 65536) == 131072);
+    TEST_ASSERT(rdbFrameBlockSizeOrDefault(0, 262144, 65536) == 262144);
+    TEST_ASSERT(rdbFrameBlockSizeOrDefault(32768, 0, 65536) == 65536);
+    TEST_ASSERT(rdbFrameBlockSizeOrDefault(0, 0, 65536) == 65536);
+    TEST_ASSERT(rdbFrameBlockSizeOrDefault(0, 131072, 0) == 131072);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend the replication preface integration suite to cover codec changes, fallback behavior, block limits, and switching between block and auto frame modes
- add a new integration test that verifies framed RDB files emit the expected codec, block size, and checksum metadata in their headers
- add unit tests for rdb frame default helpers and register them with the unit test harness

## Testing
- src/valkey-unit-tests --single rdb_frame_unit.c
- ./runtest --single integration/repl_preface_line
- ./runtest --single integration/rdb_frame_file

------
https://chatgpt.com/codex/tasks/task_e_68cf0341aa5c832bb14b1877f423f260