### PR TITLE
Refine RDB codec handling

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -133,15 +133,9 @@ int bg_unlink(const char *filename) {
 }
 
 static int configured_rdbc_codec(void) {
-    switch (server.rdb_frame_config.codec) {
-    case RDB_FR_CODEC_LZF:
-        return RDBC_LZF;
-    case RDB_FR_CODEC_LZ4:
-        return RDBC_LZ4;
-    default:
-        break;
-    }
-    return RDBC_RAW;
+    int codec = rdbFrameCodecToRdbCodec(server.rdb_frame_config.codec);
+    if (codec == -1) return RDBC_RAW;
+    return codec;
 }
 
 static uint8_t config_codec_mask(void) {
@@ -1591,12 +1585,11 @@ void replconfCommand(client *c) {
             sds *toks = sdssplitlen(csv, csv_len, ",", 1, &ntoks);
             if (toks) {
                 for (int t = 0; t < ntoks; t++) {
-                    if (!strcasecmp(toks[t], "raw"))
-                        mask |= codec_to_mask(RDBC_RAW);
-                    else if (!strcasecmp(toks[t], "lzf"))
-                        mask |= codec_to_mask(RDBC_LZF);
-                    else if (!strcasecmp(toks[t], "lz4"))
-                        mask |= codec_to_mask(RDBC_LZ4);
+                    int frame_codec = rdbFrameCodecFromString(toks[t]);
+                    if (frame_codec != -1) {
+                        int codec = rdbFrameCodecToRdbCodec(frame_codec);
+                        if (codec != -1) mask |= codec_to_mask(codec);
+                    }
                 }
                 sdsfreesplitres(toks, ntoks);
             }
@@ -2464,9 +2457,6 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
     if (replicationSupportSkipRDBChecksum(conn, 1, *usemark)) rdb.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
     int loadingFailed = 0;
     int use_framed_rdb = 0;
-    int preface_claimed_codec = RDBC_RAW;
-    uint32_t preface_claimed_blk = 0;
-    int preface_claimed_checksum_crc64 = 0;
     unsigned char peek[9];
     off_t saved_pos = rdb.io.conn.pos;
     size_t saved_processed = rdb.processed_bytes;
@@ -2546,15 +2536,11 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
                                           "PRIMARY <-> REPLICA sync: RDB preface specified unsupported checksum '%s'",
                                           checksum_str);
                                 loadingFailed = 1;
-                            } else {
-                                preface_claimed_checksum_crc64 = (checksum == RDB_FR_CHECKSUM_CRC64);
                             }
                         }
 
                         if (!loadingFailed) {
                             use_framed_rdb = 1;
-                            preface_claimed_codec = codec;
-                            preface_claimed_blk = (uint32_t)blk_val;
                             serverLog(LL_DEBUG,
                                       "PRIMARY <-> REPLICA sync: Received framed RDB preface codec=%s blk=%lu checksum=%s",
                                       codec_str, blk_val, checksum_str);
@@ -2600,10 +2586,6 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
             using_decompress = 1;
         }
     }
-
-    (void)preface_claimed_codec;
-    (void)preface_claimed_blk;
-    (void)preface_claimed_checksum_crc64;
 
     rdbLoadingCtx loadingCtx = {.dbarray = dbarray, .functions_lib_ctx = functions_lib_ctx};
     if (!loadingFailed && rdbLoadRioWithLoadingCtxScopedRdb(load_rio, RDBFLAGS_REPLICATION, rsi, &loadingCtx) != C_OK) {

--- a/src/rio_compress.c
+++ b/src/rio_compress.c
@@ -106,17 +106,9 @@ static int rioCompressInitBuffers(rio_compress *rc) {
 }
 
 static rdb_codec_t rioCompressSelectCodec(int frame_codec) {
-    switch (frame_codec) {
-    case RDB_FR_CODEC_RAW:
-        return RDBC_RAW;
-    case RDB_FR_CODEC_LZ4:
-        return RDBC_LZ4;
-    case RDB_FR_CODEC_LZF:
-        return RDBC_LZF;
-    default:
-        break;
-    }
-    return RDBC_RAW;
+    int codec = rdbFrameCodecToRdbCodec(frame_codec);
+    if (codec == -1) return RDBC_RAW;
+    return codec;
 }
 
 int rioInitCompress(rio_compress *rc, rio *dst, const rdb_frame_opts *opts) {

--- a/src/server.h
+++ b/src/server.h
@@ -102,6 +102,7 @@ typedef struct serverObject robj;
 #include "endianconv.h"
 #include "crc64.h"
 #include "rdb_frame.h"
+#include "rdb_codec.h"
 
 struct hdr_histogram;
 
@@ -666,10 +667,6 @@ typedef enum {
 /* RDB frame file output modes. */
 #define RDB_FR_FILE_MODE_LEGACY 0
 #define RDB_FR_FILE_MODE_BLOCK 1
-
-/* RDB frame checksum options. */
-#define RDB_FR_CHECKSUM_CRC64 0
-#define RDB_FR_CHECKSUM_NONE 1
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes. */
@@ -1577,11 +1574,6 @@ typedef struct rdb_frame_opts {
     int checksum;       /* crc64|none */
 } rdb_frame_opts;
 
-#ifndef RDBC_RAW
-#define RDBC_RAW 0
-#define RDBC_LZF 1
-#define RDBC_LZ4 2
-#endif
 static inline uint8_t codec_to_mask(int c) {
     return (uint8_t)(1u << c);
 }


### PR DESCRIPTION
## Summary
- rely on the shared codec header for RDBC constants instead of duplicating macros in `server.h`
- reuse the frame/codec conversion helpers when negotiating replication codecs and drop unused preface bookkeeping
- switch the RIO compression filter to the shared codec conversion helper

## Testing
- make -j4

------
https://chatgpt.com/codex/tasks/task_e_68d17267b658832ba1e7c273aced0648