### PR TITLE
Remove unrelated changes from chunked compression work

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -240,13 +240,7 @@ int evalExtractShebangFlags(sds body,
         }
 
         if (out_engine) {
-            size_t engine_len = sdslen(parts[0]);
-            if (engine_len <= 2 || engine_len > 1024) {
-                if (err) *err = sdsnew("Invalid engine in script shebang");
-                sdsfreesplitres(parts, numparts);
-                return C_ERR;
-            }
-            size_t engine_name_len = engine_len - 2;
+            uint32_t engine_name_len = sdslen(parts[0]) - 2;
             *out_engine = zcalloc(engine_name_len + 1);
             valkey_strlcpy(*out_engine, parts[0] + 2, engine_name_len + 1);
         }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3653,6 +3653,24 @@ static void rdbLoadChecksumCallback(rio *r, const void *buf, size_t len) {
     if (server.rdb_checksum) rioGenericUpdateChecksum(r, buf, len);
 }
 
+/* Progress-only callback for the underlying rio when chunk decompression is used.
+ * This tracks progress on compressed bytes without updating the checksum
+ * (checksum is calculated on decompressed data by the chunk rio). */
+static void rdbLoadProgressOnlyCallback(rio *r, const void *buf, size_t len) {
+    UNUSED(buf);
+    if (server.loading_process_events_interval_bytes &&
+        (r->processed_bytes + len) / server.loading_process_events_interval_bytes >
+            r->processed_bytes / server.loading_process_events_interval_bytes) {
+        if (server.primary_host && server.repl_state == REPL_STATE_TRANSFER) replicationSendNewlineToPrimary();
+        loadingAbsProgress(r->processed_bytes);
+        processEventsWhileBlocked();
+        processModuleLoadingProgressEvent(0);
+    }
+    if (server.repl_state == REPL_STATE_TRANSFER && rioCheckType(r) == RIO_TYPE_CONN) {
+        server.stat_net_repl_input_bytes += len;
+    }
+}
+
 /* Save the given functions_ctx to the rdb.
  * The err output parameter is optional and will be set with relevant error
  * message on failure, it is the caller responsibility to free the error

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3800,6 +3800,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             serverLog(LL_WARNING, "Failed to initialize chunk decompression buffer");
             return C_ERR;
         }
+        rdb->update_cksum = rdbLoadProgressOnlyCallback;
         actual_rdb = &chunk_rio;
         actual_rdb->cksum = rdb->cksum;
         actual_rdb->processed_bytes = rdb->processed_bytes;

--- a/src/unit/test_chunk_buffer.c
+++ b/src/unit/test_chunk_buffer.c
@@ -76,24 +76,22 @@ int test_chunkBufferWriteSmall(int argc, char **argv, int flags) {
     TEST_ASSERT_MESSAGE("Chunk buffer creation should succeed", chunk_buf != NULL);
 
     /* Write small data (1KB) */
-    char *data = zmalloc(1024);
-    memset(data, 'A', 1024);
-    ssize_t written = rdbChunkBufferWrite(chunk_buf, data, 1024);
-    TEST_ASSERT_MESSAGE("Writing 1KB should succeed", written == 1024);
+    char data[1024];
+    memset(data, 'A', sizeof(data));
+    ssize_t written = rdbChunkBufferWrite(chunk_buf, data, sizeof(data));
+    TEST_ASSERT_MESSAGE("Writing 1KB should succeed", written == sizeof(data));
 
     /* Write another small chunk (2KB) */
-    char *data2 = zmalloc(2048);
-    memset(data2, 'B', 2048);
-    written = rdbChunkBufferWrite(chunk_buf, data2, 2048);
-    TEST_ASSERT_MESSAGE("Writing 2KB should succeed", written == 2048);
+    char data2[2048];
+    memset(data2, 'B', sizeof(data2));
+    written = rdbChunkBufferWrite(chunk_buf, data2, sizeof(data2));
+    TEST_ASSERT_MESSAGE("Writing 2KB should succeed", written == sizeof(data2));
 
     /* Flush the buffer */
     int result = rdbChunkBufferFlush(chunk_buf);
     TEST_ASSERT_MESSAGE("Flushing buffer should succeed", result == 0);
 
     /* Clean up */
-    zfree(data);
-    zfree(data2);
     rdbChunkBufferFree(chunk_buf);
     sdsfree(r.io.buffer.ptr); /* Free the potentially reallocated buffer */
     return 0;
@@ -151,10 +149,10 @@ int test_chunkBufferFlushPartial(int argc, char **argv, int flags) {
     TEST_ASSERT_MESSAGE("Chunk buffer creation should succeed", chunk_buf != NULL);
 
     /* Write partial chunk (3KB) */
-    char *data = zmalloc(3072);
-    memset(data, 'P', 3072);
-    ssize_t written = rdbChunkBufferWrite(chunk_buf, data, 3072);
-    TEST_ASSERT_MESSAGE("Writing 3KB should succeed", written == 3072);
+    char data[3072];
+    memset(data, 'P', sizeof(data));
+    ssize_t written = rdbChunkBufferWrite(chunk_buf, data, sizeof(data));
+    TEST_ASSERT_MESSAGE("Writing 3KB should succeed", written == sizeof(data));
 
     /* Flush the partial chunk */
     int result = rdbChunkBufferFlush(chunk_buf);
@@ -165,7 +163,6 @@ int test_chunkBufferFlushPartial(int argc, char **argv, int flags) {
     TEST_ASSERT_MESSAGE("Flushing empty buffer should succeed", result == 0);
 
     /* Clean up */
-    zfree(data);
     rdbChunkBufferFree(chunk_buf);
     sdsfree(r.io.buffer.ptr); /* Free the potentially reallocated buffer */
     return 0;
@@ -226,7 +223,7 @@ int test_chunkBufferWriteZero(int argc, char **argv, int flags) {
     TEST_ASSERT_MESSAGE("Chunk buffer creation should succeed", chunk_buf != NULL);
 
     /* Write zero bytes */
-    char *data = zmalloc(100);
+    char data[100];
     ssize_t written = rdbChunkBufferWrite(chunk_buf, data, 0);
     TEST_ASSERT_MESSAGE("Writing 0 bytes should return 0", written == 0);
 
@@ -235,7 +232,6 @@ int test_chunkBufferWriteZero(int argc, char **argv, int flags) {
     TEST_ASSERT_MESSAGE("Flushing should succeed", result == 0);
 
     /* Clean up */
-    zfree(data);
     rdbChunkBufferFree(chunk_buf);
     sdsfree(r.io.buffer.ptr); /* Free the potentially reallocated buffer */
     return 0;
@@ -248,8 +244,8 @@ int test_chunkBufferNullHandling(int argc, char **argv, int flags) {
     UNUSED(flags);
 
     /* Test writing to NULL buffer */
-    char *data = zmalloc(100);
-    ssize_t written = rdbChunkBufferWrite(NULL, data, 100);
+    char data[100];
+    ssize_t written = rdbChunkBufferWrite(NULL, data, sizeof(data));
     TEST_ASSERT_MESSAGE("Writing to NULL buffer should fail", written == -1);
 
     /* Test flushing NULL buffer */
@@ -260,7 +256,6 @@ int test_chunkBufferNullHandling(int argc, char **argv, int flags) {
     rdbChunkBufferFree(NULL);
     TEST_ASSERT_MESSAGE("Freeing NULL buffer should not crash", 1);
 
-    zfree(data);
     return 0;
 }
 
@@ -282,16 +277,14 @@ int test_chunkBufferMultipleCycles(int argc, char **argv, int flags) {
 
     /* Perform multiple write-flush cycles */
     for (int i = 0; i < 5; i++) {
-        char *data = zmalloc(1024);
-        memset(data, 'A' + i, 1024);
-
-        ssize_t written = rdbChunkBufferWrite(chunk_buf, data, 1024);
-        TEST_ASSERT_MESSAGE("Writing should succeed in cycle", written == 1024);
-
+        char data[1024];
+        memset(data, 'A' + i, sizeof(data));
+        
+        ssize_t written = rdbChunkBufferWrite(chunk_buf, data, sizeof(data));
+        TEST_ASSERT_MESSAGE("Writing should succeed in cycle", written == sizeof(data));
+        
         int result = rdbChunkBufferFlush(chunk_buf);
         TEST_ASSERT_MESSAGE("Flushing should succeed in cycle", result == 0);
-
-        zfree(data);
     }
 
     /* Clean up */

--- a/src/unit/test_sds.c
+++ b/src/unit/test_sds.c
@@ -5,7 +5,6 @@
 
 #include "../sds.h"
 #include "../sdsalloc.h"
-#include "../zmalloc.h"
 
 static sds sdsTestTemplateCallback(const_sds varname, void *arg) {
     UNUSED(arg);
@@ -55,15 +54,13 @@ int test_sds(int argc, char **argv, int flags) {
                                                                                                            4) == 0);
 
     sdsfree(x);
-    size_t etalon_size = 1024 * 1024;
-    char *etalon = zmalloc(etalon_size);
-    for (size_t i = 0; i < etalon_size; i++) {
+    char etalon[1024 * 1024];
+    for (size_t i = 0; i < sizeof(etalon); i++) {
         etalon[i] = '0';
     }
-    x = sdscatprintf(sdsempty(), "%0*d", (int)etalon_size, 0);
+    x = sdscatprintf(sdsempty(), "%0*d", (int)sizeof(etalon), 0);
     TEST_ASSERT_MESSAGE("sdscatprintf() can print 1MB",
-                        sdslen(x) == etalon_size && memcmp(x, etalon, etalon_size) == 0);
-    zfree(etalon);
+                        sdslen(x) == sizeof(etalon) && memcmp(x, etalon, sizeof(etalon)) == 0);
 
     sdsfree(x);
     x = sdsnew("--");


### PR DESCRIPTION
## Summary
- restore eval shebang parsing and RDB loader progress tracking to their prior behavior
- revert chunk buffer and SDS unit tests to avoid unrelated cleanups while keeping chunked compression changes intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930808b208c832bbb933d9b18487486)