### PR TITLE
Fix LRU/LFU initialization and no-touch handling

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -103,11 +103,13 @@ robj *lookupKey(serverDb *db, robj *key, int flags) {
         /* Update the access time for the ageing algorithm.
          * Don't do it if we have a saving child, as this will trigger
          * a copy on write madness. */
-        if ((flags & LOOKUP_NOTOUCH) == 0 &&
-            server.current_client && server.current_client->flag.no_touch &&
+        int notouch = (flags & LOOKUP_NOTOUCH) != 0;
+        if (!notouch && server.current_client && server.current_client->flag.no_touch &&
             server.executing_client && server.executing_client->cmd->proc != touchCommand)
-            flags |= LOOKUP_NOTOUCH;
-        if (!hasActiveChildProcess() && !(flags & LOOKUP_NOTOUCH)) {
+        {
+            notouch = 1;
+        }
+        if (!hasActiveChildProcess() && !notouch) {
             /* Shared objects can't be stored in the database. */
             serverAssert(val->refcount != OBJ_SHARED_REFCOUNT);
             val->lru = lrulfu_touch(val->lru);

--- a/src/object.c
+++ b/src/object.c
@@ -101,6 +101,7 @@ robj *createObjectWithKeyAndExpire(int type, void *ptr, const sds key, long long
         sdswrite(data, key_sds_size, key_sds_type, key, key_sds_len);
     }
 
+    initObjectLRUOrLFU(o);
     return o;
 }
 
@@ -195,6 +196,7 @@ static robj *createEmbeddedStringObjectWithKeyAndExpire(const char *val_ptr,
     size_t remaining_size = bufsize - (data - (char *)(void *)o);
     o->ptr = sdswrite(data, remaining_size, SDS_TYPE_8, val_ptr, val_len);
 
+    initObjectLRUOrLFU(o);
     return o;
 }
 


### PR DESCRIPTION
## Summary
- ensure key lookups respect no-touch semantics before updating LRU/LFU metadata
- initialize LRU/LFU state when creating new objects so LFU defaults are correct

## Testing
- ./runtest --single tests/unit/introspection-2.tcl
- ./runtest --single tests/unit/dump.tcl
- ./runtest --single tests/unit/maxmemory.tcl

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c7838e50832bb8e187b608c9f44d)