### PR TITLE
Fix LRU/LFU clock handling

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -198,7 +198,7 @@ void dumpCommand(client *c) {
 
 /* RESTORE key ttl serialized-value [REPLACE] [ABSTTL] [IDLETIME seconds] [FREQ frequency] */
 void restoreCommand(client *c) {
-    long long ttl, lfu_freq = -1, lru_idle = -1;
+    long long ttl, lfu_freq = -1, lru_idle = -1, lru_clock_val = -1;
     uint16_t rdbver = 0;
     rio payload;
     int j, type, replace = 0, absttl = 0;
@@ -217,6 +217,7 @@ void restoreCommand(client *c) {
                 addReplyError(c, "Invalid IDLETIME value, must be >= 0");
                 return;
             }
+            lru_clock_val = lru_clock();
             j++; /* Consume additional arg. */
         } else if (!strcasecmp(c->argv[j]->ptr, "freq") && additional >= 1 && lru_idle == -1) {
             if (getLongLongFromObjectOrReply(c, c->argv[j + 1], &lfu_freq, NULL) != C_OK) return;
@@ -304,7 +305,7 @@ void restoreCommand(client *c) {
             rewriteClientCommandArgument(c, c->argc, shared.absttl);
         }
     }
-    objectSetLRUOrLFU(obj, lfu_freq, lru_idle);
+    objectSetLRUOrLFU(obj, lfu_freq, lru_idle, lru_clock_val);
     signalModifiedKey(c, c->db, key);
     notifyKeyspaceEvent(NOTIFY_GENERIC, "restore", key, c->db->id);
     addReply(c, shared.ok);

--- a/src/lrulfu.c
+++ b/src/lrulfu.c
@@ -26,14 +26,22 @@ static uint32_t LRUGetClockTime(void) {
 }
 
 
-uint32_t lru_import(uint32_t idle_secs) {
-    uint32_t now = LRUGetClockTime();
+uint32_t lru_import_with_clock(uint32_t idle_secs, uint32_t lru_clock) {
 #if LRU_CLOCK_RESOLUTION != 1000
     idle_secs = (uint32_t)((long)idle_secs * 1000 / LRU_CLOCK_RESOLUTION);
 #endif
     idle_secs = idle_secs & LRULFU_MASK;
     // Underflow is ok/expected
-    return (now - idle_secs) & LRULFU_MASK;
+    return (lru_clock - idle_secs) & LRULFU_MASK;
+}
+
+uint32_t lru_import(uint32_t idle_secs) {
+    return lru_import_with_clock(idle_secs, LRUGetClockTime());
+}
+
+
+uint32_t lru_clock(void) {
+    return LRUGetClockTime();
 }
 
 

--- a/src/lrulfu.h
+++ b/src/lrulfu.h
@@ -31,6 +31,12 @@
 /* Import a given LRU idleness to the current time.  */
 uint32_t lru_import(uint32_t idle_secs);
 
+/* Import a given LRU idleness relative to the supplied clock. */
+uint32_t lru_import_with_clock(uint32_t idle_secs, uint32_t lru_clock);
+
+/* Get the current LRU clock value. */
+uint32_t lru_clock(void);
+
 /* Get the current idle secs from the given LRU value.  */
 uint32_t lru_getIdleSecs(uint32_t lru);
 

--- a/src/module.c
+++ b/src/module.c
@@ -13739,7 +13739,7 @@ size_t moduleCount(void) {
  * returns VALKEYMODULE_OK if the LRU was updated, VALKEYMODULE_ERR otherwise. */
 int VM_SetLRU(ValkeyModuleKey *key, mstime_t lru_idle) {
     if (!key->value) return VALKEYMODULE_ERR;
-    if (objectSetLRUOrLFU(key->value, -1, lru_idle * 1000)) return VALKEYMODULE_OK;
+    if (objectSetLRUOrLFU(key->value, -1, lru_idle / 1000, -1)) return VALKEYMODULE_OK;
     return VALKEYMODULE_ERR;
 }
 
@@ -13762,7 +13762,7 @@ int VM_GetLRU(ValkeyModuleKey *key, mstime_t *lru_idle) {
  * returns VALKEYMODULE_OK if the LFU was updated, VALKEYMODULE_ERR otherwise. */
 int VM_SetLFU(ValkeyModuleKey *key, long long lfu_freq) {
     if (!key->value) return VALKEYMODULE_ERR;
-    if (objectSetLRUOrLFU(key->value, lfu_freq, -1)) return VALKEYMODULE_OK;
+    if (objectSetLRUOrLFU(key->value, lfu_freq, -1, -1)) return VALKEYMODULE_OK;
     return VALKEYMODULE_ERR;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -1599,7 +1599,7 @@ uint32_t objectGetIdleness(robj *o) {
  * The lru_idle and lru_clock args are only relevant if policy
  * is MAXMEMORY_FLAG_LRU.
  * Either or both of them may be <0, in that case, nothing is set. */
-int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle_secs) {
+int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle_secs, long long lru_clock_val) {
     if (lrulfu_isUsingLFU()) {
         if (lfu_freq >= 0) {
             serverAssert(lfu_freq <= UINT8_MAX);
@@ -1607,7 +1607,8 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle_secs) {
             return 1;
         }
     } else if (lru_idle_secs >= 0) {
-        val->lru = lru_import(lru_idle_secs);
+        uint32_t clock = lru_clock_val >= 0 ? (uint32_t)lru_clock_val : lru_clock();
+        val->lru = lru_import_with_clock(lru_idle_secs, clock);
         return 1;
     }
     return 0;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3134,6 +3134,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
     /* Key-specific attributes, set by opcodes before the key type. */
     long long lru_idle = -1, lfu_freq = -1, expiretime = -1, now = mstime();
+    long long lru_clock_val = lru_clock();
 
     while (1) {
         sds key;
@@ -3478,7 +3479,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             }
 
             /* Set usage information (for eviction). */
-            objectSetLRUOrLFU(val, lfu_freq, lru_idle);
+            objectSetLRUOrLFU(val, lfu_freq, lru_idle, lru_clock_val);
 
             /* call key space notification on key loaded for modules only */
             moduleNotifyKeyspaceEvent(NOTIFY_LOADED, "loaded", &keyobj, db->id);

--- a/src/server.h
+++ b/src/server.h
@@ -3584,7 +3584,7 @@ robj *lookupKeyReadWithFlags(serverDb *db, robj *key, int flags);
 robj *lookupKeyWriteWithFlags(serverDb *db, robj *key, int flags);
 robj *objectCommandLookup(client *c, robj *key);
 robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply);
-int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle_secs);
+int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle_secs, long long lru_clock);
 #define LOOKUP_NONE 0
 #define LOOKUP_NOTOUCH (1 << 0)  /* Don't update LRU. */
 #define LOOKUP_NONOTIFY (1 << 1) /* Don't trigger keyspace event on key misses. */


### PR DESCRIPTION
## Summary
- add helpers to import LRU values relative to a provided clock and reuse them when restoring or loading keys
- correct module LRU APIs to pass idle time in seconds and propagate reference clocks through objectSetLRUOrLFU

## Testing
- ./runtest --single unit/introspection-2
- ./runtest --single unit/dump
- tclsh tests/test_helper.tcl --single unit/maxmemory --only "lru/lfu value of the key just added"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c2c20194832b974a92d2ed689703)