### PR TITLE
Fix LRU/LFU initialization and no-touch handling

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -304,7 +304,14 @@ void restoreCommand(client *c) {
             rewriteClientCommandArgument(c, c->argc, shared.absttl);
         }
     }
-    objectSetLRUOrLFU(obj, lfu_freq, lru_idle);
+    if (!objectSetLRUOrLFU(obj, lfu_freq, lru_idle) &&
+        (lfu_freq >= 0 || lru_idle >= 0)) {
+        if (lfu_freq >= 0) {
+            obj->lru = lfu_import((uint8_t)lfu_freq);
+        } else if (lru_idle >= 0) {
+            obj->lru = lru_import(lru_idle);
+        }
+    }
     signalModifiedKey(c, c->db, key);
     notifyKeyspaceEvent(NOTIFY_GENERIC, "restore", key, c->db->id);
     addReply(c, shared.ok);

--- a/src/db.c
+++ b/src/db.c
@@ -103,11 +103,14 @@ robj *lookupKey(serverDb *db, robj *key, int flags) {
         /* Update the access time for the ageing algorithm.
          * Don't do it if we have a saving child, as this will trigger
          * a copy on write madness. */
-        if ((flags & LOOKUP_NOTOUCH) == 0 &&
+        bool no_touch = flags & LOOKUP_NOTOUCH;
+        if (!no_touch &&
             server.current_client && server.current_client->flag.no_touch &&
-            server.executing_client && server.executing_client->cmd->proc != touchCommand)
+            (!server.executing_client || server.executing_client->cmd->proc != touchCommand)) {
+            no_touch = true;
             flags |= LOOKUP_NOTOUCH;
-        if (!hasActiveChildProcess() && !(flags & LOOKUP_NOTOUCH)) {
+        }
+        if (!hasActiveChildProcess() && !no_touch) {
             /* Shared objects can't be stored in the database. */
             serverAssert(val->refcount != OBJ_SHARED_REFCOUNT);
             val->lru = lrulfu_touch(val->lru);

--- a/src/object.c
+++ b/src/object.c
@@ -101,6 +101,7 @@ robj *createObjectWithKeyAndExpire(int type, void *ptr, const sds key, long long
         sdswrite(data, key_sds_size, key_sds_type, key, key_sds_len);
     }
 
+    initObjectLRUOrLFU(o);
     return o;
 }
 


### PR DESCRIPTION
## Summary
- ensure lookupKey skips LRU/LFU touch when no-touch clients are used
- initialize new objects with the appropriate LRU/LFU metadata
- apply RESTORE frequency/idle overrides even when the helper does not update the field

## Testing
- ./runtest --single tests/unit/introspection-2.tcl
- ./runtest --single tests/unit/dump.tcl
- Attempted: ./runtest --single tests/unit/maxmemory.tcl (interrupted due to long runtime); manual CLI check of default LFU frequency on new keys


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c7838e50832bb8e187b608c9f44d)