### PR TITLE
Fix LRULFU clock on 32-bit builds

### DIFF
--- a/src/lrulfu.c
+++ b/src/lrulfu.c
@@ -18,8 +18,11 @@
 // Current time in seconds (24 least significant bits).  Designed to roll over.
 static uint32_t LRUGetClockTime(void) {
 #if LRU_CLOCK_RESOLUTION == 1000
-    time_t unixtime = atomic_load_explicit(&server.unixtime, memory_order_relaxed);
-    return (uint32_t)(unixtime & LRULFU_MASK);
+    /* Using mstime instead of unixtime here avoids relying on atomics for
+     * timekeeping, which can behave differently on 32-bit builds. The extra
+     * precision is masked away while keeping the low 24 bits aligned with the
+     * wall clock. */
+    return (uint32_t)((server.mstime / 1000) & LRULFU_MASK);
 #else
     return (uint32_t)((server.mstime / LRU_CLOCK_RESOLUTION) & LRULFU_MASK);
 #endif
@@ -84,8 +87,7 @@ uint32_t lru_getIdleSecs(uint32_t lru) {
 
 // Current time in minutes (16 least significant bits).  Designed to roll over.
 static uint16_t LFUGetTimeInMinutes(void) {
-    time_t unixtime = atomic_load_explicit(&server.unixtime, memory_order_relaxed);
-    return (uint16_t)(unixtime / 60);
+    return (uint16_t)((server.mstime / 1000) / 60);
 }
 
 


### PR DESCRIPTION
## Summary
- adjust LRULFU time calculations to use the cached millisecond clock
- avoid reliance on atomic time reads that behave differently on 32-bit systems

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693263e3599c832bbb68176ebd369757)