### PR TITLE
Reduce quicklist listpack compression iterations under ASan

### DIFF
--- a/src/unit/test_quicklist.c
+++ b/src/unit/test_quicklist.c
@@ -2226,8 +2226,12 @@ int test_quicklistCompressAndDecompressQuicklistListpackNode(int argc, char **ar
     unsigned char *s = zmalloc(sz);
     randstring(s, sz);
 
-    /* Keep filling the node, until it reaches 1GB */
-    for (int i = 0; i < 32; i++) {
+    /* Keep filling the node, until it reaches 1GB (smaller with ASan). */
+    int iterations = 32;
+#ifdef VALKEY_ADDRESS_SANITIZER
+    iterations = 8;
+#endif
+    for (int i = 0; i < iterations; i++) {
         node->entry = lpAppend(node->entry, s, sz);
         node->sz = lpBytes((node)->entry);
 


### PR DESCRIPTION
### Motivation
- Large-memory quicklist compression/decompression test can run for a very long time and is especially slow under AddressSanitizer builds, which can lead to excessive test runtime or cancellations.
- Cap the number of heavy iterations when AddressSanitizer is enabled to keep the unit test practical while preserving the test logic for non-sanitized builds.

### Description
- Modified `src/unit/test_quicklist.c` to drive the compression loop with an `iterations` variable instead of a fixed `32` iterations. 
- Added `#ifdef VALKEY_ADDRESS_SANITIZER` to reduce `iterations` to `8` when `VALKEY_ADDRESS_SANITIZER` is defined, and updated the loop comment to reflect the change.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to test code and conditions only affect runs with `UNIT_TEST_LARGE_MEMORY` and builds that define `VALKEY_ADDRESS_SANITIZER`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fd8c3c48832ba42238c8ef993f39)