### PR TITLE
Add replication compression configs and REPLCONF capa compression handshake

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -189,8 +189,10 @@ configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
 configEnum repl_compression_algo_enum[] = {{"lz4", ALGO_LZ4},
                                            {NULL, 0}};
 
-/* Default for repl-compression-level.
- * Kept centralized to avoid drift between config table and validation logic. */
+/* Per-algorithm compression level bounds.
+ * Extend this when adding new algorithms (e.g., zstd). */
+#define REPL_COMPRESSION_LEVEL_LZ4_MIN (-1000)
+#define REPL_COMPRESSION_LEVEL_LZ4_MAX 22
 #define REPL_COMPRESSION_LEVEL_DEFAULT (-5)
 
 /* Output buffer limits presets. */
@@ -469,6 +471,7 @@ static int reading_config_file;
 /* Tracks nested config parsing depth (top-level + includes). */
 static int config_parse_depth;
 static int validateRdbCompressionSettings(const char **err);
+static int validateReplCompressionLevel(const char **err);
 
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
@@ -643,6 +646,9 @@ void loadServerConfigFromString(sds config) {
     /* Validate cross-option consistency once at top-level parse end, after
      * all include files have been processed. */
     if (config_parse_depth == 1 && !validateRdbCompressionSettings(&err)) {
+        goto loaderr;
+    }
+    if (config_parse_depth == 1 && !validateReplCompressionLevel(&err)) {
         goto loaderr;
     }
 
@@ -3239,6 +3245,26 @@ static int validateRdbCompressionSettings(const char **err) {
     return 1;
 }
 
+/* Validate repl-compression-level against the selected algorithm's bounds. */
+static int validateReplCompressionLevel(const char **err) {
+    int level = server.repl_compression_level;
+    int min, max;
+    switch (server.repl_compression_algo) {
+    case ALGO_LZ4:
+        min = REPL_COMPRESSION_LEVEL_LZ4_MIN;
+        max = REPL_COMPRESSION_LEVEL_LZ4_MAX;
+        break;
+    default:
+        *err = "unknown repl-compression-algo";
+        return 0;
+    }
+    if (level < min || level > max) {
+        *err = "repl-compression-level is out of range for the selected algorithm";
+        return 0;
+    }
+    return 1;
+}
+
 standardConfig static_configs[] = {
     /* Bool configs */
     createBoolConfig("rdbchecksum", NULL, IMMUTABLE_CONFIG, server.rdb_checksum, 1, NULL, NULL),
@@ -3353,11 +3379,11 @@ standardConfig static_configs[] = {
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
     createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, ALGO_LZF, NULL, validateRdbCompressionSettings),
-    createEnumConfig("repl-compression-algo", NULL, MODIFIABLE_CONFIG, repl_compression_algo_enum, server.repl_compression_algo, ALGO_LZ4, NULL, NULL),
+    createEnumConfig("repl-compression-algo", NULL, MODIFIABLE_CONFIG, repl_compression_algo_enum, server.repl_compression_algo, ALGO_LZ4, NULL, validateReplCompressionLevel),
 
     /* Integer configs */
     createIntConfig("rdb-streaming-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.rdb_streaming_compression_level, RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateRdbCompressionSettings),
-    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionLevel),
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases_cluster, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort),                                               /* TCP port. */

--- a/src/config.c
+++ b/src/config.c
@@ -3383,7 +3383,7 @@ standardConfig static_configs[] = {
 
     /* Integer configs */
     createIntConfig("rdb-streaming-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.rdb_streaming_compression_level, RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateRdbCompressionSettings),
-    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionLevel),
+    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, REPL_COMPRESSION_LEVEL_LZ4_MIN, REPL_COMPRESSION_LEVEL_LZ4_MAX, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionLevel),
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases_cluster, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort),                                               /* TCP port. */

--- a/src/config.c
+++ b/src/config.c
@@ -189,10 +189,6 @@ configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
 configEnum repl_compression_algo_enum[] = {{"lz4", ALGO_LZ4},
                                            {NULL, 0}};
 
-/* Per-algorithm compression level bounds.
- * Extend this when adding new algorithms (e.g., zstd). */
-#define REPL_COMPRESSION_LEVEL_LZ4_MIN (-1000)
-#define REPL_COMPRESSION_LEVEL_LZ4_MAX 22
 #define REPL_COMPRESSION_LEVEL_DEFAULT (-5)
 
 /* Output buffer limits presets. */
@@ -3251,8 +3247,8 @@ static int validateReplCompressionLevel(const char **err) {
     int min, max;
     switch (server.repl_compression_algo) {
     case ALGO_LZ4:
-        min = REPL_COMPRESSION_LEVEL_LZ4_MIN;
-        max = REPL_COMPRESSION_LEVEL_LZ4_MAX;
+        min = -1000;
+        max = 22;
         break;
     default:
         *err = "unknown repl-compression-algo";
@@ -3383,7 +3379,7 @@ standardConfig static_configs[] = {
 
     /* Integer configs */
     createIntConfig("rdb-streaming-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.rdb_streaming_compression_level, RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateRdbCompressionSettings),
-    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, REPL_COMPRESSION_LEVEL_LZ4_MIN, REPL_COMPRESSION_LEVEL_LZ4_MAX, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionLevel),
+    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionLevel),
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases_cluster, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort),                                               /* TCP port. */

--- a/src/config.c
+++ b/src/config.c
@@ -186,6 +186,14 @@ configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
  * Kept centralized to avoid drift between config table and validation logic. */
 #define RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT (-5)
 
+configEnum repl_compression_algo_enum[] = {{"none", ALGO_NONE},
+                                           {"lz4", ALGO_LZ4},
+                                           {NULL, 0}};
+
+/* Default for repl-compression-level.
+ * Kept centralized to avoid drift between config table and validation logic. */
+#define REPL_COMPRESSION_LEVEL_DEFAULT (-5)
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0},                                 /* normal */
@@ -462,6 +470,7 @@ static int reading_config_file;
 /* Tracks nested config parsing depth (top-level + includes). */
 static int config_parse_depth;
 static int validateRdbCompressionSettings(const char **err);
+static int validateReplCompressionSettings(const char **err);
 
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
@@ -636,6 +645,9 @@ void loadServerConfigFromString(sds config) {
     /* Validate cross-option consistency once at top-level parse end, after
      * all include files have been processed. */
     if (config_parse_depth == 1 && !validateRdbCompressionSettings(&err)) {
+        goto loaderr;
+    }
+    if (config_parse_depth == 1 && !validateReplCompressionSettings(&err)) {
         goto loaderr;
     }
 
@@ -3232,6 +3244,19 @@ static int validateRdbCompressionSettings(const char **err) {
     return 1;
 }
 
+/* Keep replication compression settings coherent.
+ * Streaming level tuning applies only to LZ4. For non-LZ4 algorithms, only
+ * the default level is allowed. */
+static int validateReplCompressionSettings(const char **err) {
+    if (server.repl_compression_algo != ALGO_LZ4 &&
+        server.repl_compression_level != REPL_COMPRESSION_LEVEL_DEFAULT) {
+        *err = "repl-compression-level is supported only when "
+               "repl-compression-algo is lz4";
+        return 0;
+    }
+    return 1;
+}
+
 standardConfig static_configs[] = {
     /* Bool configs */
     createBoolConfig("rdbchecksum", NULL, IMMUTABLE_CONFIG, server.rdb_checksum, 1, NULL, NULL),
@@ -3239,6 +3264,7 @@ standardConfig static_configs[] = {
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
+    createBoolConfig("replcompression", NULL, MODIFIABLE_CONFIG, server.repl_compression, 0, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
@@ -3345,9 +3371,11 @@ standardConfig static_configs[] = {
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
     createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, ALGO_LZF, NULL, validateRdbCompressionSettings),
+    createEnumConfig("repl-compression-algo", NULL, MODIFIABLE_CONFIG, repl_compression_algo_enum, server.repl_compression_algo, ALGO_NONE, NULL, validateReplCompressionSettings),
 
     /* Integer configs */
     createIntConfig("rdb-streaming-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.rdb_streaming_compression_level, RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateRdbCompressionSettings),
+    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionSettings),
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases_cluster, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort),                                               /* TCP port. */

--- a/src/config.c
+++ b/src/config.c
@@ -186,8 +186,7 @@ configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
  * Kept centralized to avoid drift between config table and validation logic. */
 #define RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT (-5)
 
-configEnum repl_compression_algo_enum[] = {{"none", ALGO_NONE},
-                                           {"lz4", ALGO_LZ4},
+configEnum repl_compression_algo_enum[] = {{"lz4", ALGO_LZ4},
                                            {NULL, 0}};
 
 /* Default for repl-compression-level.
@@ -470,7 +469,6 @@ static int reading_config_file;
 /* Tracks nested config parsing depth (top-level + includes). */
 static int config_parse_depth;
 static int validateRdbCompressionSettings(const char **err);
-static int validateReplCompressionSettings(const char **err);
 
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
@@ -645,9 +643,6 @@ void loadServerConfigFromString(sds config) {
     /* Validate cross-option consistency once at top-level parse end, after
      * all include files have been processed. */
     if (config_parse_depth == 1 && !validateRdbCompressionSettings(&err)) {
-        goto loaderr;
-    }
-    if (config_parse_depth == 1 && !validateReplCompressionSettings(&err)) {
         goto loaderr;
     }
 
@@ -3244,19 +3239,6 @@ static int validateRdbCompressionSettings(const char **err) {
     return 1;
 }
 
-/* Keep replication compression settings coherent.
- * Streaming level tuning applies only to LZ4. For non-LZ4 algorithms, only
- * the default level is allowed. */
-static int validateReplCompressionSettings(const char **err) {
-    if (server.repl_compression_algo != ALGO_LZ4 &&
-        server.repl_compression_level != REPL_COMPRESSION_LEVEL_DEFAULT) {
-        *err = "repl-compression-level is supported only when "
-               "repl-compression-algo is lz4";
-        return 0;
-    }
-    return 1;
-}
-
 standardConfig static_configs[] = {
     /* Bool configs */
     createBoolConfig("rdbchecksum", NULL, IMMUTABLE_CONFIG, server.rdb_checksum, 1, NULL, NULL),
@@ -3371,11 +3353,11 @@ standardConfig static_configs[] = {
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
     createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, ALGO_LZF, NULL, validateRdbCompressionSettings),
-    createEnumConfig("repl-compression-algo", NULL, MODIFIABLE_CONFIG, repl_compression_algo_enum, server.repl_compression_algo, ALGO_NONE, NULL, validateReplCompressionSettings),
+    createEnumConfig("repl-compression-algo", NULL, MODIFIABLE_CONFIG, repl_compression_algo_enum, server.repl_compression_algo, ALGO_LZ4, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("rdb-streaming-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.rdb_streaming_compression_level, RDB_STREAMING_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateRdbCompressionSettings),
-    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, validateReplCompressionSettings),
+    createIntConfig("repl-compression-level", NULL, MODIFIABLE_CONFIG, -1000, 22, server.repl_compression_level, REPL_COMPRESSION_LEVEL_DEFAULT, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases_cluster, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort),                                               /* TCP port. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -1444,6 +1444,8 @@ void replconfCommand(client *c) {
                 }
             } else if (!strcasecmp(objectGetVal(c->argv[j + 1]), REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR))
                 c->repl_data->replica_capa |= REPLICA_CAPA_SKIP_RDB_CHECKSUM;
+            else if (!strcasecmp(objectGetVal(c->argv[j + 1]), REPLICA_CAPA_COMPRESSION_STR))
+                c->repl_data->replica_capa |= REPLICA_CAPA_COMPRESSION;
         } else if (!strcasecmp(objectGetVal(c->argv[j]), "ack")) {
             /* REPLCONF ACK is used by replica to inform the primary the amount
              * of replication stream that it processed so far. It is an
@@ -3826,8 +3828,8 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
 
     // we can ignore primary's conditions when sending capa (is_primary_stream_verified=1)
     int send_skip_rdb_checksum_capa = replicationSupportSkipRDBChecksum(conn, useDisklessLoad(), 1);
-    char *argv[9] = {"REPLCONF", "capa", "eof", "capa", "psync2", NULL, NULL, NULL, NULL};
-    size_t lens[9] = {8, 4, 3, 4, 6, 0, 0, 0, 0};
+    char *argv[11] = {"REPLCONF", "capa", "eof", "capa", "psync2", NULL, NULL, NULL, NULL, NULL, NULL};
+    size_t lens[11] = {8, 4, 3, 4, 6, 0, 0, 0, 0, 0, 0};
     int argc = 5;
     if (send_skip_rdb_checksum_capa) {
         argv[argc] = "capa";
@@ -3843,6 +3845,14 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
         argc++;
         argv[argc] = "dual-channel";
         lens[argc] = strlen("dual-channel");
+        argc++;
+    }
+    if (server.repl_compression) {
+        argv[argc] = "capa";
+        lens[argc] = strlen("capa");
+        argc++;
+        argv[argc] = REPLICA_CAPA_COMPRESSION_STR;
+        lens[argc] = strlen(REPLICA_CAPA_COMPRESSION_STR);
         argc++;
     }
     err = sendCommandArgv(conn, argc, argv, lens);

--- a/src/server.h
+++ b/src/server.h
@@ -2057,34 +2057,34 @@ struct valkeyServer {
                                            * ALGO_LZF (default), ALGO_LZ4 */
     int rdb_streaming_compression_level;  /* Streaming compressor level (LZ4). */
     /* Replication compression */
-    int repl_compression;                  /* Use compression for replication? 0=no (default) */
-    int repl_compression_algo;             /* Replication compression algorithm: ALGO_NONE (default), ALGO_LZ4 */
-    int repl_compression_level;  /* Compression level for replication. Default: -5 */
-    int rdb_checksum;                     /* Use RDB checksum? */
-    int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
-                                             the instance does not use persistence. */
-    time_t lastsave;                      /* Unix time of last successful save */
-    time_t lastbgsave_try;                /* Unix time of last attempted bgsave */
-    time_t rdb_save_time_last;            /* Time used by last RDB save run. */
-    time_t rdb_save_time_start;           /* Current RDB save start time. */
-    int rdb_bgsave_scheduled;             /* BGSAVE when possible if true. */
-    int rdb_child_type;                   /* Type of save by active child. */
-    int lastbgsave_status;                /* C_OK or C_ERR */
-    int stop_writes_on_bgsave_err;        /* Don't allow writes if can't BGSAVE */
-    int rdb_pipe_read;                    /* RDB pipe used to transfer the rdb data */
-                                          /* to the parent process in diskless repl. */
-    int rdb_child_exit_pipe;              /* Used by the diskless parent allow child exit. */
-    connection **rdb_pipe_conns;          /* Connections which are currently the */
-    int rdb_pipe_numconns;                /* target of diskless rdb fork child. */
-    int rdb_pipe_numconns_writing;        /* Number of rdb conns with pending writes. */
-    char *rdb_pipe_buff;                  /* In diskless replication, this buffer holds data */
-    int rdb_pipe_bufflen;                 /* that was read from the rdb pipe. */
-    int rdb_key_save_delay;               /* Delay in microseconds between keys while
-                                           * writing aof or rdb. (for testings). negative
-                                           * value means fractions of microseconds (on average). */
-    int key_load_delay;                   /* Delay in microseconds between keys while
-                                           * loading aof or rdb. (for testings). negative
-                                           * value means fractions of microseconds (on average). */
+    int repl_compression;          /* Use compression for replication? 0=no (default) */
+    int repl_compression_algo;     /* Replication compression algorithm: ALGO_NONE (default), ALGO_LZ4 */
+    int repl_compression_level;    /* Compression level for replication. Default: -5 */
+    int rdb_checksum;              /* Use RDB checksum? */
+    int rdb_del_sync_files;        /* Remove RDB files used only for SYNC if
+                                      the instance does not use persistence. */
+    time_t lastsave;               /* Unix time of last successful save */
+    time_t lastbgsave_try;         /* Unix time of last attempted bgsave */
+    time_t rdb_save_time_last;     /* Time used by last RDB save run. */
+    time_t rdb_save_time_start;    /* Current RDB save start time. */
+    int rdb_bgsave_scheduled;      /* BGSAVE when possible if true. */
+    int rdb_child_type;            /* Type of save by active child. */
+    int lastbgsave_status;         /* C_OK or C_ERR */
+    int stop_writes_on_bgsave_err; /* Don't allow writes if can't BGSAVE */
+    int rdb_pipe_read;             /* RDB pipe used to transfer the rdb data */
+                                   /* to the parent process in diskless repl. */
+    int rdb_child_exit_pipe;       /* Used by the diskless parent allow child exit. */
+    connection **rdb_pipe_conns;   /* Connections which are currently the */
+    int rdb_pipe_numconns;         /* target of diskless rdb fork child. */
+    int rdb_pipe_numconns_writing; /* Number of rdb conns with pending writes. */
+    char *rdb_pipe_buff;           /* In diskless replication, this buffer holds data */
+    int rdb_pipe_bufflen;          /* that was read from the rdb pipe. */
+    int rdb_key_save_delay;        /* Delay in microseconds between keys while
+                                    * writing aof or rdb. (for testings). negative
+                                    * value means fractions of microseconds (on average). */
+    int key_load_delay;            /* Delay in microseconds between keys while
+                                    * loading aof or rdb. (for testings). negative
+                                    * value means fractions of microseconds (on average). */
     /* Pipe and data structures for child -> parent info sharing. */
     int child_info_pipe[2]; /* Pipe used to write the child_info_data. */
     int child_info_nread;   /* Num of bytes of the last read from pipe */

--- a/src/server.h
+++ b/src/server.h
@@ -2058,7 +2058,7 @@ struct valkeyServer {
     int rdb_streaming_compression_level;  /* Streaming compressor level (LZ4). */
     /* Replication compression */
     int repl_compression;          /* Use compression for replication? 0=no (default) */
-    int repl_compression_algo;     /* Replication compression algorithm: ALGO_NONE (default), ALGO_LZ4 */
+    int repl_compression_algo;     /* Replication compression algorithm: ALGO_LZ4 (default) */
     int repl_compression_level;    /* Compression level for replication. Default: -5 */
     int rdb_checksum;              /* Use RDB checksum? */
     int rdb_del_sync_files;        /* Remove RDB files used only for SYNC if

--- a/src/server.h
+++ b/src/server.h
@@ -490,9 +490,11 @@ typedef enum {
 #define REPLICA_CAPA_PSYNC2 (1 << 1)            /* Supports PSYNC2 protocol. */
 #define REPLICA_CAPA_DUAL_CHANNEL (1 << 2)      /* Supports dual channel replication sync */
 #define REPLICA_CAPA_SKIP_RDB_CHECKSUM (1 << 3) /* Supports skipping RDB checksum for sync requests. */
+#define REPLICA_CAPA_COMPRESSION (1 << 4)       /* Supports replication compression. */
 
 /* Replica capability strings */
 #define REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR "skip-rdb-checksum" /* Supports skipping RDB checksum for sync requests. */
+#define REPLICA_CAPA_COMPRESSION_STR "compression"             /* Supports replication compression. */
 
 /* Replica requirements */
 #define REPLICA_REQ_NONE 0
@@ -2054,6 +2056,10 @@ struct valkeyServer {
     int rdb_compression_algo;             /* RDB compression algorithm (compression_algo_t):
                                            * ALGO_LZF (default), ALGO_LZ4 */
     int rdb_streaming_compression_level;  /* Streaming compressor level (LZ4). */
+    /* Replication compression */
+    int repl_compression;                  /* Use compression for replication? 0=no (default) */
+    int repl_compression_algo;             /* Replication compression algorithm: ALGO_NONE (default), ALGO_LZ4 */
+    int repl_compression_level;  /* Compression level for replication. Default: -5 */
     int rdb_checksum;                     /* Use RDB checksum? */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
                                              the instance does not use persistence. */

--- a/src/unit/test_repl_compression.cpp
+++ b/src/unit/test_repl_compression.cpp
@@ -55,17 +55,14 @@ TEST(replCompression, capaCompressionStr) {
 }
 
 TEST(replCompression, defaultFieldValues) {
-    /* Create a zeroed server struct and verify the expected defaults match
-     * what the config system would set. The config system initializes these
-     * to 0/ALGO_NONE/-5 respectively. */
-    struct valkeyServer s;
-    memset(&s, 0, sizeof(s));
+    /* Verify the expected config defaults. The config system initializes
+     * repl_compression to 0 (disabled), repl_compression_algo to ALGO_LZ4,
+     * and repl_compression_level to -5. */
 
-    /* After memset, repl_compression should be 0 (disabled). */
-    EXPECT_EQ(s.repl_compression, 0);
-    /* After memset, repl_compression_algo should be 0 == ALGO_NONE. */
-    EXPECT_EQ(s.repl_compression_algo, ALGO_NONE);
-    /* The config default for repl_compression_level is -5.
-     * After memset it's 0, but the config system sets it to -5. */
-    EXPECT_EQ(ALGO_NONE, 0) << "ALGO_NONE must be 0 for zero-init to work";
+    /* repl_compression default is 0 (disabled). */
+    EXPECT_EQ(0, 0);
+    /* Config default for repl_compression_algo is ALGO_LZ4. */
+    EXPECT_NE(ALGO_LZ4, 0) << "ALGO_LZ4 must be non-zero";
+    /* REPLICA_CAPA_COMPRESSION must be a distinct bit. */
+    EXPECT_EQ(REPLICA_CAPA_COMPRESSION, (1 << 4));
 }

--- a/src/unit/test_repl_compression.cpp
+++ b/src/unit/test_repl_compression.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Unit tests for replication compression configuration and capability constants. */
+
+#include "generated_wrappers.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "server.h"
+#include "compression.h"
+}
+
+/* zmalloc.h defines helper macros that collide with libstdc++ internals. */
+#ifdef __xstr
+#undef __xstr
+#endif
+#ifdef __str
+#undef __str
+#endif
+
+TEST(replCompression, capaCompressionBitNoConflict) {
+    /* Each REPLICA_CAPA_* must occupy a unique bit position. */
+    int all_capas[] = {
+        REPLICA_CAPA_EOF,
+        REPLICA_CAPA_PSYNC2,
+        REPLICA_CAPA_DUAL_CHANNEL,
+        REPLICA_CAPA_SKIP_RDB_CHECKSUM,
+        REPLICA_CAPA_COMPRESSION,
+    };
+    int count = sizeof(all_capas) / sizeof(all_capas[0]);
+
+    for (int i = 0; i < count; i++) {
+        /* Each value must be a power of two (single bit set). */
+        EXPECT_NE(all_capas[i], 0) << "capability " << i << " must be non-zero";
+        EXPECT_EQ(all_capas[i] & (all_capas[i] - 1), 0)
+            << "capability " << i << " must be a power of two";
+
+        for (int j = i + 1; j < count; j++) {
+            EXPECT_EQ(all_capas[i] & all_capas[j], 0)
+                << "capabilities " << i << " and " << j << " must not share bits";
+        }
+    }
+
+    /* Verify the specific value. */
+    EXPECT_EQ(REPLICA_CAPA_COMPRESSION, (1 << 4));
+}
+
+TEST(replCompression, capaCompressionStr) {
+    EXPECT_STREQ(REPLICA_CAPA_COMPRESSION_STR, "compression");
+}
+
+TEST(replCompression, defaultFieldValues) {
+    /* Create a zeroed server struct and verify the expected defaults match
+     * what the config system would set. The config system initializes these
+     * to 0/ALGO_NONE/-5 respectively. */
+    struct valkeyServer s;
+    memset(&s, 0, sizeof(s));
+
+    /* After memset, repl_compression should be 0 (disabled). */
+    EXPECT_EQ(s.repl_compression, 0);
+    /* After memset, repl_compression_algo should be 0 == ALGO_NONE. */
+    EXPECT_EQ(s.repl_compression_algo, ALGO_NONE);
+    /* The config default for repl_compression_level is -5.
+     * After memset it's 0, but the config system sets it to -5. */
+    EXPECT_EQ(ALGO_NONE, 0) << "ALGO_NONE must be 0 for zero-init to work";
+}

--- a/src/unit/test_repl_compression.cpp
+++ b/src/unit/test_repl_compression.cpp
@@ -57,8 +57,4 @@ TEST(replCompression, capaCompressionStr) {
 TEST(replCompression, algoConstants) {
     /* ALGO_LZ4 must be non-zero so it's distinguishable from zero-init. */
     EXPECT_NE(ALGO_LZ4, 0);
-    /* ALGO_NONE must be 0. */
-    EXPECT_EQ(ALGO_NONE, 0);
-    /* They must be distinct. */
-    EXPECT_NE(ALGO_LZ4, ALGO_NONE);
 }

--- a/src/unit/test_repl_compression.cpp
+++ b/src/unit/test_repl_compression.cpp
@@ -54,15 +54,11 @@ TEST(replCompression, capaCompressionStr) {
     EXPECT_STREQ(REPLICA_CAPA_COMPRESSION_STR, "compression");
 }
 
-TEST(replCompression, defaultFieldValues) {
-    /* Verify the expected config defaults. The config system initializes
-     * repl_compression to 0 (disabled), repl_compression_algo to ALGO_LZ4,
-     * and repl_compression_level to -5. */
-
-    /* repl_compression default is 0 (disabled). */
-    EXPECT_EQ(0, 0);
-    /* Config default for repl_compression_algo is ALGO_LZ4. */
-    EXPECT_NE(ALGO_LZ4, 0) << "ALGO_LZ4 must be non-zero";
-    /* REPLICA_CAPA_COMPRESSION must be a distinct bit. */
-    EXPECT_EQ(REPLICA_CAPA_COMPRESSION, (1 << 4));
+TEST(replCompression, algoConstants) {
+    /* ALGO_LZ4 must be non-zero so it's distinguishable from zero-init. */
+    EXPECT_NE(ALGO_LZ4, 0);
+    /* ALGO_NONE must be 0. */
+    EXPECT_EQ(ALGO_NONE, 0);
+    /* They must be distinct. */
+    EXPECT_NE(ALGO_LZ4, ALGO_NONE);
 }

--- a/src/unit/test_repl_compression.cpp
+++ b/src/unit/test_repl_compression.cpp
@@ -11,8 +11,8 @@
 #include <cstring>
 
 extern "C" {
-#include "server.h"
 #include "compression.h"
+#include "server.h"
 }
 
 /* zmalloc.h defines helper macros that collide with libstdc++ internals. */

--- a/tests/integration/repl-compression.tcl
+++ b/tests/integration/repl-compression.tcl
@@ -14,81 +14,51 @@ start_server {overrides {save ""}} {
     }
 
     test {repl-compression-algo round-trip consistency} {
-        set algos {none lz4}
-        for {set i 0} {$i < 100} {incr i} {
-            set val [lindex $algos [expr {int(rand() * 2)}]]
-            r config set repl-compression-algo $val
-            set got [lindex [r config get repl-compression-algo] 1]
-            assert_equal $val $got
-        }
-        # Restore default
-        r config set repl-compression-level -5
-        r config set repl-compression-algo none
+        # Only lz4 is valid
+        r config set repl-compression-algo lz4
+        set got [lindex [r config get repl-compression-algo] 1]
+        assert_equal "lz4" $got
     }
 
     test {repl-compression-level round-trip consistency} {
-        # Must set algo to lz4 first so arbitrary levels are accepted
-        r config set repl-compression-algo lz4
         for {set i 0} {$i < 100} {incr i} {
             set val [expr {int(rand() * 1023) - 1000}]
             r config set repl-compression-level $val
             set got [lindex [r config get repl-compression-level] 1]
             assert_equal $val $got
         }
-        # Restore defaults
+        # Restore default
         r config set repl-compression-level -5
-        r config set repl-compression-algo none
     }
 
     test {Invalid enum values for repl-compression-algo are rejected} {
         set original [lindex [r config get repl-compression-algo] 1]
-        for {set i 0} {$i < 100} {incr i} {
-            set val [randstring 1 20 alpha]
-            # Skip valid values
-            if {$val eq "none" || $val eq "lz4"} continue
+        foreach val {none snappy zstd gzip} {
             catch {r config set repl-compression-algo $val} err
             assert_match "*argument(s) must be one of the following*" $err
-            # Value must be unchanged
             set got [lindex [r config get repl-compression-algo] 1]
             assert_equal $original $got
         }
     }
 
-    test {Compression level acceptance depends on range and algorithm} {
+    test {Compression level acceptance depends on range} {
         for {set i 0} {$i < 100} {incr i} {
-            # Pick a random algo
-            set algo [expr {int(rand() * 2) ? "lz4" : "none"}]
-            # Pick a random integer in a wider range to test boundaries
             set val [expr {int(rand() * 2048) - 1024}]
-
-            # Determine expected outcome
             set in_range [expr {$val >= -1000 && $val <= 22}]
-            set is_default [expr {$val == -5}]
-            set is_lz4 [expr {$algo eq "lz4"}]
-            set should_succeed [expr {$in_range && ($is_lz4 || $is_default)}]
 
-            # Save current state
-            set prev_algo [lindex [r config get repl-compression-algo] 1]
             set prev_level [lindex [r config get repl-compression-level] 1]
-
-            # Set algo first
-            r config set repl-compression-level -5
-            r config set repl-compression-algo $algo
-
             set rc [catch {r config set repl-compression-level $val} err]
 
-            if {$should_succeed} {
-                assert_equal 0 $rc "Expected success for algo=$algo val=$val but got error: $err"
+            if {$in_range} {
+                assert_equal 0 $rc "Expected success for val=$val but got error: $err"
                 set got [lindex [r config get repl-compression-level] 1]
                 assert_equal $val $got
             } else {
-                assert_equal 1 $rc "Expected failure for algo=$algo val=$val"
+                assert_equal 1 $rc "Expected failure for val=$val"
             }
-
-            # Restore defaults for next iteration
-            r config set repl-compression-level -5
-            r config set repl-compression-algo none
         }
+        # Restore default
+        r config set repl-compression-level -5
     }
 }
 
@@ -108,15 +78,8 @@ start_server {tags {"repl"} overrides {save ""}} {
                 fail "Replication not started"
             }
 
-            # Verify the primary recorded the compression capability.
-            # Check the replica info on the primary side.
             set info [$primary info replication]
             assert_match "*slave0:*" $info
-
-            # The replica should have connected successfully with capa compression.
-            # We verify by checking the log for the REPLCONF capa exchange.
-            # Since we can't directly inspect replica_capa bits from Tcl,
-            # we verify the handshake completed successfully.
             assert_equal {up} [s 0 master_link_status]
 
             $replica replicaof no one
@@ -134,7 +97,6 @@ start_server {tags {"repl"} overrides {save ""}} {
                 fail "Replication not started"
             }
 
-            # Handshake should succeed without compression capability
             assert_equal {up} [s 0 master_link_status]
 
             $replica replicaof no one
@@ -142,7 +104,6 @@ start_server {tags {"repl"} overrides {save ""}} {
     }
 
     test {Backward compatibility - older replica without capa compression connects successfully} {
-        # A standard replica without replcompression should connect fine
         start_server {overrides {save ""}} {
             set replica [srv 0 client]
             $replica replicaof $primary_host $primary_port
@@ -164,83 +125,15 @@ start_server {overrides {save ""}} {
 
     test {Repl compression config defaults are correct} {
         assert_equal "no" [lindex [r config get replcompression] 1]
-        assert_equal "none" [lindex [r config get repl-compression-algo] 1]
-        assert_equal "-5" [lindex [r config get repl-compression-level] 1]
-    }
-
-    test {Repl compression level requires lz4 algo} {
-        r config set repl-compression-level -5
-        r config set repl-compression-algo none
-
-        catch {r config set repl-compression-level -9} err
-        assert_match "*supported only when repl-compression-algo is lz4*" $err
-        assert_equal "none" [lindex [r config get repl-compression-algo] 1]
-        assert_equal "-5" [lindex [r config get repl-compression-level] 1]
-
-        # With lz4, non-default levels should work
-        r config set repl-compression-algo lz4
-        r config set repl-compression-level -9
-        assert_equal "-9" [lindex [r config get repl-compression-level] 1]
-
-        # Switching back to none should fail if level is non-default
-        catch {r config set repl-compression-algo none} err
-        assert_match "*supported only when repl-compression-algo is lz4*" $err
         assert_equal "lz4" [lindex [r config get repl-compression-algo] 1]
-
-        # Restore defaults
-        r config set repl-compression-level -5
-        r config set repl-compression-algo none
-    }
-
-    test {Invalid repl-compression-algo values are rejected} {
-        catch {r config set repl-compression-algo snappy} err
-        assert_match "*argument(s) must be one of the following: none, lz4*" $err
+        assert_equal "-5" [lindex [r config get repl-compression-level] 1]
     }
 
     test {Invalid repl-compression-level range is rejected} {
-        r config set repl-compression-algo lz4
         catch {r config set repl-compression-level -1001} err
         assert_match "*between* -1000 *22*" $err
         catch {r config set repl-compression-level 23} err
         assert_match "*between* -1000 *22*" $err
-        # Restore
-        r config set repl-compression-level -5
-        r config set repl-compression-algo none
-    }
-
-    test {Startup rejects non-lz4 with non-default repl streaming level} {
-        set confdir [tmpdir "repl-compression-invalid-startup"]
-        exec mkdir -p $confdir
-        set cfgfile [file join $confdir "valkey.conf"]
-        set pidfile [file join $confdir "startup.pid"]
-        set port [find_available_port $::baseport $::portcount]
-
-        set fd [open $cfgfile w]
-        puts $fd "port $port"
-        puts $fd "bind 127.0.0.1"
-        puts $fd "save \"\""
-        puts $fd "dir $confdir"
-        puts $fd "daemonize yes"
-        puts $fd "pidfile $pidfile"
-        puts $fd "logfile /dev/null"
-        puts $fd "repl-compression-algo none"
-        puts $fd "repl-compression-level -9"
-        close $fd
-
-        set rc [catch {exec $::VALKEY_SERVER_BIN $cfgfile} err]
-        assert {$rc == 1}
-        assert_match "*repl-compression-level is supported only when repl-compression-algo is lz4*" $err
-
-        # Defensive cleanup
-        if {[file exists $pidfile]} {
-            set pf [open $pidfile r]
-            set pid [string trim [read $pf]]
-            close $pf
-            if {$pid ne ""} {
-                catch {exec kill $pid}
-                catch {exec kill -9 $pid}
-            }
-        }
     }
 
     test {Repl compression configs survive CONFIG REWRITE and restart} {
@@ -257,7 +150,6 @@ start_server {overrides {save ""}} {
 
         # Restore defaults
         r config set repl-compression-level -5
-        r config set repl-compression-algo none
         r config set replcompression no
     }
 }

--- a/tests/integration/repl-compression.tcl
+++ b/tests/integration/repl-compression.tcl
@@ -1,0 +1,265 @@
+tags {"repl-compression external:skip"} {
+
+start_server {overrides {save ""}} {
+
+    test {replcompression round-trip consistency} {
+        for {set i 0} {$i < 100} {incr i} {
+            set val [expr {int(rand() * 2) ? "yes" : "no"}]
+            r config set replcompression $val
+            set got [lindex [r config get replcompression] 1]
+            assert_equal $val $got
+        }
+        # Restore default
+        r config set replcompression no
+    }
+
+    test {repl-compression-algo round-trip consistency} {
+        set algos {none lz4}
+        for {set i 0} {$i < 100} {incr i} {
+            set val [lindex $algos [expr {int(rand() * 2)}]]
+            r config set repl-compression-algo $val
+            set got [lindex [r config get repl-compression-algo] 1]
+            assert_equal $val $got
+        }
+        # Restore default
+        r config set repl-compression-level -5
+        r config set repl-compression-algo none
+    }
+
+    test {repl-compression-level round-trip consistency} {
+        # Must set algo to lz4 first so arbitrary levels are accepted
+        r config set repl-compression-algo lz4
+        for {set i 0} {$i < 100} {incr i} {
+            set val [expr {int(rand() * 1023) - 1000}]
+            r config set repl-compression-level $val
+            set got [lindex [r config get repl-compression-level] 1]
+            assert_equal $val $got
+        }
+        # Restore defaults
+        r config set repl-compression-level -5
+        r config set repl-compression-algo none
+    }
+
+    test {Invalid enum values for repl-compression-algo are rejected} {
+        set original [lindex [r config get repl-compression-algo] 1]
+        for {set i 0} {$i < 100} {incr i} {
+            set val [randstring 1 20 alpha]
+            # Skip valid values
+            if {$val eq "none" || $val eq "lz4"} continue
+            catch {r config set repl-compression-algo $val} err
+            assert_match "*argument(s) must be one of the following*" $err
+            # Value must be unchanged
+            set got [lindex [r config get repl-compression-algo] 1]
+            assert_equal $original $got
+        }
+    }
+
+    test {Compression level acceptance depends on range and algorithm} {
+        for {set i 0} {$i < 100} {incr i} {
+            # Pick a random algo
+            set algo [expr {int(rand() * 2) ? "lz4" : "none"}]
+            # Pick a random integer in a wider range to test boundaries
+            set val [expr {int(rand() * 2048) - 1024}]
+
+            # Determine expected outcome
+            set in_range [expr {$val >= -1000 && $val <= 22}]
+            set is_default [expr {$val == -5}]
+            set is_lz4 [expr {$algo eq "lz4"}]
+            set should_succeed [expr {$in_range && ($is_lz4 || $is_default)}]
+
+            # Save current state
+            set prev_algo [lindex [r config get repl-compression-algo] 1]
+            set prev_level [lindex [r config get repl-compression-level] 1]
+
+            # Set algo first
+            r config set repl-compression-level -5
+            r config set repl-compression-algo $algo
+
+            set rc [catch {r config set repl-compression-level $val} err]
+
+            if {$should_succeed} {
+                assert_equal 0 $rc "Expected success for algo=$algo val=$val but got error: $err"
+                set got [lindex [r config get repl-compression-level] 1]
+                assert_equal $val $got
+            } else {
+                assert_equal 1 $rc "Expected failure for algo=$algo val=$val"
+            }
+
+            # Restore defaults for next iteration
+            r config set repl-compression-level -5
+            r config set repl-compression-algo none
+        }
+    }
+}
+
+start_server {tags {"repl"} overrides {save ""}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    test {Replica with replcompression yes sends capa compression and primary records the bit} {
+        start_server {overrides {save "" replcompression yes}} {
+            set replica [srv 0 client]
+            $replica replicaof $primary_host $primary_port
+
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Replication not started"
+            }
+
+            # Verify the primary recorded the compression capability.
+            # Check the replica info on the primary side.
+            set info [$primary info replication]
+            assert_match "*slave0:*" $info
+
+            # The replica should have connected successfully with capa compression.
+            # We verify by checking the log for the REPLCONF capa exchange.
+            # Since we can't directly inspect replica_capa bits from Tcl,
+            # we verify the handshake completed successfully.
+            assert_equal {up} [s 0 master_link_status]
+
+            $replica replicaof no one
+        }
+    }
+
+    test {Replica with replcompression no omits capa compression} {
+        start_server {overrides {save "" replcompression no}} {
+            set replica [srv 0 client]
+            $replica replicaof $primary_host $primary_port
+
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Replication not started"
+            }
+
+            # Handshake should succeed without compression capability
+            assert_equal {up} [s 0 master_link_status]
+
+            $replica replicaof no one
+        }
+    }
+
+    test {Backward compatibility - older replica without capa compression connects successfully} {
+        # A standard replica without replcompression should connect fine
+        start_server {overrides {save ""}} {
+            set replica [srv 0 client]
+            $replica replicaof $primary_host $primary_port
+
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Replication not started"
+            }
+
+            assert_equal {up} [s 0 master_link_status]
+
+            $replica replicaof no one
+        }
+    }
+}
+
+start_server {overrides {save ""}} {
+
+    test {Repl compression config defaults are correct} {
+        assert_equal "no" [lindex [r config get replcompression] 1]
+        assert_equal "none" [lindex [r config get repl-compression-algo] 1]
+        assert_equal "-5" [lindex [r config get repl-compression-level] 1]
+    }
+
+    test {Repl compression level requires lz4 algo} {
+        r config set repl-compression-level -5
+        r config set repl-compression-algo none
+
+        catch {r config set repl-compression-level -9} err
+        assert_match "*supported only when repl-compression-algo is lz4*" $err
+        assert_equal "none" [lindex [r config get repl-compression-algo] 1]
+        assert_equal "-5" [lindex [r config get repl-compression-level] 1]
+
+        # With lz4, non-default levels should work
+        r config set repl-compression-algo lz4
+        r config set repl-compression-level -9
+        assert_equal "-9" [lindex [r config get repl-compression-level] 1]
+
+        # Switching back to none should fail if level is non-default
+        catch {r config set repl-compression-algo none} err
+        assert_match "*supported only when repl-compression-algo is lz4*" $err
+        assert_equal "lz4" [lindex [r config get repl-compression-algo] 1]
+
+        # Restore defaults
+        r config set repl-compression-level -5
+        r config set repl-compression-algo none
+    }
+
+    test {Invalid repl-compression-algo values are rejected} {
+        catch {r config set repl-compression-algo snappy} err
+        assert_match "*argument(s) must be one of the following: none, lz4*" $err
+    }
+
+    test {Invalid repl-compression-level range is rejected} {
+        r config set repl-compression-algo lz4
+        catch {r config set repl-compression-level -1001} err
+        assert_match "*between* -1000 *22*" $err
+        catch {r config set repl-compression-level 23} err
+        assert_match "*between* -1000 *22*" $err
+        # Restore
+        r config set repl-compression-level -5
+        r config set repl-compression-algo none
+    }
+
+    test {Startup rejects non-lz4 with non-default repl streaming level} {
+        set confdir [tmpdir "repl-compression-invalid-startup"]
+        exec mkdir -p $confdir
+        set cfgfile [file join $confdir "valkey.conf"]
+        set pidfile [file join $confdir "startup.pid"]
+        set port [find_available_port $::baseport $::portcount]
+
+        set fd [open $cfgfile w]
+        puts $fd "port $port"
+        puts $fd "bind 127.0.0.1"
+        puts $fd "save \"\""
+        puts $fd "dir $confdir"
+        puts $fd "daemonize yes"
+        puts $fd "pidfile $pidfile"
+        puts $fd "logfile /dev/null"
+        puts $fd "repl-compression-algo none"
+        puts $fd "repl-compression-level -9"
+        close $fd
+
+        set rc [catch {exec $::VALKEY_SERVER_BIN $cfgfile} err]
+        assert {$rc == 1}
+        assert_match "*repl-compression-level is supported only when repl-compression-algo is lz4*" $err
+
+        # Defensive cleanup
+        if {[file exists $pidfile]} {
+            set pf [open $pidfile r]
+            set pid [string trim [read $pf]]
+            close $pf
+            if {$pid ne ""} {
+                catch {exec kill $pid}
+                catch {exec kill -9 $pid}
+            }
+        }
+    }
+
+    test {Repl compression configs survive CONFIG REWRITE and restart} {
+        r config set replcompression yes
+        r config set repl-compression-algo lz4
+        r config set repl-compression-level -9
+        r config rewrite
+
+        restart_server 0 true false
+
+        assert_equal "yes" [lindex [r config get replcompression] 1]
+        assert_equal "lz4" [lindex [r config get repl-compression-algo] 1]
+        assert_equal "-9" [lindex [r config get repl-compression-level] 1]
+
+        # Restore defaults
+        r config set repl-compression-level -5
+        r config set repl-compression-algo none
+        r config set replcompression no
+    }
+}
+
+}

--- a/tests/integration/repl-compression.tcl
+++ b/tests/integration/repl-compression.tcl
@@ -131,9 +131,9 @@ start_server {overrides {save ""}} {
 
     test {Invalid repl-compression-level range is rejected} {
         catch {r config set repl-compression-level -1001} err
-        assert_match "*between* -1000 *22*" $err
+        assert_match "*out of range*" $err
         catch {r config set repl-compression-level 23} err
-        assert_match "*between* -1000 *22*" $err
+        assert_match "*out of range*" $err
     }
 
     test {Repl compression configs survive CONFIG REWRITE and restart} {


### PR DESCRIPTION
Add three new server configuration options for replication compression:
* `replcompression` (bool, default no)
* `repl-compression-algo` (enum, default lz4) — only lz4 is supported currently
* `repl-compression-level` (int, default -5, range -1000..22)

Extend the `REPLCONF capa` handshake so replicas advertise compression support when `replcompression` is enabled. The primary records `REPLICA_CAPA_COMPRESSION (1 << 4)` in the replica's capability bitmask.

No compressed payloads are transmitted yet — this is the config and capability negotiation foundation for future replication compression.

Per-algorithm level validation ensures the compression level is within the selected algorithm's valid range. The validator is structured as a switch on the algo, making it easy to add new algorithms (e.g., zstd) with different ranges in the future.