### PR TITLE
Add thread-safety note to adlist.h documentation

### DIFF
--- a/src/adlist.h
+++ b/src/adlist.h
@@ -1,6 +1,7 @@
 /* adlist.h - A generic doubly linked list implementation
  *
  * This module provides O(1) push/pop operations on both ends of the list.
+ * Iteration is O(n). Thread-safety is not guaranteed.
  *
  * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.


### PR DESCRIPTION
Adds a note about iteration complexity and thread-safety to the adlist.h header comment. Test PR for backport bot e2e validation.