### PR TITLE
Refactor backport caller to workflow_dispatch

### DIFF
--- a/.github/workflows/backport-bot.yml
+++ b/.github/workflows/backport-bot.yml
@@ -1,10 +1,8 @@
 name: Backport Bot
 
 permissions:
-  contents: write
-  pull-requests: write
-  actions: read
-  id-token: write
+  contents: read
+  pull-requests: read
 
 on:
   pull_request_target:
@@ -13,9 +11,6 @@ on:
 jobs:
   preflight:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
       branches: ${{ steps.extract.outputs.branches }}
       should_run: ${{ steps.extract.outputs.should_run }}
@@ -47,19 +42,29 @@ jobs:
             core.setOutput("should_run", "true");
             core.setOutput("branches", JSON.stringify(branches));
 
-  backport:
+  dispatch:
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         target_branch: ${{ fromJson(needs.preflight.outputs.branches) }}
-    uses: sarthakaggarwal97/valkey-ci-bot/.github/workflows/backport.yml@main
-    with:
-      source_pr_number: ${{ github.event.pull_request.number }}
-      repo_full_name: ${{ github.repository }}
-      target_branch: ${{ matrix.target_branch }}
-      config_path: .github/backport-bot.yml
-      aws_region: ${{ vars.AWS_REGION || 'us-east-1' }}
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+    steps:
+      - name: Dispatch backport to bot repository
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'sarthakaggarwal97',
+              repo: 'valkey-ci-bot',
+              workflow_id: 'backport.yml',
+              ref: 'main',
+              inputs: {
+                source_pr_number: String(context.payload.pull_request.number),
+                repo_full_name: context.repo.owner + '/' + context.repo.repo,
+                target_branch: '${{ matrix.target_branch }}',
+              }
+            });
+            core.info(`Dispatched backport for PR #${context.payload.pull_request.number} to ${{ matrix.target_branch }}`);


### PR DESCRIPTION
Consumer repos no longer need AWS secrets. The bot repo uses its own credentials.