### PR TITLE
Use workflow_call with secrets:inherit for backport

### DIFF
--- a/.github/workflows/backport-bot.yml
+++ b/.github/workflows/backport-bot.yml
@@ -1,8 +1,22 @@
+# Example caller workflow for consumer repositories.
+#
+# Copy this file to your repository as:
+#   .github/workflows/backport-bot.yml
+#
+# This workflow triggers the Backport Bot when a merged PR is labeled with
+# a `backport <branch>` label (e.g. `backport 8.1`). It checks that the PR
+# is merged, extracts target branches from all matching labels, and triggers
+# one backport run per target branch.
+#
+# No secrets or variables are needed in the consumer repo — the bot repo
+# owns all credentials.
 name: Backport Bot
 
 permissions:
-  contents: read
-  pull-requests: read
+  contents: write
+  pull-requests: write
+  actions: read
+  id-token: write
 
 on:
   pull_request_target:
@@ -11,6 +25,9 @@ on:
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       branches: ${{ steps.extract.outputs.branches }}
       should_run: ${{ steps.extract.outputs.should_run }}
@@ -20,51 +37,45 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+
+            // Only proceed if the PR is merged.
             if (!pr.merged) {
-              core.info("PR is not merged. Skipping backport.");
+              core.info("PR is not merged. Skipping backport (pr-not-merged).");
               core.setOutput("should_run", "false");
               core.setOutput("branches", "[]");
               return;
             }
+
+            // Extract target branches from labels matching "backport <branch>".
             const backportPrefix = "backport ";
             const branches = pr.labels
               .map(l => l.name)
               .filter(name => name.startsWith(backportPrefix))
               .map(name => name.slice(backportPrefix.length).trim())
               .filter(branch => branch.length > 0);
+
             if (branches.length === 0) {
               core.info("No backport labels found.");
               core.setOutput("should_run", "false");
               core.setOutput("branches", "[]");
               return;
             }
-            core.info("Found backport targets: " + branches.join(", "));
+
+            core.info(`Found backport targets: ${branches.join(", ")}`);
             core.setOutput("should_run", "true");
             core.setOutput("branches", JSON.stringify(branches));
 
-  dispatch:
+  backport:
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         target_branch: ${{ fromJson(needs.preflight.outputs.branches) }}
-    steps:
-      - name: Dispatch backport to bot repository
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'sarthakaggarwal97',
-              repo: 'valkey-ci-bot',
-              workflow_id: 'backport.yml',
-              ref: 'main',
-              inputs: {
-                source_pr_number: String(context.payload.pull_request.number),
-                repo_full_name: context.repo.owner + '/' + context.repo.repo,
-                target_branch: '${{ matrix.target_branch }}',
-              }
-            });
-            core.info(`Dispatched backport for PR #${context.payload.pull_request.number} to ${{ matrix.target_branch }}`);
+    uses: sarthakaggarwal97/valkey-ci-bot/.github/workflows/backport.yml@main
+    with:
+      source_pr_number: ${{ github.event.pull_request.number }}
+      repo_full_name: ${{ github.repository }}
+      target_branch: ${{ matrix.target_branch }}
+      config_path: .github/backport-bot.yml
+    secrets: inherit


### PR DESCRIPTION
Reverts to workflow_call approach with secrets:inherit so the bot repo secrets are passed through.