### PR TITLE
Add description to lzf.h header

### DIFF
--- a/src/lzf.h
+++ b/src/lzf.h
@@ -1,4 +1,4 @@
-/*
+/* lzf.h - LZF compression algorithm header.
  * Copyright (c) 2000-2008 Marc Alexander Lehmann <schmorp@schmorp.de>
  *
  * Redistribution and use in source and binary forms, with or without modifica-


### PR DESCRIPTION
Adds a brief description to the lzf.h header comment. Test for full e2e backport flow.