### PR TITLE
Add Redis compat version comment to version.h

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -18,3 +18,4 @@
  * exceed 7.2.x. */
 #define REDIS_VERSION "7.2.4"
 #define REDIS_VERSION_NUM 0x00070204
+/* Redis compat version frozen at 7.2.4 — do not bump */


### PR DESCRIPTION
Adds comment near REDIS_VERSION_NUM — will conflict on 8.0 due to different version.h structure.