### PR TITLE
Add development build comment to VALKEY_VERSION

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
  * similar. */
 #define SERVER_NAME "valkey"
 #define SERVER_TITLE "Valkey"
-#define VALKEY_VERSION "255.255.255"
+#define VALKEY_VERSION "255.255.255" /* development build */
 /* Backport conflict test: this comment will cause a merge conflict */
 #define VALKEY_VERSION_NUM 0x00ffffff
 /* Build metadata: conflict resolution test v2 */


### PR DESCRIPTION
Modifies the VALKEY_VERSION line — guaranteed conflict on 8.0 backport.