### PR TITLE
Add release stage comment to version.h

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -12,7 +12,7 @@
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.
  * When the version is released the status will be "ga". */
-#define VALKEY_RELEASE_STAGE "dev"
+#define VALKEY_RELEASE_STAGE "dev" /* auto-set during release */
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
Modifies VALKEY_RELEASE_STAGE line which doesnt exist on 8.0 — will conflict.