### PR TITLE
Style and correctness fixes for streaming compression PR

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -717,9 +717,6 @@ $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
 	rm -f $@
 	$(SERVER_AR) rcs $@ $^
 
-# valkey-unit-tests
-$(ENGINE_UNIT_TESTS): $(ENGINE_TEST_OBJ) $(ENGINE_LIB_NAME)
-	$(SERVER_LD) -o $@ $^ ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a ../deps/lz4/liblz4.a $(FINAL_LIBS)
 # valkey-sentinel
 $(ENGINE_SENTINEL_NAME): $(SERVER_NAME)
 	$(ENGINE_INSTALL) $(SERVER_NAME) $(ENGINE_SENTINEL_NAME)

--- a/src/compression.c
+++ b/src/compression.c
@@ -17,22 +17,22 @@ typedef struct {
     void (*compressor_destroy)(streamCompressor *sc);
     int (*decompressor_init)(streamDecompressor *sd);
     void (*decompressor_destroy)(streamDecompressor *sd);
-    size_t (*compress_output_bound)(size_t input_len);
+    size_t (*compress_output_bound)(size_t inputLen);
     ssize_t (*compress_feed)(streamCompressor *sc,
                              uint8_t *output,
-                             size_t output_capacity,
+                             size_t outputCapacity,
                              const uint8_t *input,
-                             size_t input_len,
-                             compressFlushMode flush_mode);
+                             size_t inputLen,
+                             compressFlushMode flushMode);
     ssize_t (*decompress_feed)(streamDecompressor *sd,
                                uint8_t *output,
-                               size_t output_capacity,
+                               size_t outputCapacity,
                                const uint8_t *input,
-                               size_t input_len,
-                               size_t *input_consumed);
+                               size_t inputLen,
+                               size_t *inputConsumed);
 } compressionCodecImpl;
 
-static const compressionCodecImpl compression_lz4_codec_impl = {
+static const compressionCodecImpl compressionLz4CodecImpl = {
     .supports_level = true,
     .compressor_init = compressionLz4CompressorInit,
     .compressor_destroy = compressionLz4CompressorDestroy,
@@ -43,32 +43,32 @@ static const compressionCodecImpl compression_lz4_codec_impl = {
     .decompress_feed = compressionLz4DecompressFeed,
 };
 
-static const char *const compression_algo_name_by_algo[] = {
+static const char *const compressionAlgoNameByAlgo[] = {
     [ALGO_NONE] = "none",
     [ALGO_LZF] = "lzf",
     [ALGO_LZ4] = "lz4",
 };
 
-static const compressionCodecImpl *const compression_codec_impl_by_algo[] = {
-    [ALGO_LZ4] = &compression_lz4_codec_impl,
+static const compressionCodecImpl *const compressionCodecImplByAlgo[] = {
+    [ALGO_LZ4] = &compressionLz4CodecImpl,
 };
 
 static const char *compressionAlgoNameForAlgo(compressionAlgo algo) {
-    unsigned int algo_index = (unsigned int)algo;
+    unsigned int algoIndex = (unsigned int)algo;
 
-    if (algo_index >= sizeof(compression_algo_name_by_algo) / sizeof(compression_algo_name_by_algo[0])) {
+    if (algoIndex >= sizeof(compressionAlgoNameByAlgo) / sizeof(compressionAlgoNameByAlgo[0])) {
         return NULL;
     }
-    return compression_algo_name_by_algo[algo_index];
+    return compressionAlgoNameByAlgo[algoIndex];
 }
 
 static const compressionCodecImpl *compressionCodecImplForAlgo(compressionAlgo algo) {
-    unsigned int algo_index = (unsigned int)algo;
+    unsigned int algoIndex = (unsigned int)algo;
 
-    if (algo_index >= sizeof(compression_codec_impl_by_algo) / sizeof(compression_codec_impl_by_algo[0])) {
+    if (algoIndex >= sizeof(compressionCodecImplByAlgo) / sizeof(compressionCodecImplByAlgo[0])) {
         return NULL;
     }
-    return compression_codec_impl_by_algo[algo_index];
+    return compressionCodecImplByAlgo[algoIndex];
 }
 
 bool compressionAlgoSupportsStreaming(compressionAlgo algo) {
@@ -76,27 +76,27 @@ bool compressionAlgoSupportsStreaming(compressionAlgo algo) {
 }
 
 bool compressionAlgoSupportsLevel(compressionAlgo algo) {
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
-    return codec_impl && codec_impl->supports_level;
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(algo);
+    return codecImpl && codecImpl->supports_level;
 }
 
 const char *compressionAlgoName(compressionAlgo algo) {
-    const char *algo_name = compressionAlgoNameForAlgo(algo);
+    const char *algoName = compressionAlgoNameForAlgo(algo);
 
-    return algo_name ? algo_name : "unknown";
+    return algoName ? algoName : "unknown";
 }
 
 int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) {
     if (!sc) return -1;
     memset(sc, 0, sizeof(*sc));
 
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
-    if (!codec_impl || !codec_impl->compressor_init) return -1;
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(algo);
+    if (!codecImpl || !codecImpl->compressor_init) return -1;
 
     sc->algo = algo;
     sc->level = level;
 
-    if (codec_impl->compressor_init(sc) != 0) {
+    if (codecImpl->compressor_init(sc) != 0) {
         streamCompressorDestroy(sc);
         return -1;
     }
@@ -106,9 +106,9 @@ int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) 
 void streamCompressorDestroy(streamCompressor *sc) {
     if (!sc) return;
 
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
-    if (codec_impl && codec_impl->compressor_destroy) {
-        codec_impl->compressor_destroy(sc);
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(sc->algo);
+    if (codecImpl && codecImpl->compressor_destroy) {
+        codecImpl->compressor_destroy(sc);
     }
     memset(sc, 0, sizeof(*sc));
 }
@@ -117,12 +117,12 @@ int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
     if (!sd) return -1;
     memset(sd, 0, sizeof(*sd));
 
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
-    if (!codec_impl || !codec_impl->decompressor_init) return -1;
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(algo);
+    if (!codecImpl || !codecImpl->decompressor_init) return -1;
 
     sd->algo = algo;
 
-    if (codec_impl->decompressor_init(sd) != 0) {
+    if (codecImpl->decompressor_init(sd) != 0) {
         streamDecompressorDestroy(sd);
         return -1;
     }
@@ -132,59 +132,59 @@ int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
 void streamDecompressorDestroy(streamDecompressor *sd) {
     if (!sd) return;
 
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sd->algo);
-    if (codec_impl && codec_impl->decompressor_destroy) {
-        codec_impl->decompressor_destroy(sd);
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(sd->algo);
+    if (codecImpl && codecImpl->decompressor_destroy) {
+        codecImpl->decompressor_destroy(sd);
     }
     memset(sd, 0, sizeof(*sd));
 }
 
-size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len) {
+size_t streamCompressOutputBound(const streamCompressor *sc, size_t inputLen) {
     if (!sc) return 0;
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
-    if (!codec_impl || !codec_impl->compress_output_bound) return 0;
-    return codec_impl->compress_output_bound(input_len);
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(sc->algo);
+    if (!codecImpl || !codecImpl->compress_output_bound) return 0;
+    return codecImpl->compress_output_bound(inputLen);
 }
 
 ssize_t streamCompressFeed(streamCompressor *sc,
                            uint8_t *output,
-                           size_t output_capacity,
+                           size_t outputCapacity,
                            const uint8_t *input,
-                           size_t input_len,
-                           compressFlushMode flush_mode) {
+                           size_t inputLen,
+                           compressFlushMode flushMode) {
     if (!sc || !output) return -1;
     if (sc->errored) return -1;
 
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
-    if (!codec_impl || !codec_impl->compress_feed) return -1;
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(sc->algo);
+    if (!codecImpl || !codecImpl->compress_feed) return -1;
 
-    return codec_impl->compress_feed(sc, output, output_capacity,
-                                     input, input_len, flush_mode);
+    return codecImpl->compress_feed(sc, output, outputCapacity,
+                                     input, inputLen, flushMode);
 }
 
 ssize_t streamDecompressFeed(streamDecompressor *sd,
                              uint8_t *output,
-                             size_t output_capacity,
+                             size_t outputCapacity,
                              const uint8_t *input,
-                             size_t input_len,
-                             size_t *input_consumed) {
-    if (!sd || !input_consumed) return -1;
+                             size_t inputLen,
+                             size_t *inputConsumed) {
+    if (!sd || !inputConsumed) return -1;
     if (sd->errored) return -1;
-    *input_consumed = 0;
+    *inputConsumed = 0;
     if (sd->frame_done) return 0;
     /* Zero output capacity is a caller bug — returning 0 with no progress
      * would cause streaming loops to spin forever. */
-    if (!output || output_capacity == 0) {
+    if (!output || outputCapacity == 0) {
         sd->errored = true;
         return -1;
     }
 
-    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sd->algo);
-    if (!codec_impl || !codec_impl->decompress_feed) {
+    const compressionCodecImpl *codecImpl = compressionCodecImplForAlgo(sd->algo);
+    if (!codecImpl || !codecImpl->decompress_feed) {
         sd->errored = true;
         return -1;
     }
 
-    return codec_impl->decompress_feed(sd, output, output_capacity,
-                                       input, input_len, input_consumed);
+    return codecImpl->decompress_feed(sd, output, outputCapacity,
+                                       input, inputLen, inputConsumed);
 }

--- a/src/compression.c
+++ b/src/compression.c
@@ -13,26 +13,26 @@
 
 typedef struct {
     bool supports_level;
-    int (*compressor_init)(stream_compressor_t *sc);
-    void (*compressor_destroy)(stream_compressor_t *sc);
-    int (*decompressor_init)(stream_decompressor_t *sd);
-    void (*decompressor_destroy)(stream_decompressor_t *sd);
+    int (*compressor_init)(streamCompressor *sc);
+    void (*compressor_destroy)(streamCompressor *sc);
+    int (*decompressor_init)(streamDecompressor *sd);
+    void (*decompressor_destroy)(streamDecompressor *sd);
     size_t (*compress_output_bound)(size_t input_len);
-    ssize_t (*compress_feed)(stream_compressor_t *sc,
+    ssize_t (*compress_feed)(streamCompressor *sc,
                              uint8_t *output,
                              size_t output_capacity,
                              const uint8_t *input,
                              size_t input_len,
-                             compress_flush_mode_t flush_mode);
-    ssize_t (*decompress_feed)(stream_decompressor_t *sd,
+                             compressFlushMode flush_mode);
+    ssize_t (*decompress_feed)(streamDecompressor *sd,
                                uint8_t *output,
                                size_t output_capacity,
                                const uint8_t *input,
                                size_t input_len,
                                size_t *input_consumed);
-} compression_codec_impl_t;
+} compressionCodecImpl;
 
-static const compression_codec_impl_t compression_lz4_codec_impl = {
+static const compressionCodecImpl compression_lz4_codec_impl = {
     .supports_level = true,
     .compressor_init = compressionLz4CompressorInit,
     .compressor_destroy = compressionLz4CompressorDestroy,
@@ -49,11 +49,11 @@ static const char *const compression_algo_name_by_algo[] = {
     [ALGO_LZ4] = "lz4",
 };
 
-static const compression_codec_impl_t *const compression_codec_impl_by_algo[] = {
+static const compressionCodecImpl *const compression_codec_impl_by_algo[] = {
     [ALGO_LZ4] = &compression_lz4_codec_impl,
 };
 
-static const char *compressionAlgoNameForAlgo(compression_algo_t algo) {
+static const char *compressionAlgoNameForAlgo(compressionAlgo algo) {
     unsigned int algo_index = (unsigned int)algo;
 
     if (algo_index >= sizeof(compression_algo_name_by_algo) / sizeof(compression_algo_name_by_algo[0])) {
@@ -62,7 +62,7 @@ static const char *compressionAlgoNameForAlgo(compression_algo_t algo) {
     return compression_algo_name_by_algo[algo_index];
 }
 
-static const compression_codec_impl_t *compressionCodecImplForAlgo(compression_algo_t algo) {
+static const compressionCodecImpl *compressionCodecImplForAlgo(compressionAlgo algo) {
     unsigned int algo_index = (unsigned int)algo;
 
     if (algo_index >= sizeof(compression_codec_impl_by_algo) / sizeof(compression_codec_impl_by_algo[0])) {
@@ -71,26 +71,26 @@ static const compression_codec_impl_t *compressionCodecImplForAlgo(compression_a
     return compression_codec_impl_by_algo[algo_index];
 }
 
-bool compressionAlgoSupportsStreaming(compression_algo_t algo) {
+bool compressionAlgoSupportsStreaming(compressionAlgo algo) {
     return compressionCodecImplForAlgo(algo) != NULL;
 }
 
-bool compressionAlgoSupportsLevel(compression_algo_t algo) {
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+bool compressionAlgoSupportsLevel(compressionAlgo algo) {
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
     return codec_impl && codec_impl->supports_level;
 }
 
-const char *compressionAlgoName(compression_algo_t algo) {
+const char *compressionAlgoName(compressionAlgo algo) {
     const char *algo_name = compressionAlgoNameForAlgo(algo);
 
     return algo_name ? algo_name : "unknown";
 }
 
-int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int level) {
+int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) {
     if (!sc) return -1;
     memset(sc, 0, sizeof(*sc));
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
     if (!codec_impl || !codec_impl->compressor_init) return -1;
 
     sc->algo = algo;
@@ -103,21 +103,21 @@ int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int l
     return 0;
 }
 
-void streamCompressorDestroy(stream_compressor_t *sc) {
+void streamCompressorDestroy(streamCompressor *sc) {
     if (!sc) return;
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
     if (codec_impl && codec_impl->compressor_destroy) {
         codec_impl->compressor_destroy(sc);
     }
     memset(sc, 0, sizeof(*sc));
 }
 
-int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo) {
+int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
     if (!sd) return -1;
     memset(sd, 0, sizeof(*sd));
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
     if (!codec_impl || !codec_impl->decompressor_init) return -1;
 
     sd->algo = algo;
@@ -129,40 +129,40 @@ int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo) {
     return 0;
 }
 
-void streamDecompressorDestroy(stream_decompressor_t *sd) {
+void streamDecompressorDestroy(streamDecompressor *sd) {
     if (!sd) return;
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sd->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sd->algo);
     if (codec_impl && codec_impl->decompressor_destroy) {
         codec_impl->decompressor_destroy(sd);
     }
     memset(sd, 0, sizeof(*sd));
 }
 
-size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len) {
+size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len) {
     if (!sc) return 0;
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
     if (!codec_impl || !codec_impl->compress_output_bound) return 0;
     return codec_impl->compress_output_bound(input_len);
 }
 
-ssize_t streamCompressFeed(stream_compressor_t *sc,
+ssize_t streamCompressFeed(streamCompressor *sc,
                            uint8_t *output,
                            size_t output_capacity,
                            const uint8_t *input,
                            size_t input_len,
-                           compress_flush_mode_t flush_mode) {
+                           compressFlushMode flush_mode) {
     if (!sc || !output) return -1;
     if (sc->errored) return -1;
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
     if (!codec_impl || !codec_impl->compress_feed) return -1;
 
     return codec_impl->compress_feed(sc, output, output_capacity,
                                      input, input_len, flush_mode);
 }
 
-ssize_t streamDecompressFeed(stream_decompressor_t *sd,
+ssize_t streamDecompressFeed(streamDecompressor *sd,
                              uint8_t *output,
                              size_t output_capacity,
                              const uint8_t *input,
@@ -179,7 +179,7 @@ ssize_t streamDecompressFeed(stream_decompressor_t *sd,
         return -1;
     }
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sd->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sd->algo);
     if (!codec_impl || !codec_impl->decompress_feed) {
         sd->errored = true;
         return -1;

--- a/src/compression.c
+++ b/src/compression.c
@@ -159,7 +159,7 @@ ssize_t streamCompressFeed(streamCompressor *sc,
     if (!codecImpl || !codecImpl->compress_feed) return -1;
 
     return codecImpl->compress_feed(sc, output, outputCapacity,
-                                     input, inputLen, flushMode);
+                                    input, inputLen, flushMode);
 }
 
 ssize_t streamDecompressFeed(streamDecompressor *sd,
@@ -186,5 +186,5 @@ ssize_t streamDecompressFeed(streamDecompressor *sd,
     }
 
     return codecImpl->decompress_feed(sd, output, outputCapacity,
-                                       input, inputLen, inputConsumed);
+                                      input, inputLen, inputConsumed);
 }

--- a/src/compression.h
+++ b/src/compression.h
@@ -17,18 +17,18 @@ typedef enum {
     ALGO_NONE = 0x00, /* Disabled */
     ALGO_LZF = 0x01,  /* Per-string LZF (RDB only, existing behavior) */
     ALGO_LZ4 = 0x02,
-} compression_algo_t;
+} compressionAlgo;
 
 /* --- Flush modes for streaming compression --- */
 typedef enum {
     FLUSH_CONTINUE = 0, /* Buffer internally */
     FLUSH_SYNC = 1,     /* Emit all buffered data, keep frame open */
     FLUSH_END = 2,      /* Finalize frame */
-} compress_flush_mode_t;
+} compressFlushMode;
 
 /* --- Streaming compressor context --- */
 typedef struct {
-    compression_algo_t algo;
+    compressionAlgo algo;
     int level;
     void *ctx; /* Private codec-specific compressor context. */
     bool frame_started;
@@ -40,11 +40,11 @@ typedef struct {
                           * cannot be unsent. */
     bool codec_checksum; /* Codec-native integrity toggle.
                           * For LZ4 streams this maps to per-block checksums. */
-} stream_compressor_t;
+} streamCompressor;
 
 /* --- Streaming decompressor context --- */
 typedef struct {
-    compression_algo_t algo;
+    compressionAlgo algo;
     void *ctx;       /* Private codec-specific decompressor context. */
     bool errored;    /* Permanently failed — algorithm state is undefined after
                       * an error. All subsequent streamDecompressFeed calls
@@ -52,47 +52,47 @@ typedef struct {
     bool frame_done; /* Set when the codec frame is fully decoded.
                       * Subsequent streamDecompressFeed calls return 0
                       * immediately (no more output). */
-} stream_decompressor_t;
+} streamDecompressor;
 
 /* Returns true if the algorithm supports streaming codec framing. */
-bool compressionAlgoSupportsStreaming(compression_algo_t algo);
+bool compressionAlgoSupportsStreaming(compressionAlgo algo);
 
 /* Returns true if the algorithm exposes a tunable compression level. */
-bool compressionAlgoSupportsLevel(compression_algo_t algo);
+bool compressionAlgoSupportsLevel(compressionAlgo algo);
 
 /* Returns a stable name for logging/debugging. */
-const char *compressionAlgoName(compression_algo_t algo);
+const char *compressionAlgoName(compressionAlgo algo);
 
 /* --- Streaming compression API --- */
 
 /* Initialize/destroy streaming compressor. */
-int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int level);
-void streamCompressorDestroy(stream_compressor_t *sc);
+int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level);
+void streamCompressorDestroy(streamCompressor *sc);
 
 /* Initialize/destroy streaming decompressor. */
-int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo);
-void streamDecompressorDestroy(stream_decompressor_t *sd);
+int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo);
+void streamDecompressorDestroy(streamDecompressor *sd);
 
 /* Return upper bound on compressed output size.
  * The bound is conservative: it includes frame header, data, and flush/end
  * overhead so the caller can allocate once and reuse for any flush mode. */
-size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len);
+size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len);
 
 /* Feed data through streaming compressor.
  * flush_mode: FLUSH_CONTINUE, FLUSH_SYNC, or FLUSH_END.
  * Returns bytes written to output, 0 for no output, -1 on error. */
-ssize_t streamCompressFeed(stream_compressor_t *sc,
+ssize_t streamCompressFeed(streamCompressor *sc,
                            uint8_t *output,
                            size_t output_capacity,
                            const uint8_t *input,
                            size_t input_len,
-                           compress_flush_mode_t flush_mode);
+                           compressFlushMode flush_mode);
 
 /* Feed compressed data through streaming decompressor.
  * Returns bytes written to output, 0 for no output, -1 on error.
  * *input_consumed is set to the number of compressed bytes consumed.
- * Fatal errors latch stream_decompressor_t.errored until reinit. */
-ssize_t streamDecompressFeed(stream_decompressor_t *sd,
+ * Fatal errors latch streamDecompressor.errored until reinit. */
+ssize_t streamDecompressFeed(streamDecompressor *sd,
                              uint8_t *output,
                              size_t output_capacity,
                              const uint8_t *input,

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -26,7 +26,7 @@ static const LZ4F_preferences_t lz4f_prefs = {
                             * compression uses sc->level via a local copy */
 };
 
-int compressionLz4CompressorInit(stream_compressor_t *sc) {
+int compressionLz4CompressorInit(streamCompressor *sc) {
     LZ4F_cctx *cctx = NULL;
     LZ4F_errorCode_t err;
 
@@ -39,14 +39,14 @@ int compressionLz4CompressorInit(stream_compressor_t *sc) {
     return 0;
 }
 
-void compressionLz4CompressorDestroy(stream_compressor_t *sc) {
+void compressionLz4CompressorDestroy(streamCompressor *sc) {
     if (!sc || !sc->ctx) return;
 
     LZ4F_freeCompressionContext((LZ4F_cctx *)sc->ctx);
     sc->ctx = NULL;
 }
 
-int compressionLz4DecompressorInit(stream_decompressor_t *sd) {
+int compressionLz4DecompressorInit(streamDecompressor *sd) {
     LZ4F_dctx *dctx = NULL;
     LZ4F_errorCode_t err;
 
@@ -59,7 +59,7 @@ int compressionLz4DecompressorInit(stream_decompressor_t *sd) {
     return 0;
 }
 
-void compressionLz4DecompressorDestroy(stream_decompressor_t *sd) {
+void compressionLz4DecompressorDestroy(streamDecompressor *sd) {
     if (!sd || !sd->ctx) return;
 
     LZ4F_freeDecompressionContext((LZ4F_dctx *)sd->ctx);
@@ -73,12 +73,12 @@ size_t compressionLz4OutputBound(size_t input_len) {
     return LZ4F_compressBound(input_len, &lz4f_prefs) + LZ4F_HEADER_SIZE_MAX + LZ4F_compressBound(0, &lz4f_prefs);
 }
 
-ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
+ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                    uint8_t *output,
                                    size_t output_capacity,
                                    const uint8_t *input,
                                    size_t input_len,
-                                   compress_flush_mode_t flush_mode) {
+                                   compressFlushMode flush_mode) {
     LZ4F_cctx *cctx;
     size_t offset = 0;
 
@@ -149,7 +149,7 @@ lz4_error:
     return -1;
 }
 
-ssize_t compressionLz4DecompressFeed(stream_decompressor_t *sd,
+ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
                                      uint8_t *output,
                                      size_t output_capacity,
                                      const uint8_t *input,

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -15,7 +15,7 @@
  *
  * Bounds are computed with block-independent mode and block checksums enabled
  * so the returned capacity is safe for both checksum settings. */
-static const LZ4F_preferences_t lz4f_prefs = {
+static const LZ4F_preferences_t lz4fPrefs = {
     .frameInfo = {
         .blockChecksumFlag = LZ4F_blockChecksumEnabled,
         .contentChecksumFlag = LZ4F_noContentChecksum,
@@ -66,19 +66,19 @@ void compressionLz4DecompressorDestroy(streamDecompressor *sd) {
     sd->ctx = NULL;
 }
 
-size_t compressionLz4OutputBound(size_t input_len) {
+size_t compressionLz4OutputBound(size_t inputLen) {
     /* Conservative worst-case: data bound + frame header + flush/end overhead.
      * Always includes all components so the caller can allocate once and reuse
      * for any flush mode and frame state. */
-    return LZ4F_compressBound(input_len, &lz4f_prefs) + LZ4F_HEADER_SIZE_MAX + LZ4F_compressBound(0, &lz4f_prefs);
+    return LZ4F_compressBound(inputLen, &lz4fPrefs) + LZ4F_HEADER_SIZE_MAX + LZ4F_compressBound(0, &lz4fPrefs);
 }
 
 ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                    uint8_t *output,
-                                   size_t output_capacity,
+                                   size_t outputCapacity,
                                    const uint8_t *input,
-                                   size_t input_len,
-                                   compressFlushMode flush_mode) {
+                                   size_t inputLen,
+                                   compressFlushMode flushMode) {
     LZ4F_cctx *cctx;
     size_t offset = 0;
 
@@ -90,14 +90,14 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
     if (!sc->frame_started) {
         /* Local copy of shared prefs so we can set the actual level
          * and checksum mode per-stream. */
-        LZ4F_preferences_t prefs = lz4f_prefs;
+        LZ4F_preferences_t prefs = lz4fPrefs;
         size_t r;
 
         prefs.compressionLevel = sc->level;
         prefs.frameInfo.blockChecksumFlag = sc->codec_checksum
                                                 ? LZ4F_blockChecksumEnabled
                                                 : LZ4F_noBlockChecksum;
-        r = LZ4F_compressBegin(cctx, output, output_capacity, &prefs);
+        r = LZ4F_compressBegin(cctx, output, outputCapacity, &prefs);
         if (LZ4F_isError(r)) {
             /* compressBegin failure before any frame bytes are emitted is
              * recoverable — the LZ4F context is still clean. Caller can
@@ -109,29 +109,29 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
     }
 
     /* Compress input data */
-    if (input_len > 0) {
+    if (inputLen > 0) {
         size_t r;
 
-        if (offset >= output_capacity) goto lz4_error;
-        r = LZ4F_compressUpdate(cctx, output + offset, output_capacity - offset,
-                                input, input_len, NULL);
+        if (offset >= outputCapacity) goto lz4_error;
+        r = LZ4F_compressUpdate(cctx, output + offset, outputCapacity - offset,
+                                input, inputLen, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
         offset += r;
     }
 
     /* Handle flush/end modes */
-    if (flush_mode == FLUSH_SYNC) {
+    if (flushMode == FLUSH_SYNC) {
         size_t r;
 
-        if (offset >= output_capacity) goto lz4_error;
-        r = LZ4F_flush(cctx, output + offset, output_capacity - offset, NULL);
+        if (offset >= outputCapacity) goto lz4_error;
+        r = LZ4F_flush(cctx, output + offset, outputCapacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
         offset += r;
-    } else if (flush_mode == FLUSH_END) {
+    } else if (flushMode == FLUSH_END) {
         size_t r;
 
-        if (offset >= output_capacity) goto lz4_error;
-        r = LZ4F_compressEnd(cctx, output + offset, output_capacity - offset, NULL);
+        if (offset >= outputCapacity) goto lz4_error;
+        r = LZ4F_compressEnd(cctx, output + offset, outputCapacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
         offset += r;
         sc->frame_started = false;
@@ -151,30 +151,30 @@ lz4_error:
 
 ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
                                      uint8_t *output,
-                                     size_t output_capacity,
+                                     size_t outputCapacity,
                                      const uint8_t *input,
-                                     size_t input_len,
-                                     size_t *input_consumed) {
+                                     size_t inputLen,
+                                     size_t *inputConsumed) {
     LZ4F_dctx *dctx;
-    size_t dst_size;
-    size_t src_size;
+    size_t dstSize;
+    size_t srcSize;
     size_t ret;
 
-    if (!sd || !sd->ctx || !input_consumed) return -1;
+    if (!sd || !sd->ctx || !inputConsumed) return -1;
 
     dctx = (LZ4F_dctx *)sd->ctx;
-    dst_size = output_capacity;
-    src_size = input_len;
-    ret = LZ4F_decompress(dctx, output, &dst_size, input, &src_size, NULL);
+    dstSize = outputCapacity;
+    srcSize = inputLen;
+    ret = LZ4F_decompress(dctx, output, &dstSize, input, &srcSize, NULL);
     if (LZ4F_isError(ret)) {
         sd->errored = true;
         return -1;
     }
-    *input_consumed = src_size;
+    *inputConsumed = srcSize;
     if (ret == 0) sd->frame_done = true;
-    if (dst_size > (size_t)SSIZE_MAX) {
+    if (dstSize > (size_t)SSIZE_MAX) {
         sd->errored = true;
         return -1;
     }
-    return (ssize_t)dst_size;
+    return (ssize_t)dstSize;
 }

--- a/src/compression_lz4.h
+++ b/src/compression_lz4.h
@@ -9,18 +9,18 @@
 
 #include "compression.h"
 
-int compressionLz4CompressorInit(stream_compressor_t *sc);
-void compressionLz4CompressorDestroy(stream_compressor_t *sc);
-int compressionLz4DecompressorInit(stream_decompressor_t *sd);
-void compressionLz4DecompressorDestroy(stream_decompressor_t *sd);
+int compressionLz4CompressorInit(streamCompressor *sc);
+void compressionLz4CompressorDestroy(streamCompressor *sc);
+int compressionLz4DecompressorInit(streamDecompressor *sd);
+void compressionLz4DecompressorDestroy(streamDecompressor *sd);
 size_t compressionLz4OutputBound(size_t input_len);
-ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
+ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                    uint8_t *output,
                                    size_t output_capacity,
                                    const uint8_t *input,
                                    size_t input_len,
-                                   compress_flush_mode_t flush_mode);
-ssize_t compressionLz4DecompressFeed(stream_decompressor_t *sd,
+                                   compressFlushMode flush_mode);
+ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
                                      uint8_t *output,
                                      size_t output_capacity,
                                      const uint8_t *input,

--- a/src/compression_lz4.h
+++ b/src/compression_lz4.h
@@ -13,18 +13,18 @@ int compressionLz4CompressorInit(streamCompressor *sc);
 void compressionLz4CompressorDestroy(streamCompressor *sc);
 int compressionLz4DecompressorInit(streamDecompressor *sd);
 void compressionLz4DecompressorDestroy(streamDecompressor *sd);
-size_t compressionLz4OutputBound(size_t input_len);
+size_t compressionLz4OutputBound(size_t inputLen);
 ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                    uint8_t *output,
-                                   size_t output_capacity,
+                                   size_t outputCapacity,
                                    const uint8_t *input,
-                                   size_t input_len,
-                                   compressFlushMode flush_mode);
+                                   size_t inputLen,
+                                   compressFlushMode flushMode);
 ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
                                      uint8_t *output,
-                                     size_t output_capacity,
+                                     size_t outputCapacity,
                                      const uint8_t *input,
-                                     size_t input_len,
-                                     size_t *input_consumed);
+                                     size_t inputLen,
+                                     size_t *inputConsumed);
 
 #endif /* COMPRESSION_LZ4_H */

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -64,14 +64,14 @@ static void rioInitBase(rio *base,
 /* Emit callback for compress_rio: writes compressed bytes to inner rio.
  * Returns 0 on success, -1 on error. */
 static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
-    compress_rio_t *cr = (compress_rio_t *)ctx;
+    compressRio *cr = (compressRio *)ctx;
     if (rioWrite(cr->inner, data, len) == 0) return -1;
     return 0;
 }
 
 /* rio vtable: write callback — compress then delegate to inner rio */
 static size_t compressRioWrite(rio *r, const void *buf, size_t len) {
-    compress_rio_t *cr = (compress_rio_t *)r;
+    compressRio *cr = (compressRio *)r;
     if (!cr->compressor || cr->finalized || stream_writer_is_errored(cr->compressor)) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
@@ -92,7 +92,7 @@ static off_t compressRioTell(rio *r) {
  * keep frame open) + inner flush. Does NOT end the frame.
  * This is critical because some call sites flush mid-stream. */
 static int compressRioFlush(rio *r) {
-    compress_rio_t *cr = (compress_rio_t *)r;
+    compressRio *cr = (compressRio *)r;
     if (!cr->compressor || stream_writer_is_errored(cr->compressor)) return 0;
     if (cr->finalized) return 1;
 
@@ -109,7 +109,7 @@ static int compressRioFlush(rio *r) {
  * Sets up the rio vtable so callers can use standard rioWrite/rioFlush.
  * The compressor is initialized with a fresh algorithm context (fork-safe). */
 /* Returns 0 on success, -1 on failure (e.g., compressor init failed). */
-int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_config_t *cfg) {
+int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg) {
     if (!cr || !inner || !cfg) return -1;
 
     memset(cr, 0, sizeof(*cr));
@@ -138,7 +138,7 @@ int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_conf
  * Must be called exactly once at end of stream.
  * Idempotent: safe to call multiple times (second call is a no-op). */
 /* Returns 0 on success, -1 if the compressor or inner flush errored. */
-int compress_rio_finish(compress_rio_t *cr) {
+int compress_rio_finish(compressRio *cr) {
     if (!cr) return -1;
     if (!cr->compressor) return -1;
     if (cr->finalized) return stream_writer_is_errored(cr->compressor) ? -1 : 0;
@@ -159,7 +159,7 @@ int compress_rio_finish(compress_rio_t *cr) {
 
 /* Free compressor context and buffers. Does NOT finalize the frame.
  * Call compress_rio_finish() first on all exit paths. */
-void compress_rio_destroy(compress_rio_t *cr) {
+void compress_rio_destroy(compressRio *cr) {
     if (!cr) return;
     if (cr->compressor) {
         stream_writer_destroy(cr->compressor);
@@ -169,18 +169,18 @@ void compress_rio_destroy(compress_rio_t *cr) {
 
 /* ===================================================================
  * Decompression Rio Decorator
- * Thin rio adapter around stream_reader_t.
+ * Thin rio adapter around streamReader.
  * =================================================================== */
 
 /* Read up to `len` bytes from the inner rio (partial reads allowed).
  * Returns >0 bytes, 0 on EOF, -1 on error. */
 static ssize_t decompressRioReadPartial(void *ctx, void *buf, size_t len) {
-    decompress_rio_t *dr = (decompress_rio_t *)ctx;
+    decompressRio *dr = (decompressRio *)ctx;
     return rioReadPartial(dr->inner, buf, len);
 }
 
 static size_t decompressRioRead(rio *r, void *buf, size_t len) {
-    decompress_rio_t *dr = (decompress_rio_t *)r;
+    decompressRio *dr = (decompressRio *)r;
     if (dr->base.flags & RIO_FLAG_READ_ERROR) return 0;
     if (!dr->reader) {
         dr->base.flags |= RIO_FLAG_READ_ERROR;
@@ -209,11 +209,11 @@ static size_t decompressRioRead(rio *r, void *buf, size_t len) {
 /* rio vtable: tell callback — report transport bytes consumed from the wrapped
  * rio so progress stays tied to source-stream position. */
 static off_t decompressRioTell(rio *r) {
-    decompress_rio_t *dr = (decompress_rio_t *)r;
+    decompressRio *dr = (decompressRio *)r;
     return (off_t)dr->inner->processed_bytes;
 }
 
-stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr) {
+streamReaderError decompress_rio_get_error(const decompressRio *dr) {
     if (!dr || !dr->reader) return STREAM_READER_ERROR_IO;
     return stream_reader_get_error(dr->reader);
 }
@@ -221,11 +221,11 @@ stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr) {
 /* Initialize a decompression rio and eagerly probe the wrapped stream so the
  * caller gets a stable classification up front: passthrough, compressed, or
  * incompatible envelope. */
-decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
+decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
                                                    rio *inner,
-                                                   const stream_reader_config_t *cfg,
-                                                   stream_reader_info_t *info) {
-    stream_reader_info_t local_info = {0};
+                                                   const streamReaderConfig *cfg,
+                                                   streamReaderInfo *info) {
+    streamReaderInfo local_info = {0};
 
     if (!dr || !inner || !cfg) return DECOMPRESS_RIO_INIT_ERROR;
 
@@ -242,7 +242,7 @@ decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
         return DECOMPRESS_RIO_INIT_ERROR;
     }
     if (stream_reader_get_info(dr->reader, &local_info) != 0) {
-        stream_reader_error_t error_kind = stream_reader_get_error(dr->reader);
+        streamReaderError error_kind = stream_reader_get_error(dr->reader);
         decompress_rio_destroy(dr);
         return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
                    ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
@@ -259,7 +259,7 @@ decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
     return DECOMPRESS_RIO_INIT_OK;
 }
 
-void decompress_rio_destroy(decompress_rio_t *dr) {
+void decompress_rio_destroy(decompressRio *dr) {
     if (!dr) return;
     if (dr->reader) {
         stream_reader_destroy(dr->reader);

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -72,11 +72,11 @@ static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
 /* rio vtable: write callback — compress then delegate to inner rio */
 static size_t compressRioWrite(rio *r, const void *buf, size_t len) {
     compressRio *cr = (compressRio *)r;
-    if (!cr->compressor || cr->finalized || stream_writer_is_errored(cr->compressor)) {
+    if (!cr->compressor || cr->finalized || streamWriterIsErrored(cr->compressor)) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
-    if (stream_writer_write(cr->compressor, buf, len) < 0) {
+    if (streamWriterWrite(cr->compressor, buf, len) < 0) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
@@ -93,13 +93,13 @@ static off_t compressRioTell(rio *r) {
  * This is critical because some call sites flush mid-stream. */
 static int compressRioFlush(rio *r) {
     compressRio *cr = (compressRio *)r;
-    if (!cr->compressor || stream_writer_is_errored(cr->compressor)) return 0;
+    if (!cr->compressor || streamWriterIsErrored(cr->compressor)) return 0;
     if (cr->finalized) return 1;
 
-    if (stream_writer_flush(cr->compressor) != 0) return 0;
+    if (streamWriterFlush(cr->compressor) != 0) return 0;
 
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->compressor);
+        streamWriterSetError(cr->compressor);
         return 0;
     }
     return 1;
@@ -130,7 +130,7 @@ int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *c
 
     cr->inner = inner;
     cr->finalized = 0;
-    cr->compressor = stream_writer_create(cfg, compressRioEmit, cr);
+    cr->compressor = streamWriterCreate(cfg, compressRioEmit, cr);
     return cr->compressor ? 0 : -1;
 }
 
@@ -138,13 +138,13 @@ int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *c
  * Must be called exactly once at end of stream.
  * Idempotent: safe to call multiple times (second call is a no-op). */
 /* Returns 0 on success, -1 if the compressor or inner flush errored. */
-int compress_rio_finish(compressRio *cr) {
+int compressRioFinish(compressRio *cr) {
     if (!cr) return -1;
     if (!cr->compressor) return -1;
-    if (cr->finalized) return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    if (cr->finalized) return streamWriterIsErrored(cr->compressor) ? -1 : 0;
     cr->finalized = 1;
 
-    if (stream_writer_finish(cr->compressor) != 0) {
+    if (streamWriterFinish(cr->compressor) != 0) {
         return -1;
     }
 
@@ -152,17 +152,17 @@ int compress_rio_finish(compressRio *cr) {
      * Propagate flush failure to the compressor error state so
      * callers can detect it. */
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->compressor);
+        streamWriterSetError(cr->compressor);
     }
-    return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    return streamWriterIsErrored(cr->compressor) ? -1 : 0;
 }
 
 /* Free compressor context and buffers. Does NOT finalize the frame.
- * Call compress_rio_finish() first on all exit paths. */
-void compress_rio_destroy(compressRio *cr) {
+ * Call compressRioFinish() first on all exit paths. */
+void compressRioDestroy(compressRio *cr) {
     if (!cr) return;
     if (cr->compressor) {
-        stream_writer_destroy(cr->compressor);
+        streamWriterDestroy(cr->compressor);
         cr->compressor = NULL;
     }
 }
@@ -190,7 +190,7 @@ static size_t decompressRioRead(rio *r, void *buf, size_t len) {
     uint8_t *dst = (uint8_t *)buf;
     size_t remaining = len;
     while (remaining > 0) {
-        ssize_t nread = stream_reader_read(dr->reader, dst, remaining);
+        ssize_t nread = streamReaderRead(dr->reader, dst, remaining);
         if (nread < 0) {
             dr->base.flags |= RIO_FLAG_READ_ERROR;
             return 0;
@@ -213,9 +213,9 @@ static off_t decompressRioTell(rio *r) {
     return (off_t)dr->inner->processed_bytes;
 }
 
-streamReaderError decompress_rio_get_error(const decompressRio *dr) {
+streamReaderError decompressRioGetError(const decompressRio *dr) {
     if (!dr || !dr->reader) return STREAM_READER_ERROR_IO;
-    return stream_reader_get_error(dr->reader);
+    return streamReaderGetError(dr->reader);
 }
 
 /* Initialize a decompression rio and eagerly probe the wrapped stream so the
@@ -236,14 +236,14 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
                 rioCheckType(inner));
     dr->inner = inner;
 
-    dr->reader = stream_reader_create(cfg, decompressRioReadPartial, dr);
+    dr->reader = streamReaderCreate(cfg, decompressRioReadPartial, dr);
     if (!dr->reader) {
         dr->base.flags |= RIO_FLAG_READ_ERROR;
         return DECOMPRESS_RIO_INIT_ERROR;
     }
-    if (stream_reader_get_info(dr->reader, &local_info) != 0) {
-        streamReaderError error_kind = stream_reader_get_error(dr->reader);
-        decompress_rio_destroy(dr);
+    if (streamReaderGetInfo(dr->reader, &local_info) != 0) {
+        streamReaderError error_kind = streamReaderGetError(dr->reader);
+        decompressRioDestroy(dr);
         return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
                    ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
                    : DECOMPRESS_RIO_INIT_ERROR;
@@ -259,10 +259,10 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
     return DECOMPRESS_RIO_INIT_OK;
 }
 
-void decompress_rio_destroy(decompressRio *dr) {
+void decompressRioDestroy(decompressRio *dr) {
     if (!dr) return;
     if (dr->reader) {
-        stream_reader_destroy(dr->reader);
+        streamReaderDestroy(dr->reader);
         dr->reader = NULL;
     }
 }

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -222,9 +222,9 @@ streamReaderError decompressRioGetError(const decompressRio *dr) {
  * caller gets a stable classification up front: passthrough, compressed, or
  * incompatible envelope. */
 decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
-                                                   rio *inner,
-                                                   const streamReaderConfig *cfg,
-                                                   streamReaderInfo *info) {
+                                              rio *inner,
+                                              const streamReaderConfig *cfg,
+                                              streamReaderInfo *info) {
     streamReaderInfo local_info = {0};
 
     if (!dr || !inner || !cfg) return DECOMPRESS_RIO_INIT_ERROR;

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -33,8 +33,8 @@ typedef enum {
 
 /* --- Rio Decorator API --- */
 int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg);
-int compress_rio_finish(compressRio *cr);
-void compress_rio_destroy(compressRio *cr);
+int compressRioFinish(compressRio *cr);
+void compressRioDestroy(compressRio *cr);
 
 /* Initialize and probe a decompression adapter in one step.
  * Returns OK for both passthrough and compressed streams, INCOMPATIBLE for
@@ -43,8 +43,8 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
                                                    rio *inner,
                                                    const streamReaderConfig *cfg,
                                                    streamReaderInfo *info);
-streamReaderError decompress_rio_get_error(const decompressRio *dr);
+streamReaderError decompressRioGetError(const decompressRio *dr);
 /* Destroy the adapter without additional I/O. */
-void decompress_rio_destroy(decompressRio *dr);
+void decompressRioDestroy(decompressRio *dr);
 
 #endif /* COMPRESSION_RIO_H */

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -14,37 +14,37 @@
 typedef struct {
     rio base; /* Must be first — allows casting to (rio *) */
     rio *inner;
-    stream_writer_t *compressor;
+    streamWriter *compressor;
     bool finalized;
-} compress_rio_t;
+} compressRio;
 
 /* Decompression rio wrapper. */
 typedef struct {
     rio base; /* Must be first */
     rio *inner;
-    stream_reader_t *reader;
-} decompress_rio_t;
+    streamReader *reader;
+} decompressRio;
 
 typedef enum {
     DECOMPRESS_RIO_INIT_ERROR = -1,
     DECOMPRESS_RIO_INIT_OK = 0,
     DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
-} decompress_rio_init_result_t;
+} decompressRioInitResult;
 
 /* --- Rio Decorator API --- */
-int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_config_t *cfg);
-int compress_rio_finish(compress_rio_t *cr);
-void compress_rio_destroy(compress_rio_t *cr);
+int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg);
+int compress_rio_finish(compressRio *cr);
+void compress_rio_destroy(compressRio *cr);
 
 /* Initialize and probe a decompression adapter in one step.
  * Returns OK for both passthrough and compressed streams, INCOMPATIBLE for
  * malformed/unexpected stream envelopes, and ERROR for I/O or setup failures. */
-decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
+decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
                                                    rio *inner,
-                                                   const stream_reader_config_t *cfg,
-                                                   stream_reader_info_t *info);
-stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr);
+                                                   const streamReaderConfig *cfg,
+                                                   streamReaderInfo *info);
+streamReaderError decompress_rio_get_error(const decompressRio *dr);
 /* Destroy the adapter without additional I/O. */
-void decompress_rio_destroy(decompress_rio_t *dr);
+void decompress_rio_destroy(decompressRio *dr);
 
 #endif /* COMPRESSION_RIO_H */

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -40,9 +40,9 @@ void compressRioDestroy(compressRio *cr);
  * Returns OK for both passthrough and compressed streams, INCOMPATIBLE for
  * malformed/unexpected stream envelopes, and ERROR for I/O or setup failures. */
 decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
-                                                   rio *inner,
-                                                   const streamReaderConfig *cfg,
-                                                   streamReaderInfo *info);
+                                              rio *inner,
+                                              const streamReaderConfig *cfg,
+                                              streamReaderInfo *info);
 streamReaderError decompressRioGetError(const decompressRio *dr);
 /* Destroy the adapter without additional I/O. */
 void decompressRioDestroy(decompressRio *dr);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -87,7 +87,7 @@ static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
 /* Write 8-byte VKCS envelope via callback.
  * Layout: [0..3] magic "VKCS", [4] version, [5] codec_id, [6] flags, [7] stream_kind.
  * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
-static int write_vkcs_envelope(vkcsEmitFn emit_cb,
+static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
                                void *ctx,
                                vkcsCodec codec,
                                uint8_t stream_kind,
@@ -115,7 +115,7 @@ static int write_vkcs_envelope(vkcsEmitFn emit_cb,
  * On success populates *codec and *stream_kind and returns 0.
  * Returns -1 on error (bad magic, unsupported version, unknown codec,
  * reserved bits set). */
-static int read_vkcs_envelope(const uint8_t *buf,
+static int readVkcsEnvelope(const uint8_t *buf,
                               size_t len,
                               vkcsCodec *codec,
                               uint8_t *stream_kind,
@@ -148,7 +148,7 @@ static int readVkcsEnvelopeInfo(const uint8_t *buf,
     bool codec_checksum_enabled = false;
     compressionAlgo algo = ALGO_NONE;
 
-    if (read_vkcs_envelope(buf, VKCS_ENVELOPE_SIZE,
+    if (readVkcsEnvelope(buf, VKCS_ENVELOPE_SIZE,
                            &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
         stream_kind != expected_stream_kind ||
         vkcsCodecToCompressionAlgo(codec, &algo) != 0) {
@@ -244,7 +244,7 @@ struct stream_writer {
     void *emit_ctx;
     uint8_t stream_kind; /* Concrete on-wire stream kind */
     bool envelope_written;
-    bool finished;          /* Set by stream_writer_finish — blocks further writes.
+    bool finished;          /* Set by streamWriterFinish — blocks further writes.
                              * Prevents accidental multi-frame output under one envelope. */
     bool errored;           /* Sticky error flag — once set, all writes fail */
     uint64_t bytes_emitted; /* Running total of bytes successfully emitted */
@@ -272,7 +272,7 @@ static int streamWriterEnsureEnvelope(streamWriter *t) {
     if (t->envelope_written) return 0;
     vkcsCodec codec;
     if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
-        write_vkcs_envelope(t->emit_cb, t->emit_ctx, codec,
+        writeVkcsEnvelope(t->emit_cb, t->emit_ctx, codec,
                             t->stream_kind, t->compressor.codec_checksum) != 0) {
         t->errored = true;
         return -1;
@@ -342,7 +342,7 @@ static void streamWriterReleaseContext(streamWriter *t) {
     t->out_buf_size = 0;
 }
 
-streamWriter *stream_writer_create(const streamWriterConfig *cfg,
+streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
                                       vkcsEmitFn emit_cb,
                                       void *emit_ctx) {
     if (!cfg || !emit_cb || !compressionAlgoSupportsStreaming(cfg->algo)) {
@@ -357,7 +357,7 @@ streamWriter *stream_writer_create(const streamWriterConfig *cfg,
     return t;
 }
 
-ssize_t stream_writer_write(streamWriter *t, const void *buf, size_t len) {
+ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len) {
     if (!t) return -1;
     if (t->errored) return -1;
     /* Writes after finish are always a caller bug. Returning an error
@@ -385,7 +385,7 @@ ssize_t stream_writer_write(streamWriter *t, const void *buf, size_t len) {
     return (ssize_t)emitted_delta;
 }
 
-int stream_writer_flush(streamWriter *t) {
+int streamWriterFlush(streamWriter *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     /* Flush-after-finish is a harmless no-op: frame is already closed. */
@@ -396,7 +396,7 @@ int stream_writer_flush(streamWriter *t) {
     return 0;
 }
 
-int stream_writer_finish(streamWriter *t) {
+int streamWriterFinish(streamWriter *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     if (t->finished) return 0;
@@ -408,17 +408,17 @@ int stream_writer_finish(streamWriter *t) {
     return 0;
 }
 
-void stream_writer_destroy(streamWriter *t) {
+void streamWriterDestroy(streamWriter *t) {
     if (!t) return;
     streamWriterReleaseContext(t);
     zfree(t);
 }
 
-int stream_writer_is_errored(const streamWriter *t) {
+int streamWriterIsErrored(const streamWriter *t) {
     return t && t->errored;
 }
 
-void stream_writer_set_error(streamWriter *t) {
+void streamWriterSetError(streamWriter *t) {
     if (!t) return;
     t->errored = true;
 }
@@ -501,7 +501,7 @@ static void streamReaderResetCompressedState(streamReader *t) {
     t->decompressed_buf_len = 0;
 }
 
-streamReader *stream_reader_create(const streamReaderConfig *cfg,
+streamReader *streamReaderCreate(const streamReaderConfig *cfg,
                                       streamReaderReadFn read_cb,
                                       void *read_ctx) {
     if (!read_cb) return NULL;
@@ -526,7 +526,7 @@ static size_t streamReaderProbeBytesNeeded(const streamReader *t) {
     return VKCS_ENVELOPE_SIZE - t->probe.header_len;
 }
 
-int stream_reader_probe(streamReader *t) {
+int streamReaderProbe(streamReader *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     if (t->probe.ready) return 0;
@@ -741,13 +741,13 @@ static ssize_t streamReaderReadCompressed(streamReader *t, uint8_t *dst, size_t 
     return (ssize_t)total;
 }
 
-ssize_t stream_reader_read(streamReader *t, void *buf, size_t len) {
+ssize_t streamReaderRead(streamReader *t, void *buf, size_t len) {
     if (!t || !buf) return -1;
     if (t->errored) return -1;
     if (len == 0) return 0;
     if (len > (size_t)SSIZE_MAX) return -1;
 
-    if (stream_reader_probe(t) != 0) return -1;
+    if (streamReaderProbe(t) != 0) return -1;
 
     if (!t->probe.compressed) {
         return streamReaderReadPassthrough(t, (uint8_t *)buf, len);
@@ -756,9 +756,9 @@ ssize_t stream_reader_read(streamReader *t, void *buf, size_t len) {
     return streamReaderReadCompressed(t, (uint8_t *)buf, len);
 }
 
-int stream_reader_get_info(streamReader *t, streamReaderInfo *info) {
+int streamReaderGetInfo(streamReader *t, streamReaderInfo *info) {
     if (!t || !info) return -1;
-    if (stream_reader_probe(t) != 0) return -1;
+    if (streamReaderProbe(t) != 0) return -1;
 
     info->compressed = t->probe.compressed;
     info->codec_checksum_enabled = t->probe.compressed ? t->probe.codec_checksum_enabled : false;
@@ -767,11 +767,11 @@ int stream_reader_get_info(streamReader *t, streamReaderInfo *info) {
     return 0;
 }
 
-streamReaderError stream_reader_get_error(const streamReader *t) {
+streamReaderError streamReaderGetError(const streamReader *t) {
     return t ? t->error_kind : STREAM_READER_ERROR_IO;
 }
 
-void stream_reader_destroy(streamReader *t) {
+void streamReaderDestroy(streamReader *t) {
     if (!t) return;
     streamReaderResetCompressedState(t);
     zfree(t);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -88,10 +88,10 @@ static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
  * Layout: [0..3] magic "VKCS", [4] version, [5] codec_id, [6] flags, [7] streamKind.
  * Returns 0 on success, -1 on error (invalid codec or emitCb failure). */
 static int writeVkcsEnvelope(vkcsEmitFn emitCb,
-                               void *ctx,
-                               vkcsCodec codec,
-                               uint8_t streamKind,
-                               bool codecChecksumEnabled) {
+                             void *ctx,
+                             vkcsCodec codec,
+                             uint8_t streamKind,
+                             bool codecChecksumEnabled) {
     if (!emitCb) return -1;
     if (!vkcsCodecIsSupported(codec)) return -1;
 
@@ -116,10 +116,10 @@ static int writeVkcsEnvelope(vkcsEmitFn emitCb,
  * Returns -1 on error (bad magic, unsupported version, unknown codec,
  * reserved bits set). */
 static int readVkcsEnvelope(const uint8_t *buf,
-                              size_t len,
-                              vkcsCodec *codec,
-                              uint8_t *streamKind,
-                              bool *codecChecksumEnabled) {
+                            size_t len,
+                            vkcsCodec *codec,
+                            uint8_t *streamKind,
+                            bool *codecChecksumEnabled) {
     if (!buf || len < VKCS_ENVELOPE_SIZE) return -1;
 
     if (buf[0] != VKCS_MAGIC_0 || buf[1] != VKCS_MAGIC_1 ||
@@ -149,7 +149,7 @@ static int readVkcsEnvelopeInfo(const uint8_t *buf,
     compressionAlgo algo = ALGO_NONE;
 
     if (readVkcsEnvelope(buf, VKCS_ENVELOPE_SIZE,
-                           &codec, &streamKind, &codecChecksumEnabled) != 0 ||
+                         &codec, &streamKind, &codecChecksumEnabled) != 0 ||
         streamKind != expectedStreamKind ||
         vkcsCodecToCompressionAlgo(codec, &algo) != 0) {
         return -1;
@@ -172,11 +172,11 @@ static void vkcsProbeInit(vkcsProbe *probe) {
  * VKCS_ENVELOPE_SIZE bytes per read. The probe also retains any consumed
  * prefix so passthrough streams can replay those bytes exactly. */
 static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
-                                         const vkcsProbeConfig *cfg,
-                                         const uint8_t *src,
-                                         size_t srcLen,
-                                         bool inputEof,
-                                         size_t *srcConsumed) {
+                                     const vkcsProbeConfig *cfg,
+                                     const uint8_t *src,
+                                     size_t srcLen,
+                                     bool inputEof,
+                                     size_t *srcConsumed) {
     size_t consumed = 0;
 
     *srcConsumed = 0;
@@ -238,15 +238,15 @@ static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
 /* Streaming writer context. */
 struct stream_writer {
     streamCompressor compressor;
-    uint8_t *outBuf;     /* Reusable output buffer, sized via streamCompressOutputBound */
-    size_t outBufSize;  /* Current allocation size of outBuf */
+    uint8_t *outBuf;   /* Reusable output buffer, sized via streamCompressOutputBound */
+    size_t outBufSize; /* Current allocation size of outBuf */
     vkcsEmitFn emitCb; /* Returns 0 on success, -1 on error */
     void *emitCtx;
     uint8_t streamKind; /* Concrete on-wire stream kind */
     bool envelopeWritten;
-    bool finished;          /* Set by streamWriterFinish — blocks further writes.
+    bool finished;         /* Set by streamWriterFinish — blocks further writes.
                              * Prevents accidental multi-frame output under one envelope. */
-    bool errored;           /* Sticky error flag — once set, all writes fail */
+    bool errored;          /* Sticky error flag — once set, all writes fail */
     uint64_t bytesEmitted; /* Running total of bytes successfully emitted */
 };
 
@@ -273,7 +273,7 @@ static int streamWriterEnsureEnvelope(streamWriter *t) {
     vkcsCodec codec;
     if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
         writeVkcsEnvelope(t->emitCb, t->emitCtx, codec,
-                            t->streamKind, t->compressor.codec_checksum) != 0) {
+                          t->streamKind, t->compressor.codec_checksum) != 0) {
         t->errored = true;
         return -1;
     }
@@ -343,8 +343,8 @@ static void streamWriterReleaseContext(streamWriter *t) {
 }
 
 streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
-                                      vkcsEmitFn emitCb,
-                                      void *emitCtx) {
+                                 vkcsEmitFn emitCb,
+                                 void *emitCtx) {
     if (!cfg || !emitCb || !compressionAlgoSupportsStreaming(cfg->algo)) {
         return NULL;
     }
@@ -371,8 +371,8 @@ ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len) {
     if (streamWriterEnsureEnvelope(t) != 0) return -1;
     while (remaining > 0) {
         size_t chunkLen = remaining < STREAM_WRITER_INPUT_CHUNK_SIZE
-                               ? remaining
-                               : STREAM_WRITER_INPUT_CHUNK_SIZE;
+                              ? remaining
+                              : STREAM_WRITER_INPUT_CHUNK_SIZE;
         if (streamWriterFeedAndEmit(t, src, chunkLen, FLUSH_CONTINUE) != 0) return -1;
         src += chunkLen;
         remaining -= chunkLen;
@@ -502,8 +502,8 @@ static void streamReaderResetCompressedState(streamReader *t) {
 }
 
 streamReader *streamReaderCreate(const streamReaderConfig *cfg,
-                                      streamReaderReadFn readCb,
-                                      void *readCtx) {
+                                 streamReaderReadFn readCb,
+                                 void *readCtx) {
     if (!readCb) return NULL;
     if (!cfg) return NULL;
 
@@ -543,8 +543,8 @@ int streamReaderProbe(streamReader *t) {
         }
 
         vkcsProbeResult status = vkcsProbeFeed(&t->probe, &t->probeCfg, buf,
-                                                   got > 0 ? (size_t)got : 0,
-                                                   got == 0, &consumed);
+                                               got > 0 ? (size_t)got : 0,
+                                               got == 0, &consumed);
         if (status == VKCS_PROBE_ERROR) {
             streamReaderSetError(t, STREAM_READER_ERROR_INCOMPATIBLE);
             return -1;
@@ -726,7 +726,7 @@ static ssize_t streamReaderReadCompressed(streamReader *t, uint8_t *dst, size_t 
                 return streamReaderFailWithError(
                     t, total,
                     t->errorKind == STREAM_READER_ERROR_NONE ? STREAM_READER_ERROR_IO
-                                                              : t->errorKind);
+                                                             : t->errorKind);
             }
             if (filled == 0 && !t->decompressor.frame_done) {
                 return streamReaderFailWithError(t, total, STREAM_READER_ERROR_CORRUPT);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -16,13 +16,13 @@ typedef enum {
     VKCS_PROBE_PASSTHROUGH = 1,
     VKCS_PROBE_COMPRESSED = 2,
     VKCS_PROBE_ERROR = 3,
-} vkcs_probe_result_t;
+} vkcsProbeResult;
 
 /* Probe options. */
 typedef struct {
     bool allow_passthrough;
     uint8_t expected_stream_kind;
-} vkcs_probe_config_t;
+} vkcsProbeConfig;
 
 /* Probe state. */
 typedef struct {
@@ -31,21 +31,21 @@ typedef struct {
     bool ready;
     bool compressed;
     bool codec_checksum_enabled;
-    compression_algo_t algo;
+    compressionAlgo algo;
     uint8_t stream_kind;
-} vkcs_probe_t;
+} vkcsProbe;
 
-static bool vkcsCodecIsSupported(vkcs_codec_t codec) {
+static bool vkcsCodecIsSupported(vkcsCodec codec) {
     return codec == VKCS_CODEC_LZ4;
 }
 
-static bool vkcsProbeHasMagicPrefix(const vkcs_probe_t *probe) {
+static bool vkcsProbeHasMagicPrefix(const vkcsProbe *probe) {
     if (probe->header_len == 0) return false;
     size_t magic_prefix_len = probe->header_len < 4 ? probe->header_len : 4;
     return memcmp(probe->header, "VKCS", magic_prefix_len) == 0;
 }
 
-static void vkcsProbeSetPassthrough(vkcs_probe_t *probe) {
+static void vkcsProbeSetPassthrough(vkcsProbe *probe) {
     probe->ready = true;
     probe->compressed = false;
     probe->codec_checksum_enabled = false;
@@ -53,8 +53,8 @@ static void vkcsProbeSetPassthrough(vkcs_probe_t *probe) {
     probe->stream_kind = 0;
 }
 
-static void vkcsProbeSetCompressed(vkcs_probe_t *probe,
-                                   compression_algo_t algo,
+static void vkcsProbeSetCompressed(vkcsProbe *probe,
+                                   compressionAlgo algo,
                                    uint8_t stream_kind,
                                    bool codec_checksum_enabled) {
     probe->ready = true;
@@ -64,7 +64,7 @@ static void vkcsProbeSetCompressed(vkcs_probe_t *probe,
     probe->stream_kind = stream_kind;
 }
 
-static int compressionAlgoToVkcsCodec(compression_algo_t algo, vkcs_codec_t *codec) {
+static int compressionAlgoToVkcsCodec(compressionAlgo algo, vkcsCodec *codec) {
     switch (algo) {
     case ALGO_LZ4:
         *codec = VKCS_CODEC_LZ4;
@@ -74,7 +74,7 @@ static int compressionAlgoToVkcsCodec(compression_algo_t algo, vkcs_codec_t *cod
     }
 }
 
-static int vkcsCodecToCompressionAlgo(vkcs_codec_t codec, compression_algo_t *algo) {
+static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
     switch (codec) {
     case VKCS_CODEC_LZ4:
         *algo = ALGO_LZ4;
@@ -87,9 +87,9 @@ static int vkcsCodecToCompressionAlgo(vkcs_codec_t codec, compression_algo_t *al
 /* Write 8-byte VKCS envelope via callback.
  * Layout: [0..3] magic "VKCS", [4] version, [5] codec_id, [6] flags, [7] stream_kind.
  * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
-static int write_vkcs_envelope(vkcs_emit_fn emit_cb,
+static int write_vkcs_envelope(vkcsEmitFn emit_cb,
                                void *ctx,
-                               vkcs_codec_t codec,
+                               vkcsCodec codec,
                                uint8_t stream_kind,
                                bool codec_checksum_enabled) {
     if (!emit_cb) return -1;
@@ -117,7 +117,7 @@ static int write_vkcs_envelope(vkcs_emit_fn emit_cb,
  * reserved bits set). */
 static int read_vkcs_envelope(const uint8_t *buf,
                               size_t len,
-                              vkcs_codec_t *codec,
+                              vkcsCodec *codec,
                               uint8_t *stream_kind,
                               bool *codec_checksum_enabled) {
     if (!buf || len < VKCS_ENVELOPE_SIZE) return -1;
@@ -128,7 +128,7 @@ static int read_vkcs_envelope(const uint8_t *buf,
     }
     if (buf[4] != VKCS_VERSION) return -1;
 
-    vkcs_codec_t parsed_codec = (vkcs_codec_t)buf[5];
+    vkcsCodec parsed_codec = (vkcsCodec)buf[5];
     if (!vkcsCodecIsSupported(parsed_codec)) return -1;
 
     uint8_t flags = buf[6];
@@ -142,11 +142,11 @@ static int read_vkcs_envelope(const uint8_t *buf,
 
 static int readVkcsEnvelopeInfo(const uint8_t *buf,
                                 uint8_t expected_stream_kind,
-                                stream_reader_info_t *info) {
-    vkcs_codec_t codec;
+                                streamReaderInfo *info) {
+    vkcsCodec codec;
     uint8_t stream_kind = 0;
     bool codec_checksum_enabled = false;
-    compression_algo_t algo = ALGO_NONE;
+    compressionAlgo algo = ALGO_NONE;
 
     if (read_vkcs_envelope(buf, VKCS_ENVELOPE_SIZE,
                            &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
@@ -162,7 +162,7 @@ static int readVkcsEnvelopeInfo(const uint8_t *buf,
     return 0;
 }
 
-static void vkcsProbeInit(vkcs_probe_t *probe) {
+static void vkcsProbeInit(vkcsProbe *probe) {
     memset(probe, 0, sizeof(*probe));
     probe->algo = ALGO_NONE;
     probe->codec_checksum_enabled = false;
@@ -171,8 +171,8 @@ static void vkcsProbeInit(vkcs_probe_t *probe) {
 /* Probe incrementally because wrapped rios may legally return fewer than
  * VKCS_ENVELOPE_SIZE bytes per read. The probe also retains any consumed
  * prefix so passthrough streams can replay those bytes exactly. */
-static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
-                                         const vkcs_probe_config_t *cfg,
+static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
+                                         const vkcsProbeConfig *cfg,
                                          const uint8_t *src,
                                          size_t src_len,
                                          bool input_eof,
@@ -202,7 +202,7 @@ static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
         }
 
         if (probe->header_len == VKCS_ENVELOPE_SIZE) {
-            stream_reader_info_t info = {0};
+            streamReaderInfo info = {0};
 
             if (readVkcsEnvelopeInfo(probe->header, cfg->expected_stream_kind, &info) != 0) {
                 *src_consumed = consumed;
@@ -237,10 +237,10 @@ static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
 
 /* Streaming writer context. */
 struct stream_writer {
-    stream_compressor_t compressor;
+    streamCompressor compressor;
     uint8_t *out_buf;     /* Reusable output buffer, sized via streamCompressOutputBound */
     size_t out_buf_size;  /* Current allocation size of out_buf */
-    vkcs_emit_fn emit_cb; /* Returns 0 on success, -1 on error */
+    vkcsEmitFn emit_cb; /* Returns 0 on success, -1 on error */
     void *emit_ctx;
     uint8_t stream_kind; /* Concrete on-wire stream kind */
     bool envelope_written;
@@ -250,9 +250,9 @@ struct stream_writer {
     uint64_t bytes_emitted; /* Running total of bytes successfully emitted */
 };
 
-static int streamWriterInitContext(stream_writer_t *t,
-                                   const stream_writer_config_t *cfg,
-                                   vkcs_emit_fn emit_cb,
+static int streamWriterInitContext(streamWriter *t,
+                                   const streamWriterConfig *cfg,
+                                   vkcsEmitFn emit_cb,
                                    void *emit_ctx) {
     memset(t, 0, sizeof(*t));
     t->emit_cb = emit_cb;
@@ -268,9 +268,9 @@ static int streamWriterInitContext(stream_writer_t *t,
 
 /* Emit envelope lazily on first write/flush/finish.
  * Returns 0 on success, -1 on error (and sets t->errored). */
-static int streamWriterEnsureEnvelope(stream_writer_t *t) {
+static int streamWriterEnsureEnvelope(streamWriter *t) {
     if (t->envelope_written) return 0;
-    vkcs_codec_t codec;
+    vkcsCodec codec;
     if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
         write_vkcs_envelope(t->emit_cb, t->emit_ctx, codec,
                             t->stream_kind, t->compressor.codec_checksum) != 0) {
@@ -284,7 +284,7 @@ static int streamWriterEnsureEnvelope(stream_writer_t *t) {
 
 /* Emit compressed bytes to the output sink.
  * Returns 0 on success, -1 on error (and sets t->errored). */
-static int streamWriterEmit(stream_writer_t *t, const uint8_t *buf, size_t len) {
+static int streamWriterEmit(streamWriter *t, const uint8_t *buf, size_t len) {
     if (len == 0) return 0;
     if (t->emit_cb(t->emit_ctx, buf, len) != 0) {
         t->errored = true;
@@ -297,7 +297,7 @@ static int streamWriterEmit(stream_writer_t *t, const uint8_t *buf, size_t len) 
 /* Ensure the output buffer is large enough for the given input.
  * Reuses the existing buffer when possible to avoid per-write allocation.
  * zmalloc aborts on OOM, so this cannot fail. */
-static void streamWriterEnsureOutBuf(stream_writer_t *t, size_t input_len) {
+static void streamWriterEnsureOutBuf(streamWriter *t, size_t input_len) {
     size_t needed = streamCompressOutputBound(&t->compressor, input_len);
     if (needed == 0) {
         /* Ensure a minimal valid buffer so streamCompressFeed never gets NULL. */
@@ -315,10 +315,10 @@ static void streamWriterEnsureOutBuf(stream_writer_t *t, size_t input_len) {
 
 /* Compress one chunk with the requested flush mode and emit produced bytes.
  * Returns 0 on success, -1 on error (and sets t->errored). */
-static int streamWriterFeedAndEmit(stream_writer_t *t,
+static int streamWriterFeedAndEmit(streamWriter *t,
                                    const uint8_t *input,
                                    size_t input_len,
-                                   compress_flush_mode_t flush_mode) {
+                                   compressFlushMode flush_mode) {
     streamWriterEnsureOutBuf(t, input_len);
 
     ssize_t compressed = streamCompressFeed(&t->compressor, t->out_buf,
@@ -331,9 +331,9 @@ static int streamWriterFeedAndEmit(stream_writer_t *t,
     return streamWriterEmit(t, t->out_buf, (size_t)compressed);
 }
 
-/* Release stream compressor state owned by stream_writer_t.
+/* Release stream compressor state owned by streamWriter.
  * Does not free the context object itself. */
-static void streamWriterReleaseContext(stream_writer_t *t) {
+static void streamWriterReleaseContext(streamWriter *t) {
     streamCompressorDestroy(&t->compressor);
     if (t->out_buf) {
         zfree(t->out_buf);
@@ -342,14 +342,14 @@ static void streamWriterReleaseContext(stream_writer_t *t) {
     t->out_buf_size = 0;
 }
 
-stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
-                                      vkcs_emit_fn emit_cb,
+streamWriter *stream_writer_create(const streamWriterConfig *cfg,
+                                      vkcsEmitFn emit_cb,
                                       void *emit_ctx) {
     if (!cfg || !emit_cb || !compressionAlgoSupportsStreaming(cfg->algo)) {
         return NULL;
     }
 
-    stream_writer_t *t = zmalloc(sizeof(*t));
+    streamWriter *t = zmalloc(sizeof(*t));
     if (streamWriterInitContext(t, cfg, emit_cb, emit_ctx) != 0) {
         zfree(t);
         return NULL;
@@ -357,7 +357,7 @@ stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
     return t;
 }
 
-ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len) {
+ssize_t stream_writer_write(streamWriter *t, const void *buf, size_t len) {
     if (!t) return -1;
     if (t->errored) return -1;
     /* Writes after finish are always a caller bug. Returning an error
@@ -385,7 +385,7 @@ ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len) {
     return (ssize_t)emitted_delta;
 }
 
-int stream_writer_flush(stream_writer_t *t) {
+int stream_writer_flush(streamWriter *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     /* Flush-after-finish is a harmless no-op: frame is already closed. */
@@ -396,7 +396,7 @@ int stream_writer_flush(stream_writer_t *t) {
     return 0;
 }
 
-int stream_writer_finish(stream_writer_t *t) {
+int stream_writer_finish(streamWriter *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     if (t->finished) return 0;
@@ -408,34 +408,34 @@ int stream_writer_finish(stream_writer_t *t) {
     return 0;
 }
 
-void stream_writer_destroy(stream_writer_t *t) {
+void stream_writer_destroy(streamWriter *t) {
     if (!t) return;
     streamWriterReleaseContext(t);
     zfree(t);
 }
 
-int stream_writer_is_errored(const stream_writer_t *t) {
+int stream_writer_is_errored(const streamWriter *t) {
     return t && t->errored;
 }
 
-void stream_writer_set_error(stream_writer_t *t) {
+void stream_writer_set_error(streamWriter *t) {
     if (!t) return;
     t->errored = true;
 }
 
 /* Streaming reader context. */
 struct stream_reader {
-    stream_reader_read_fn read_cb; /* Returns >0 bytes, 0 EOF, -1 error */
+    streamReaderReadFn read_cb; /* Returns >0 bytes, 0 EOF, -1 error */
     void *read_ctx;
 
-    vkcs_probe_config_t probe_cfg;
-    vkcs_probe_t probe;
+    vkcsProbeConfig probe_cfg;
+    vkcsProbe probe;
     size_t probe_replay_pos; /* Unread passthrough bytes buffered by vkcsProbeFeed */
     size_t buffer_size;
     bool errored;
-    stream_reader_error_t error_kind;
+    streamReaderError error_kind;
 
-    stream_decompressor_t decompressor;
+    streamDecompressor decompressor;
     bool decompressor_initialized;
 
     uint8_t *compressed_buf; /* Buffered compressed input */
@@ -447,7 +447,7 @@ struct stream_reader {
     size_t decompressed_buf_len;
 };
 
-static void streamReaderSetError(stream_reader_t *t, stream_reader_error_t error_kind) {
+static void streamReaderSetError(streamReader *t, streamReaderError error_kind) {
     t->errored = true;
     if (t->error_kind == STREAM_READER_ERROR_NONE) {
         t->error_kind = error_kind;
@@ -455,19 +455,19 @@ static void streamReaderSetError(stream_reader_t *t, stream_reader_error_t error
 }
 
 /* Preserve partial output on read errors while latching sticky error state. */
-static ssize_t streamReaderFail(stream_reader_t *t, size_t partial_bytes) {
+static ssize_t streamReaderFail(streamReader *t, size_t partial_bytes) {
     streamReaderSetError(t, STREAM_READER_ERROR_IO);
     return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
 }
 
-static ssize_t streamReaderFailWithError(stream_reader_t *t,
+static ssize_t streamReaderFailWithError(streamReader *t,
                                          size_t partial_bytes,
-                                         stream_reader_error_t error_kind) {
+                                         streamReaderError error_kind) {
     streamReaderSetError(t, error_kind);
     return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
 }
 
-static int streamReaderInitCompressedState(stream_reader_t *t, size_t buffer_size) {
+static int streamReaderInitCompressedState(streamReader *t, size_t buffer_size) {
     if (streamDecompressorInit(&t->decompressor, t->probe.algo) != 0) {
         return -1;
     }
@@ -482,7 +482,7 @@ static int streamReaderInitCompressedState(stream_reader_t *t, size_t buffer_siz
     return 0;
 }
 
-static void streamReaderResetCompressedState(stream_reader_t *t) {
+static void streamReaderResetCompressedState(streamReader *t) {
     if (t->decompressor_initialized) {
         streamDecompressorDestroy(&t->decompressor);
         t->decompressor_initialized = false;
@@ -501,13 +501,13 @@ static void streamReaderResetCompressedState(stream_reader_t *t) {
     t->decompressed_buf_len = 0;
 }
 
-stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
-                                      stream_reader_read_fn read_cb,
+streamReader *stream_reader_create(const streamReaderConfig *cfg,
+                                      streamReaderReadFn read_cb,
                                       void *read_ctx) {
     if (!read_cb) return NULL;
     if (!cfg) return NULL;
 
-    stream_reader_t *t = zmalloc(sizeof(*t));
+    streamReader *t = zmalloc(sizeof(*t));
     memset(t, 0, sizeof(*t));
     t->read_cb = read_cb;
     t->read_ctx = read_ctx;
@@ -521,12 +521,12 @@ stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
     return t;
 }
 
-static size_t streamReaderProbeBytesNeeded(const stream_reader_t *t) {
+static size_t streamReaderProbeBytesNeeded(const streamReader *t) {
     if (t->probe.header_len < 4) return 4 - t->probe.header_len;
     return VKCS_ENVELOPE_SIZE - t->probe.header_len;
 }
 
-int stream_reader_probe(stream_reader_t *t) {
+int stream_reader_probe(streamReader *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     if (t->probe.ready) return 0;
@@ -542,7 +542,7 @@ int stream_reader_probe(stream_reader_t *t) {
             return -1;
         }
 
-        vkcs_probe_result_t status = vkcsProbeFeed(&t->probe, &t->probe_cfg, buf,
+        vkcsProbeResult status = vkcsProbeFeed(&t->probe, &t->probe_cfg, buf,
                                                    got > 0 ? (size_t)got : 0,
                                                    got == 0, &consumed);
         if (status == VKCS_PROBE_ERROR) {
@@ -565,7 +565,7 @@ int stream_reader_probe(stream_reader_t *t) {
     return 0;
 }
 
-static size_t streamReaderProbeAvail(const stream_reader_t *t) {
+static size_t streamReaderProbeAvail(const streamReader *t) {
     if (t->probe.header_len <= t->probe_replay_pos) return 0;
     return t->probe.header_len - t->probe_replay_pos;
 }
@@ -573,7 +573,7 @@ static size_t streamReaderProbeAvail(const stream_reader_t *t) {
 /* Passthrough reads may need to replay probe bytes before reading directly
  * from the wrapped source. On a transport read error after replaying some
  * bytes, return the partial payload and latch a sticky error for the next call. */
-static ssize_t streamReaderReadPassthrough(stream_reader_t *t,
+static ssize_t streamReaderReadPassthrough(streamReader *t,
                                            uint8_t *dst,
                                            size_t len) {
     size_t total = 0;
@@ -595,7 +595,7 @@ static ssize_t streamReaderReadPassthrough(stream_reader_t *t,
     return (ssize_t)(total + (size_t)got);
 }
 
-static int streamReaderDrainCompressedBuf(stream_reader_t *t,
+static int streamReaderDrainCompressedBuf(streamReader *t,
                                           uint8_t *out,
                                           size_t out_size,
                                           size_t *out_written) {
@@ -625,7 +625,7 @@ static int streamReaderDrainCompressedBuf(stream_reader_t *t,
     return 0;
 }
 
-static size_t streamReaderCompressedBufTailSpace(stream_reader_t *t) {
+static size_t streamReaderCompressedBufTailSpace(streamReader *t) {
     size_t tail_space = t->buffer_size - t->compressed_buf_pos - t->compressed_buf_len;
     if (tail_space > 0) return tail_space;
 
@@ -648,7 +648,7 @@ static size_t streamReaderCompressedBufTailSpace(stream_reader_t *t) {
     return 0;
 }
 
-static int streamReaderRefillCompressedBuf(stream_reader_t *t) {
+static int streamReaderRefillCompressedBuf(streamReader *t) {
     size_t read_size = streamReaderCompressedBufTailSpace(t);
     if (read_size > (size_t)SSIZE_MAX) read_size = (size_t)SSIZE_MAX;
     if (read_size == 0) return -1;
@@ -664,7 +664,7 @@ static int streamReaderRefillCompressedBuf(stream_reader_t *t) {
     return 1;
 }
 
-static ssize_t streamReaderFillDecompressedBuf(stream_reader_t *t) {
+static ssize_t streamReaderFillDecompressedBuf(streamReader *t) {
     size_t written = 0;
 
     t->decompressed_buf_pos = 0;
@@ -695,12 +695,12 @@ static ssize_t streamReaderFillDecompressedBuf(stream_reader_t *t) {
     return (ssize_t)written;
 }
 
-static inline size_t streamReaderDecompressedBufAvail(const stream_reader_t *t) {
+static inline size_t streamReaderDecompressedBufAvail(const streamReader *t) {
     if (t->decompressed_buf_len <= t->decompressed_buf_pos) return 0;
     return t->decompressed_buf_len - t->decompressed_buf_pos;
 }
 
-static size_t streamReaderCopyFromDecompressedBuf(stream_reader_t *t,
+static size_t streamReaderCopyFromDecompressedBuf(streamReader *t,
                                                   uint8_t **dst,
                                                   size_t *remaining) {
     size_t avail = streamReaderDecompressedBufAvail(t);
@@ -714,7 +714,7 @@ static size_t streamReaderCopyFromDecompressedBuf(stream_reader_t *t,
     return to_copy;
 }
 
-static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size_t len) {
+static ssize_t streamReaderReadCompressed(streamReader *t, uint8_t *dst, size_t len) {
     size_t remaining = len;
     size_t total = 0;
 
@@ -741,7 +741,7 @@ static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size
     return (ssize_t)total;
 }
 
-ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len) {
+ssize_t stream_reader_read(streamReader *t, void *buf, size_t len) {
     if (!t || !buf) return -1;
     if (t->errored) return -1;
     if (len == 0) return 0;
@@ -756,7 +756,7 @@ ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len) {
     return streamReaderReadCompressed(t, (uint8_t *)buf, len);
 }
 
-int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info) {
+int stream_reader_get_info(streamReader *t, streamReaderInfo *info) {
     if (!t || !info) return -1;
     if (stream_reader_probe(t) != 0) return -1;
 
@@ -767,11 +767,11 @@ int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info) {
     return 0;
 }
 
-stream_reader_error_t stream_reader_get_error(const stream_reader_t *t) {
+streamReaderError stream_reader_get_error(const streamReader *t) {
     return t ? t->error_kind : STREAM_READER_ERROR_IO;
 }
 
-void stream_reader_destroy(stream_reader_t *t) {
+void stream_reader_destroy(streamReader *t) {
     if (!t) return;
     streamReaderResetCompressedState(t);
     zfree(t);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -20,19 +20,19 @@ typedef enum {
 
 /* Probe options. */
 typedef struct {
-    bool allow_passthrough;
-    uint8_t expected_stream_kind;
+    bool allowPassthrough;
+    uint8_t expectedStreamKind;
 } vkcsProbeConfig;
 
 /* Probe state. */
 typedef struct {
     uint8_t header[VKCS_ENVELOPE_SIZE];
-    size_t header_len;
+    size_t headerLen;
     bool ready;
     bool compressed;
-    bool codec_checksum_enabled;
+    bool codecChecksumEnabled;
     compressionAlgo algo;
-    uint8_t stream_kind;
+    uint8_t streamKind;
 } vkcsProbe;
 
 static bool vkcsCodecIsSupported(vkcsCodec codec) {
@@ -40,28 +40,28 @@ static bool vkcsCodecIsSupported(vkcsCodec codec) {
 }
 
 static bool vkcsProbeHasMagicPrefix(const vkcsProbe *probe) {
-    if (probe->header_len == 0) return false;
-    size_t magic_prefix_len = probe->header_len < 4 ? probe->header_len : 4;
-    return memcmp(probe->header, "VKCS", magic_prefix_len) == 0;
+    if (probe->headerLen == 0) return false;
+    size_t magicPrefixLen = probe->headerLen < 4 ? probe->headerLen : 4;
+    return memcmp(probe->header, "VKCS", magicPrefixLen) == 0;
 }
 
 static void vkcsProbeSetPassthrough(vkcsProbe *probe) {
     probe->ready = true;
     probe->compressed = false;
-    probe->codec_checksum_enabled = false;
+    probe->codecChecksumEnabled = false;
     probe->algo = ALGO_NONE;
-    probe->stream_kind = 0;
+    probe->streamKind = 0;
 }
 
 static void vkcsProbeSetCompressed(vkcsProbe *probe,
                                    compressionAlgo algo,
-                                   uint8_t stream_kind,
-                                   bool codec_checksum_enabled) {
+                                   uint8_t streamKind,
+                                   bool codecChecksumEnabled) {
     probe->ready = true;
     probe->compressed = true;
-    probe->codec_checksum_enabled = codec_checksum_enabled;
+    probe->codecChecksumEnabled = codecChecksumEnabled;
     probe->algo = algo;
-    probe->stream_kind = stream_kind;
+    probe->streamKind = streamKind;
 }
 
 static int compressionAlgoToVkcsCodec(compressionAlgo algo, vkcsCodec *codec) {
@@ -85,14 +85,14 @@ static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
 }
 
 /* Write 8-byte VKCS envelope via callback.
- * Layout: [0..3] magic "VKCS", [4] version, [5] codec_id, [6] flags, [7] stream_kind.
- * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
-static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
+ * Layout: [0..3] magic "VKCS", [4] version, [5] codec_id, [6] flags, [7] streamKind.
+ * Returns 0 on success, -1 on error (invalid codec or emitCb failure). */
+static int writeVkcsEnvelope(vkcsEmitFn emitCb,
                                void *ctx,
                                vkcsCodec codec,
-                               uint8_t stream_kind,
-                               bool codec_checksum_enabled) {
-    if (!emit_cb) return -1;
+                               uint8_t streamKind,
+                               bool codecChecksumEnabled) {
+    if (!emitCb) return -1;
     if (!vkcsCodecIsSupported(codec)) return -1;
 
     uint8_t envelope[VKCS_ENVELOPE_SIZE];
@@ -102,24 +102,24 @@ static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
     envelope[3] = VKCS_MAGIC_3;
     envelope[4] = VKCS_VERSION;
     envelope[5] = (uint8_t)codec;
-    envelope[6] = codec_checksum_enabled ? VKCS_FLAG_CODEC_CHECKSUM : 0;
-    envelope[7] = stream_kind;
+    envelope[6] = codecChecksumEnabled ? VKCS_FLAG_CODEC_CHECKSUM : 0;
+    envelope[7] = streamKind;
 
-    return emit_cb(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
+    return emitCb(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
 }
 
 /* Parse 8-byte VKCS envelope from buffer.
  * Validates magic bytes, version, codec, and reserved fields.
  * Rejects envelopes with unknown flag bits so future versions are detected
  * early rather than causing silent data corruption.
- * On success populates *codec and *stream_kind and returns 0.
+ * On success populates *codec and *streamKind and returns 0.
  * Returns -1 on error (bad magic, unsupported version, unknown codec,
  * reserved bits set). */
 static int readVkcsEnvelope(const uint8_t *buf,
                               size_t len,
                               vkcsCodec *codec,
-                              uint8_t *stream_kind,
-                              bool *codec_checksum_enabled) {
+                              uint8_t *streamKind,
+                              bool *codecChecksumEnabled) {
     if (!buf || len < VKCS_ENVELOPE_SIZE) return -1;
 
     if (buf[0] != VKCS_MAGIC_0 || buf[1] != VKCS_MAGIC_1 ||
@@ -128,44 +128,44 @@ static int readVkcsEnvelope(const uint8_t *buf,
     }
     if (buf[4] != VKCS_VERSION) return -1;
 
-    vkcsCodec parsed_codec = (vkcsCodec)buf[5];
-    if (!vkcsCodecIsSupported(parsed_codec)) return -1;
+    vkcsCodec parsedCodec = (vkcsCodec)buf[5];
+    if (!vkcsCodecIsSupported(parsedCodec)) return -1;
 
     uint8_t flags = buf[6];
     if (flags & ~VKCS_FLAG_CODEC_CHECKSUM) return -1;
 
-    if (codec) *codec = parsed_codec;
-    if (stream_kind) *stream_kind = buf[7];
-    if (codec_checksum_enabled) *codec_checksum_enabled = (flags & VKCS_FLAG_CODEC_CHECKSUM) != 0;
+    if (codec) *codec = parsedCodec;
+    if (streamKind) *streamKind = buf[7];
+    if (codecChecksumEnabled) *codecChecksumEnabled = (flags & VKCS_FLAG_CODEC_CHECKSUM) != 0;
     return 0;
 }
 
 static int readVkcsEnvelopeInfo(const uint8_t *buf,
-                                uint8_t expected_stream_kind,
+                                uint8_t expectedStreamKind,
                                 streamReaderInfo *info) {
     vkcsCodec codec;
-    uint8_t stream_kind = 0;
-    bool codec_checksum_enabled = false;
+    uint8_t streamKind = 0;
+    bool codecChecksumEnabled = false;
     compressionAlgo algo = ALGO_NONE;
 
     if (readVkcsEnvelope(buf, VKCS_ENVELOPE_SIZE,
-                           &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
-        stream_kind != expected_stream_kind ||
+                           &codec, &streamKind, &codecChecksumEnabled) != 0 ||
+        streamKind != expectedStreamKind ||
         vkcsCodecToCompressionAlgo(codec, &algo) != 0) {
         return -1;
     }
 
     info->compressed = true;
-    info->codec_checksum_enabled = codec_checksum_enabled;
+    info->codec_checksum_enabled = codecChecksumEnabled;
     info->algo = algo;
-    info->stream_kind = stream_kind;
+    info->stream_kind = streamKind;
     return 0;
 }
 
 static void vkcsProbeInit(vkcsProbe *probe) {
     memset(probe, 0, sizeof(*probe));
     probe->algo = ALGO_NONE;
-    probe->codec_checksum_enabled = false;
+    probe->codecChecksumEnabled = false;
 }
 
 /* Probe incrementally because wrapped rios may legally return fewer than
@@ -174,60 +174,60 @@ static void vkcsProbeInit(vkcsProbe *probe) {
 static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
                                          const vkcsProbeConfig *cfg,
                                          const uint8_t *src,
-                                         size_t src_len,
-                                         bool input_eof,
-                                         size_t *src_consumed) {
+                                         size_t srcLen,
+                                         bool inputEof,
+                                         size_t *srcConsumed) {
     size_t consumed = 0;
 
-    *src_consumed = 0;
+    *srcConsumed = 0;
     if (probe->ready) {
         return probe->compressed ? VKCS_PROBE_COMPRESSED : VKCS_PROBE_PASSTHROUGH;
     }
 
-    while (consumed < src_len) {
-        size_t target = probe->header_len < 4 ? 4 : VKCS_ENVELOPE_SIZE;
-        size_t need = target - probe->header_len;
-        size_t take = src_len - consumed < need ? src_len - consumed : need;
+    while (consumed < srcLen) {
+        size_t target = probe->headerLen < 4 ? 4 : VKCS_ENVELOPE_SIZE;
+        size_t need = target - probe->headerLen;
+        size_t take = srcLen - consumed < need ? srcLen - consumed : need;
 
-        memcpy(probe->header + probe->header_len, src + consumed, take);
-        probe->header_len += take;
+        memcpy(probe->header + probe->headerLen, src + consumed, take);
+        probe->headerLen += take;
         consumed += take;
 
-        if (probe->header_len >= 4 &&
+        if (probe->headerLen >= 4 &&
             memcmp(probe->header, "VKCS", 4) != 0) {
-            *src_consumed = consumed;
-            if (!cfg->allow_passthrough) return VKCS_PROBE_ERROR;
+            *srcConsumed = consumed;
+            if (!cfg->allowPassthrough) return VKCS_PROBE_ERROR;
             vkcsProbeSetPassthrough(probe);
             return VKCS_PROBE_PASSTHROUGH;
         }
 
-        if (probe->header_len == VKCS_ENVELOPE_SIZE) {
+        if (probe->headerLen == VKCS_ENVELOPE_SIZE) {
             streamReaderInfo info = {0};
 
-            if (readVkcsEnvelopeInfo(probe->header, cfg->expected_stream_kind, &info) != 0) {
-                *src_consumed = consumed;
+            if (readVkcsEnvelopeInfo(probe->header, cfg->expectedStreamKind, &info) != 0) {
+                *srcConsumed = consumed;
                 return VKCS_PROBE_ERROR;
             }
 
             vkcsProbeSetCompressed(probe, info.algo, info.stream_kind,
                                    info.codec_checksum_enabled);
-            *src_consumed = consumed;
+            *srcConsumed = consumed;
             return VKCS_PROBE_COMPRESSED;
         }
     }
 
-    if (input_eof) {
-        *src_consumed = consumed;
+    if (inputEof) {
+        *srcConsumed = consumed;
         /* If EOF lands in the middle of a potential VKCS header, treat it as
          * a malformed compressed stream rather than silently downgrading it to
          * passthrough mode. */
         if (vkcsProbeHasMagicPrefix(probe)) return VKCS_PROBE_ERROR;
-        if (!cfg->allow_passthrough) return VKCS_PROBE_ERROR;
+        if (!cfg->allowPassthrough) return VKCS_PROBE_ERROR;
         vkcsProbeSetPassthrough(probe);
         return VKCS_PROBE_PASSTHROUGH;
     }
 
-    *src_consumed = consumed;
+    *srcConsumed = consumed;
     return VKCS_PROBE_NEED_INPUT;
 }
 
@@ -238,26 +238,26 @@ static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
 /* Streaming writer context. */
 struct stream_writer {
     streamCompressor compressor;
-    uint8_t *out_buf;     /* Reusable output buffer, sized via streamCompressOutputBound */
-    size_t out_buf_size;  /* Current allocation size of out_buf */
-    vkcsEmitFn emit_cb; /* Returns 0 on success, -1 on error */
-    void *emit_ctx;
-    uint8_t stream_kind; /* Concrete on-wire stream kind */
-    bool envelope_written;
+    uint8_t *outBuf;     /* Reusable output buffer, sized via streamCompressOutputBound */
+    size_t outBufSize;  /* Current allocation size of outBuf */
+    vkcsEmitFn emitCb; /* Returns 0 on success, -1 on error */
+    void *emitCtx;
+    uint8_t streamKind; /* Concrete on-wire stream kind */
+    bool envelopeWritten;
     bool finished;          /* Set by streamWriterFinish — blocks further writes.
                              * Prevents accidental multi-frame output under one envelope. */
     bool errored;           /* Sticky error flag — once set, all writes fail */
-    uint64_t bytes_emitted; /* Running total of bytes successfully emitted */
+    uint64_t bytesEmitted; /* Running total of bytes successfully emitted */
 };
 
 static int streamWriterInitContext(streamWriter *t,
                                    const streamWriterConfig *cfg,
-                                   vkcsEmitFn emit_cb,
-                                   void *emit_ctx) {
+                                   vkcsEmitFn emitCb,
+                                   void *emitCtx) {
     memset(t, 0, sizeof(*t));
-    t->emit_cb = emit_cb;
-    t->emit_ctx = emit_ctx;
-    t->stream_kind = cfg->stream_kind;
+    t->emitCb = emitCb;
+    t->emitCtx = emitCtx;
+    t->streamKind = cfg->stream_kind;
 
     if (streamCompressorInit(&t->compressor, cfg->algo, cfg->level) != 0) {
         return -1;
@@ -269,16 +269,16 @@ static int streamWriterInitContext(streamWriter *t,
 /* Emit envelope lazily on first write/flush/finish.
  * Returns 0 on success, -1 on error (and sets t->errored). */
 static int streamWriterEnsureEnvelope(streamWriter *t) {
-    if (t->envelope_written) return 0;
+    if (t->envelopeWritten) return 0;
     vkcsCodec codec;
     if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
-        writeVkcsEnvelope(t->emit_cb, t->emit_ctx, codec,
-                            t->stream_kind, t->compressor.codec_checksum) != 0) {
+        writeVkcsEnvelope(t->emitCb, t->emitCtx, codec,
+                            t->streamKind, t->compressor.codec_checksum) != 0) {
         t->errored = true;
         return -1;
     }
-    t->bytes_emitted += VKCS_ENVELOPE_SIZE;
-    t->envelope_written = true;
+    t->bytesEmitted += VKCS_ENVELOPE_SIZE;
+    t->envelopeWritten = true;
     return 0;
 }
 
@@ -286,30 +286,30 @@ static int streamWriterEnsureEnvelope(streamWriter *t) {
  * Returns 0 on success, -1 on error (and sets t->errored). */
 static int streamWriterEmit(streamWriter *t, const uint8_t *buf, size_t len) {
     if (len == 0) return 0;
-    if (t->emit_cb(t->emit_ctx, buf, len) != 0) {
+    if (t->emitCb(t->emitCtx, buf, len) != 0) {
         t->errored = true;
         return -1;
     }
-    t->bytes_emitted += len;
+    t->bytesEmitted += len;
     return 0;
 }
 
 /* Ensure the output buffer is large enough for the given input.
  * Reuses the existing buffer when possible to avoid per-write allocation.
  * zmalloc aborts on OOM, so this cannot fail. */
-static void streamWriterEnsureOutBuf(streamWriter *t, size_t input_len) {
-    size_t needed = streamCompressOutputBound(&t->compressor, input_len);
+static void streamWriterEnsureOutBuf(streamWriter *t, size_t inputLen) {
+    size_t needed = streamCompressOutputBound(&t->compressor, inputLen);
     if (needed == 0) {
         /* Ensure a minimal valid buffer so streamCompressFeed never gets NULL. */
-        if (t->out_buf == NULL) {
-            t->out_buf = zmalloc(64);
-            t->out_buf_size = 64;
+        if (t->outBuf == NULL) {
+            t->outBuf = zmalloc(64);
+            t->outBufSize = 64;
         }
         return;
     }
-    if (needed > t->out_buf_size) {
-        t->out_buf = zrealloc(t->out_buf, needed);
-        t->out_buf_size = needed;
+    if (needed > t->outBufSize) {
+        t->outBuf = zrealloc(t->outBuf, needed);
+        t->outBufSize = needed;
     }
 }
 
@@ -317,40 +317,40 @@ static void streamWriterEnsureOutBuf(streamWriter *t, size_t input_len) {
  * Returns 0 on success, -1 on error (and sets t->errored). */
 static int streamWriterFeedAndEmit(streamWriter *t,
                                    const uint8_t *input,
-                                   size_t input_len,
+                                   size_t inputLen,
                                    compressFlushMode flush_mode) {
-    streamWriterEnsureOutBuf(t, input_len);
+    streamWriterEnsureOutBuf(t, inputLen);
 
-    ssize_t compressed = streamCompressFeed(&t->compressor, t->out_buf,
-                                            t->out_buf_size,
-                                            input, input_len, flush_mode);
+    ssize_t compressed = streamCompressFeed(&t->compressor, t->outBuf,
+                                            t->outBufSize,
+                                            input, inputLen, flush_mode);
     if (compressed < 0) {
         t->errored = true;
         return -1;
     }
-    return streamWriterEmit(t, t->out_buf, (size_t)compressed);
+    return streamWriterEmit(t, t->outBuf, (size_t)compressed);
 }
 
 /* Release stream compressor state owned by streamWriter.
  * Does not free the context object itself. */
 static void streamWriterReleaseContext(streamWriter *t) {
     streamCompressorDestroy(&t->compressor);
-    if (t->out_buf) {
-        zfree(t->out_buf);
-        t->out_buf = NULL;
+    if (t->outBuf) {
+        zfree(t->outBuf);
+        t->outBuf = NULL;
     }
-    t->out_buf_size = 0;
+    t->outBufSize = 0;
 }
 
 streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
-                                      vkcsEmitFn emit_cb,
-                                      void *emit_ctx) {
-    if (!cfg || !emit_cb || !compressionAlgoSupportsStreaming(cfg->algo)) {
+                                      vkcsEmitFn emitCb,
+                                      void *emitCtx) {
+    if (!cfg || !emitCb || !compressionAlgoSupportsStreaming(cfg->algo)) {
         return NULL;
     }
 
     streamWriter *t = zmalloc(sizeof(*t));
-    if (streamWriterInitContext(t, cfg, emit_cb, emit_ctx) != 0) {
+    if (streamWriterInitContext(t, cfg, emitCb, emitCtx) != 0) {
         zfree(t);
         return NULL;
     }
@@ -367,22 +367,22 @@ ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len) {
 
     const uint8_t *src = (const uint8_t *)buf;
     size_t remaining = len;
-    uint64_t emitted_before = t->bytes_emitted;
+    uint64_t emittedBefore = t->bytesEmitted;
     if (streamWriterEnsureEnvelope(t) != 0) return -1;
     while (remaining > 0) {
-        size_t chunk_len = remaining < STREAM_WRITER_INPUT_CHUNK_SIZE
+        size_t chunkLen = remaining < STREAM_WRITER_INPUT_CHUNK_SIZE
                                ? remaining
                                : STREAM_WRITER_INPUT_CHUNK_SIZE;
-        if (streamWriterFeedAndEmit(t, src, chunk_len, FLUSH_CONTINUE) != 0) return -1;
-        src += chunk_len;
-        remaining -= chunk_len;
+        if (streamWriterFeedAndEmit(t, src, chunkLen, FLUSH_CONTINUE) != 0) return -1;
+        src += chunkLen;
+        remaining -= chunkLen;
     }
-    uint64_t emitted_delta = t->bytes_emitted - emitted_before;
-    if (emitted_delta > (uint64_t)SSIZE_MAX) {
+    uint64_t emittedDelta = t->bytesEmitted - emittedBefore;
+    if (emittedDelta > (uint64_t)SSIZE_MAX) {
         t->errored = true;
         return -1;
     }
-    return (ssize_t)emitted_delta;
+    return (ssize_t)emittedDelta;
 }
 
 int streamWriterFlush(streamWriter *t) {
@@ -391,7 +391,7 @@ int streamWriterFlush(streamWriter *t) {
     /* Flush-after-finish is a harmless no-op: frame is already closed. */
     if (t->finished) return 0;
 
-    if (!t->envelope_written || !t->compressor.frame_started) return 0;
+    if (!t->envelopeWritten || !t->compressor.frame_started) return 0;
     if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_SYNC) != 0) return -1;
     return 0;
 }
@@ -425,105 +425,105 @@ void streamWriterSetError(streamWriter *t) {
 
 /* Streaming reader context. */
 struct stream_reader {
-    streamReaderReadFn read_cb; /* Returns >0 bytes, 0 EOF, -1 error */
-    void *read_ctx;
+    streamReaderReadFn readCb; /* Returns >0 bytes, 0 EOF, -1 error */
+    void *readCtx;
 
-    vkcsProbeConfig probe_cfg;
+    vkcsProbeConfig probeCfg;
     vkcsProbe probe;
-    size_t probe_replay_pos; /* Unread passthrough bytes buffered by vkcsProbeFeed */
-    size_t buffer_size;
+    size_t probeReplayPos; /* Unread passthrough bytes buffered by vkcsProbeFeed */
+    size_t bufferSize;
     bool errored;
-    streamReaderError error_kind;
+    streamReaderError errorKind;
 
     streamDecompressor decompressor;
-    bool decompressor_initialized;
+    bool decompressorInitialized;
 
-    uint8_t *compressed_buf; /* Buffered compressed input */
-    size_t compressed_buf_pos;
-    size_t compressed_buf_len;
+    uint8_t *compressedBuf; /* Buffered compressed input */
+    size_t compressedBufPos;
+    size_t compressedBufLen;
 
-    uint8_t *decompressed_buf; /* Buffered decompressed output for small caller reads */
-    size_t decompressed_buf_pos;
-    size_t decompressed_buf_len;
+    uint8_t *decompressedBuf; /* Buffered decompressed output for small caller reads */
+    size_t decompressedBufPos;
+    size_t decompressedBufLen;
 };
 
-static void streamReaderSetError(streamReader *t, streamReaderError error_kind) {
+static void streamReaderSetError(streamReader *t, streamReaderError errorKind) {
     t->errored = true;
-    if (t->error_kind == STREAM_READER_ERROR_NONE) {
-        t->error_kind = error_kind;
+    if (t->errorKind == STREAM_READER_ERROR_NONE) {
+        t->errorKind = errorKind;
     }
 }
 
 /* Preserve partial output on read errors while latching sticky error state. */
-static ssize_t streamReaderFail(streamReader *t, size_t partial_bytes) {
+static ssize_t streamReaderFail(streamReader *t, size_t partialBytes) {
     streamReaderSetError(t, STREAM_READER_ERROR_IO);
-    return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
+    return partialBytes > 0 ? (ssize_t)partialBytes : -1;
 }
 
 static ssize_t streamReaderFailWithError(streamReader *t,
-                                         size_t partial_bytes,
-                                         streamReaderError error_kind) {
-    streamReaderSetError(t, error_kind);
-    return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
+                                         size_t partialBytes,
+                                         streamReaderError errorKind) {
+    streamReaderSetError(t, errorKind);
+    return partialBytes > 0 ? (ssize_t)partialBytes : -1;
 }
 
-static int streamReaderInitCompressedState(streamReader *t, size_t buffer_size) {
+static int streamReaderInitCompressedState(streamReader *t, size_t bufferSize) {
     if (streamDecompressorInit(&t->decompressor, t->probe.algo) != 0) {
         return -1;
     }
-    t->decompressor_initialized = true;
+    t->decompressorInitialized = true;
 
-    t->compressed_buf = zmalloc(buffer_size);
-    t->compressed_buf_pos = 0;
-    t->compressed_buf_len = 0;
-    t->decompressed_buf = zmalloc(buffer_size);
-    t->decompressed_buf_pos = 0;
-    t->decompressed_buf_len = 0;
+    t->compressedBuf = zmalloc(bufferSize);
+    t->compressedBufPos = 0;
+    t->compressedBufLen = 0;
+    t->decompressedBuf = zmalloc(bufferSize);
+    t->decompressedBufPos = 0;
+    t->decompressedBufLen = 0;
     return 0;
 }
 
 static void streamReaderResetCompressedState(streamReader *t) {
-    if (t->decompressor_initialized) {
+    if (t->decompressorInitialized) {
         streamDecompressorDestroy(&t->decompressor);
-        t->decompressor_initialized = false;
+        t->decompressorInitialized = false;
     }
-    if (t->compressed_buf) {
-        zfree(t->compressed_buf);
-        t->compressed_buf = NULL;
+    if (t->compressedBuf) {
+        zfree(t->compressedBuf);
+        t->compressedBuf = NULL;
     }
-    t->compressed_buf_pos = 0;
-    t->compressed_buf_len = 0;
-    if (t->decompressed_buf) {
-        zfree(t->decompressed_buf);
-        t->decompressed_buf = NULL;
+    t->compressedBufPos = 0;
+    t->compressedBufLen = 0;
+    if (t->decompressedBuf) {
+        zfree(t->decompressedBuf);
+        t->decompressedBuf = NULL;
     }
-    t->decompressed_buf_pos = 0;
-    t->decompressed_buf_len = 0;
+    t->decompressedBufPos = 0;
+    t->decompressedBufLen = 0;
 }
 
 streamReader *streamReaderCreate(const streamReaderConfig *cfg,
-                                      streamReaderReadFn read_cb,
-                                      void *read_ctx) {
-    if (!read_cb) return NULL;
+                                      streamReaderReadFn readCb,
+                                      void *readCtx) {
+    if (!readCb) return NULL;
     if (!cfg) return NULL;
 
     streamReader *t = zmalloc(sizeof(*t));
     memset(t, 0, sizeof(*t));
-    t->read_cb = read_cb;
-    t->read_ctx = read_ctx;
-    t->probe_cfg.allow_passthrough = cfg->allow_passthrough;
-    t->probe_cfg.expected_stream_kind = cfg->expected_stream_kind;
+    t->readCb = readCb;
+    t->readCtx = readCtx;
+    t->probeCfg.allowPassthrough = cfg->allow_passthrough;
+    t->probeCfg.expectedStreamKind = cfg->expected_stream_kind;
     vkcsProbeInit(&t->probe);
-    t->buffer_size = cfg->buffer_size ? cfg->buffer_size : STREAM_READER_BUFFER_SIZE_DEFAULT;
-    if (t->buffer_size < STREAM_READER_BUFFER_SIZE_MIN) {
-        t->buffer_size = STREAM_READER_BUFFER_SIZE_MIN;
+    t->bufferSize = cfg->buffer_size ? cfg->buffer_size : STREAM_READER_BUFFER_SIZE_DEFAULT;
+    if (t->bufferSize < STREAM_READER_BUFFER_SIZE_MIN) {
+        t->bufferSize = STREAM_READER_BUFFER_SIZE_MIN;
     }
     return t;
 }
 
 static size_t streamReaderProbeBytesNeeded(const streamReader *t) {
-    if (t->probe.header_len < 4) return 4 - t->probe.header_len;
-    return VKCS_ENVELOPE_SIZE - t->probe.header_len;
+    if (t->probe.headerLen < 4) return 4 - t->probe.headerLen;
+    return VKCS_ENVELOPE_SIZE - t->probe.headerLen;
 }
 
 int streamReaderProbe(streamReader *t) {
@@ -534,7 +534,7 @@ int streamReaderProbe(streamReader *t) {
     while (!t->probe.ready) {
         uint8_t buf[VKCS_ENVELOPE_SIZE];
         size_t need = streamReaderProbeBytesNeeded(t);
-        ssize_t got = t->read_cb(t->read_ctx, buf, need);
+        ssize_t got = t->readCb(t->readCtx, buf, need);
         size_t consumed = 0;
 
         if (got < 0 || (size_t)got > need) {
@@ -542,7 +542,7 @@ int streamReaderProbe(streamReader *t) {
             return -1;
         }
 
-        vkcsProbeResult status = vkcsProbeFeed(&t->probe, &t->probe_cfg, buf,
+        vkcsProbeResult status = vkcsProbeFeed(&t->probe, &t->probeCfg, buf,
                                                    got > 0 ? (size_t)got : 0,
                                                    got == 0, &consumed);
         if (status == VKCS_PROBE_ERROR) {
@@ -555,8 +555,8 @@ int streamReaderProbe(streamReader *t) {
         }
         if (status == VKCS_PROBE_NEED_INPUT) continue;
         if (status == VKCS_PROBE_COMPRESSED &&
-            !t->decompressor_initialized &&
-            streamReaderInitCompressedState(t, t->buffer_size) != 0) {
+            !t->decompressorInitialized &&
+            streamReaderInitCompressedState(t, t->bufferSize) != 0) {
             streamReaderSetError(t, STREAM_READER_ERROR_IO);
             return -1;
         }
@@ -566,8 +566,8 @@ int streamReaderProbe(streamReader *t) {
 }
 
 static size_t streamReaderProbeAvail(const streamReader *t) {
-    if (t->probe.header_len <= t->probe_replay_pos) return 0;
-    return t->probe.header_len - t->probe_replay_pos;
+    if (t->probe.headerLen <= t->probeReplayPos) return 0;
+    return t->probe.headerLen - t->probeReplayPos;
 }
 
 /* Passthrough reads may need to replay probe bytes before reading directly
@@ -581,8 +581,8 @@ static ssize_t streamReaderReadPassthrough(streamReader *t,
     size_t prefix_avail = streamReaderProbeAvail(t);
     if (prefix_avail > 0) {
         size_t from_prefix = prefix_avail < len ? prefix_avail : len;
-        memcpy(dst, t->probe.header + t->probe_replay_pos, from_prefix);
-        t->probe_replay_pos += from_prefix;
+        memcpy(dst, t->probe.header + t->probeReplayPos, from_prefix);
+        t->probeReplayPos += from_prefix;
         dst += from_prefix;
         len -= from_prefix;
         total += from_prefix;
@@ -590,7 +590,7 @@ static ssize_t streamReaderReadPassthrough(streamReader *t,
 
     if (len == 0) return (ssize_t)total;
 
-    ssize_t got = t->read_cb(t->read_ctx, dst, len);
+    ssize_t got = t->readCb(t->readCtx, dst, len);
     if (got < 0 || (size_t)got > len) return streamReaderFail(t, total);
     return (ssize_t)(total + (size_t)got);
 }
@@ -600,44 +600,44 @@ static int streamReaderDrainCompressedBuf(streamReader *t,
                                           size_t out_size,
                                           size_t *out_written) {
     *out_written = 0;
-    while (t->compressed_buf_len > 0 && *out_written < out_size) {
+    while (t->compressedBufLen > 0 && *out_written < out_size) {
         size_t consumed = 0;
         ssize_t produced = streamDecompressFeed(
             &t->decompressor,
             out + *out_written, out_size - *out_written,
-            t->compressed_buf + t->compressed_buf_pos,
-            t->compressed_buf_len, &consumed);
+            t->compressedBuf + t->compressedBufPos,
+            t->compressedBufLen, &consumed);
         if (produced < 0) {
             streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
             return -1;
         }
-        if (consumed > t->compressed_buf_len ||
+        if (consumed > t->compressedBufLen ||
             (size_t)produced > out_size - *out_written) {
             streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
             return -1;
         }
         *out_written += (size_t)produced;
-        t->compressed_buf_pos += consumed;
-        t->compressed_buf_len -= consumed;
+        t->compressedBufPos += consumed;
+        t->compressedBufLen -= consumed;
         if (consumed == 0 && produced == 0) break;
     }
-    if (t->compressed_buf_len == 0) t->compressed_buf_pos = 0;
+    if (t->compressedBufLen == 0) t->compressedBufPos = 0;
     return 0;
 }
 
 static size_t streamReaderCompressedBufTailSpace(streamReader *t) {
-    size_t tail_space = t->buffer_size - t->compressed_buf_pos - t->compressed_buf_len;
+    size_t tail_space = t->bufferSize - t->compressedBufPos - t->compressedBufLen;
     if (tail_space > 0) return tail_space;
 
-    if (t->compressed_buf_len == 0) {
-        t->compressed_buf_pos = 0;
-        return t->buffer_size;
+    if (t->compressedBufLen == 0) {
+        t->compressedBufPos = 0;
+        return t->bufferSize;
     }
 
-    if (t->compressed_buf_pos > 0) {
-        memmove(t->compressed_buf, t->compressed_buf + t->compressed_buf_pos, t->compressed_buf_len);
-        t->compressed_buf_pos = 0;
-        return t->buffer_size - t->compressed_buf_len;
+    if (t->compressedBufPos > 0) {
+        memmove(t->compressedBuf, t->compressedBuf + t->compressedBufPos, t->compressedBufLen);
+        t->compressedBufPos = 0;
+        return t->bufferSize - t->compressedBufLen;
     }
 
     /* The generic stream reader intentionally keeps a fixed-size compressed
@@ -653,33 +653,33 @@ static int streamReaderRefillCompressedBuf(streamReader *t) {
     if (read_size > (size_t)SSIZE_MAX) read_size = (size_t)SSIZE_MAX;
     if (read_size == 0) return -1;
 
-    ssize_t got = t->read_cb(
-        t->read_ctx,
-        t->compressed_buf + t->compressed_buf_pos + t->compressed_buf_len,
+    ssize_t got = t->readCb(
+        t->readCtx,
+        t->compressedBuf + t->compressedBufPos + t->compressedBufLen,
         read_size);
     if (got < 0) return -1;
     if (got == 0) return 0;
     if ((size_t)got > read_size) return -1;
-    t->compressed_buf_len += (size_t)got;
+    t->compressedBufLen += (size_t)got;
     return 1;
 }
 
 static ssize_t streamReaderFillDecompressedBuf(streamReader *t) {
     size_t written = 0;
 
-    t->decompressed_buf_pos = 0;
-    t->decompressed_buf_len = 0;
+    t->decompressedBufPos = 0;
+    t->decompressedBufLen = 0;
 
-    while (written < t->buffer_size) {
-        if (t->compressed_buf_len > 0) {
+    while (written < t->bufferSize) {
+        if (t->compressedBufLen > 0) {
             size_t chunk_written = 0;
-            if (streamReaderDrainCompressedBuf(t, t->decompressed_buf + written,
-                                               t->buffer_size - written, &chunk_written) != 0) {
+            if (streamReaderDrainCompressedBuf(t, t->decompressedBuf + written,
+                                               t->bufferSize - written, &chunk_written) != 0) {
                 written += chunk_written;
                 break;
             }
             written += chunk_written;
-            if (written >= t->buffer_size) break;
+            if (written >= t->bufferSize) break;
         }
 
         int read_rc = streamReaderRefillCompressedBuf(t);
@@ -691,13 +691,13 @@ static ssize_t streamReaderFillDecompressedBuf(streamReader *t) {
         if (read_rc == 0) break;
     }
 
-    t->decompressed_buf_len = written;
+    t->decompressedBufLen = written;
     return (ssize_t)written;
 }
 
 static inline size_t streamReaderDecompressedBufAvail(const streamReader *t) {
-    if (t->decompressed_buf_len <= t->decompressed_buf_pos) return 0;
-    return t->decompressed_buf_len - t->decompressed_buf_pos;
+    if (t->decompressedBufLen <= t->decompressedBufPos) return 0;
+    return t->decompressedBufLen - t->decompressedBufPos;
 }
 
 static size_t streamReaderCopyFromDecompressedBuf(streamReader *t,
@@ -707,8 +707,8 @@ static size_t streamReaderCopyFromDecompressedBuf(streamReader *t,
     if (avail == 0 || *remaining == 0) return 0;
 
     size_t to_copy = avail < *remaining ? avail : *remaining;
-    memcpy(*dst, t->decompressed_buf + t->decompressed_buf_pos, to_copy);
-    t->decompressed_buf_pos += to_copy;
+    memcpy(*dst, t->decompressedBuf + t->decompressedBufPos, to_copy);
+    t->decompressedBufPos += to_copy;
     *dst += to_copy;
     *remaining -= to_copy;
     return to_copy;
@@ -725,8 +725,8 @@ static ssize_t streamReaderReadCompressed(streamReader *t, uint8_t *dst, size_t 
             if (filled < 0) {
                 return streamReaderFailWithError(
                     t, total,
-                    t->error_kind == STREAM_READER_ERROR_NONE ? STREAM_READER_ERROR_IO
-                                                              : t->error_kind);
+                    t->errorKind == STREAM_READER_ERROR_NONE ? STREAM_READER_ERROR_IO
+                                                              : t->errorKind);
             }
             if (filled == 0 && !t->decompressor.frame_done) {
                 return streamReaderFailWithError(t, total, STREAM_READER_ERROR_CORRUPT);
@@ -761,14 +761,14 @@ int streamReaderGetInfo(streamReader *t, streamReaderInfo *info) {
     if (streamReaderProbe(t) != 0) return -1;
 
     info->compressed = t->probe.compressed;
-    info->codec_checksum_enabled = t->probe.compressed ? t->probe.codec_checksum_enabled : false;
+    info->codec_checksum_enabled = t->probe.compressed ? t->probe.codecChecksumEnabled : false;
     info->algo = t->probe.compressed ? t->probe.algo : ALGO_NONE;
-    info->stream_kind = t->probe.stream_kind;
+    info->stream_kind = t->probe.streamKind;
     return 0;
 }
 
 streamReaderError streamReaderGetError(const streamReader *t) {
-    return t ? t->error_kind : STREAM_READER_ERROR_IO;
+    return t ? t->errorKind : STREAM_READER_ERROR_IO;
 }
 
 void streamReaderDestroy(streamReader *t) {

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -85,48 +85,48 @@ typedef ssize_t (*streamReaderReadFn)(void *ctx, void *buf, size_t len);
  * Ownership: returned context is owned by caller and must be destroyed.
  * Threading: streamWriter is NOT thread-safe; all API calls on a given
  * instance must be externally serialized and single-owner at any instant. */
-streamWriter *stream_writer_create(const streamWriterConfig *cfg,
+streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
                                       vkcsEmitFn emit_cb,
                                       void *emit_ctx);
 /* Returns emitted bytes for this call (>=0), -1 on error.
  * NOTE: the return value is the number of *compressed* bytes emitted to the
  * output sink, NOT the number of input bytes consumed (which is always `len`
  * on success). Callers that need to track input progress should use `len`.
- * After stream_writer_finish(), write returns -1 and does not emit bytes. */
-ssize_t stream_writer_write(streamWriter *t, const void *buf, size_t len);
+ * After streamWriterFinish(), write returns -1 and does not emit bytes. */
+ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len);
 /* Returns 0 on success, -1 on error.
  * Flush-after-finish is a no-op success. */
-int stream_writer_flush(streamWriter *t);
+int streamWriterFlush(streamWriter *t);
 /* Returns 0 on success, -1 on error.
  * Calling finish more than once is a no-op success. */
-int stream_writer_finish(streamWriter *t);
-void stream_writer_destroy(streamWriter *t);
+int streamWriterFinish(streamWriter *t);
+void streamWriterDestroy(streamWriter *t);
 /* Snapshot only; cross-thread readers must synchronize externally
  * (for example via waitForClientIO-equivalent quiesce). */
-int stream_writer_is_errored(const streamWriter *t);
-void stream_writer_set_error(streamWriter *t);
+int streamWriterIsErrored(const streamWriter *t);
+void streamWriterSetError(streamWriter *t);
 
 /* Streaming reader API.
  * Ownership: returned context is owned by caller and must be destroyed. */
-streamReader *stream_reader_create(const streamReaderConfig *cfg,
+streamReader *streamReaderCreate(const streamReaderConfig *cfg,
                                       streamReaderReadFn read_cb,
                                       void *read_ctx);
 /* Ensure stream mode is detected and metadata is available.
  * Safe to call more than once.
  * Returns 0 on success, -1 on error. */
-int stream_reader_probe(streamReader *t);
+int streamReaderProbe(streamReader *t);
 /* Read up to len bytes into buf.
  * len must fit in ssize_t; larger requests return -1 without consuming input.
  * Returns:
  * - >0: bytes produced (decompressed or passthrough)
  * -  0: EOF
  * - -1: error */
-ssize_t stream_reader_read(streamReader *t, void *buf, size_t len);
+ssize_t streamReaderRead(streamReader *t, void *buf, size_t len);
 /* Populate stream metadata after probing.
  * For passthrough streams: compressed=0, algo=ALGO_NONE, stream_kind=0.
  * Returns 0 on success, -1 on error. */
-int stream_reader_get_info(streamReader *t, streamReaderInfo *info);
-streamReaderError stream_reader_get_error(const streamReader *t);
-void stream_reader_destroy(streamReader *t);
+int streamReaderGetInfo(streamReader *t, streamReaderInfo *info);
+streamReaderError streamReaderGetError(const streamReader *t);
+void streamReaderDestroy(streamReader *t);
 
 #endif /* COMPRESSION_STREAM_H */

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -21,10 +21,10 @@
 
 typedef enum {
     VKCS_CODEC_LZ4 = 0x01,
-} vkcs_codec_t;
+} vkcsCodec;
 
 /* Emit callback used by the VKCS envelope and streaming writer. */
-typedef int (*vkcs_emit_fn)(void *ctx, const uint8_t *data, size_t len);
+typedef int (*vkcsEmitFn)(void *ctx, const uint8_t *data, size_t len);
 
 /* Default fixed buffer size for stream_reader when cfg->buffer_size == 0.
  * The reader uses one compressed input buffer and one decompressed output
@@ -36,11 +36,11 @@ typedef int (*vkcs_emit_fn)(void *ctx, const uint8_t *data, size_t len);
 
 /* Streaming writer config. */
 typedef struct {
-    compression_algo_t algo;     /* Compression algorithm for this stream. */
+    compressionAlgo algo;     /* Compression algorithm for this stream. */
     int level;                   /* Codec-specific compression level; ignored when unsupported. */
     uint8_t stream_kind;         /* Application-defined stream kind stored in the VKCS envelope. */
     bool codec_checksum_enabled; /* Enable codec-native integrity checks when supported. */
-} stream_writer_config_t;
+} streamWriterConfig;
 
 /* Streaming reader config.
  * - auto-detect VKCS envelope, decode if compressed
@@ -52,81 +52,81 @@ typedef struct {
     uint8_t expected_stream_kind; /* Required VKCS stream kind when the input is compressed. */
     bool allow_passthrough;       /* true => non-VKCS input is treated as raw bytes instead of an error. */
     size_t buffer_size;           /* Fixed compressed input buffer and decompressed output window size; 0 => internal default. */
-} stream_reader_config_t;
+} streamReaderConfig;
 
 /* Opaque streaming writer context. */
-typedef struct stream_writer stream_writer_t;
+typedef struct stream_writer streamWriter;
 /* Opaque streaming reader context. */
-typedef struct stream_reader stream_reader_t;
+typedef struct stream_reader streamReader;
 
 /* Stream metadata returned after probing. */
 typedef struct {
     bool compressed;             /* true => input was classified as VKCS-compressed, false => passthrough. */
     bool codec_checksum_enabled; /* Parsed VKCS checksum policy. Ignore when compressed is false. */
-    compression_algo_t algo;     /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
+    compressionAlgo algo;     /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
     uint8_t stream_kind;         /* Parsed VKCS stream kind. Ignore when compressed is false. */
-} stream_reader_info_t;
+} streamReaderInfo;
 
 typedef enum {
     STREAM_READER_ERROR_NONE = 0,
     STREAM_READER_ERROR_IO = 1,
     STREAM_READER_ERROR_INCOMPATIBLE = 2,
     STREAM_READER_ERROR_CORRUPT = 3,
-} stream_reader_error_t;
+} streamReaderError;
 
 /* Caller-provided input callback.
  * Returns:
  * - >0: bytes read into buf (partial reads allowed)
  * -  0: EOF
  * - -1: read error */
-typedef ssize_t (*stream_reader_read_fn)(void *ctx, void *buf, size_t len);
+typedef ssize_t (*streamReaderReadFn)(void *ctx, void *buf, size_t len);
 
 /* Streaming writer API.
  * Ownership: returned context is owned by caller and must be destroyed.
- * Threading: stream_writer_t is NOT thread-safe; all API calls on a given
+ * Threading: streamWriter is NOT thread-safe; all API calls on a given
  * instance must be externally serialized and single-owner at any instant. */
-stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
-                                      vkcs_emit_fn emit_cb,
+streamWriter *stream_writer_create(const streamWriterConfig *cfg,
+                                      vkcsEmitFn emit_cb,
                                       void *emit_ctx);
 /* Returns emitted bytes for this call (>=0), -1 on error.
  * NOTE: the return value is the number of *compressed* bytes emitted to the
  * output sink, NOT the number of input bytes consumed (which is always `len`
  * on success). Callers that need to track input progress should use `len`.
  * After stream_writer_finish(), write returns -1 and does not emit bytes. */
-ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len);
+ssize_t stream_writer_write(streamWriter *t, const void *buf, size_t len);
 /* Returns 0 on success, -1 on error.
  * Flush-after-finish is a no-op success. */
-int stream_writer_flush(stream_writer_t *t);
+int stream_writer_flush(streamWriter *t);
 /* Returns 0 on success, -1 on error.
  * Calling finish more than once is a no-op success. */
-int stream_writer_finish(stream_writer_t *t);
-void stream_writer_destroy(stream_writer_t *t);
+int stream_writer_finish(streamWriter *t);
+void stream_writer_destroy(streamWriter *t);
 /* Snapshot only; cross-thread readers must synchronize externally
  * (for example via waitForClientIO-equivalent quiesce). */
-int stream_writer_is_errored(const stream_writer_t *t);
-void stream_writer_set_error(stream_writer_t *t);
+int stream_writer_is_errored(const streamWriter *t);
+void stream_writer_set_error(streamWriter *t);
 
 /* Streaming reader API.
  * Ownership: returned context is owned by caller and must be destroyed. */
-stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
-                                      stream_reader_read_fn read_cb,
+streamReader *stream_reader_create(const streamReaderConfig *cfg,
+                                      streamReaderReadFn read_cb,
                                       void *read_ctx);
 /* Ensure stream mode is detected and metadata is available.
  * Safe to call more than once.
  * Returns 0 on success, -1 on error. */
-int stream_reader_probe(stream_reader_t *t);
+int stream_reader_probe(streamReader *t);
 /* Read up to len bytes into buf.
  * len must fit in ssize_t; larger requests return -1 without consuming input.
  * Returns:
  * - >0: bytes produced (decompressed or passthrough)
  * -  0: EOF
  * - -1: error */
-ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len);
+ssize_t stream_reader_read(streamReader *t, void *buf, size_t len);
 /* Populate stream metadata after probing.
  * For passthrough streams: compressed=0, algo=ALGO_NONE, stream_kind=0.
  * Returns 0 on success, -1 on error. */
-int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info);
-stream_reader_error_t stream_reader_get_error(const stream_reader_t *t);
-void stream_reader_destroy(stream_reader_t *t);
+int stream_reader_get_info(streamReader *t, streamReaderInfo *info);
+streamReaderError stream_reader_get_error(const streamReader *t);
+void stream_reader_destroy(streamReader *t);
 
 #endif /* COMPRESSION_STREAM_H */

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -36,7 +36,7 @@ typedef int (*vkcsEmitFn)(void *ctx, const uint8_t *data, size_t len);
 
 /* Streaming writer config. */
 typedef struct {
-    compressionAlgo algo;     /* Compression algorithm for this stream. */
+    compressionAlgo algo;        /* Compression algorithm for this stream. */
     int level;                   /* Codec-specific compression level; ignored when unsupported. */
     uint8_t stream_kind;         /* Application-defined stream kind stored in the VKCS envelope. */
     bool codec_checksum_enabled; /* Enable codec-native integrity checks when supported. */
@@ -63,7 +63,7 @@ typedef struct stream_reader streamReader;
 typedef struct {
     bool compressed;             /* true => input was classified as VKCS-compressed, false => passthrough. */
     bool codec_checksum_enabled; /* Parsed VKCS checksum policy. Ignore when compressed is false. */
-    compressionAlgo algo;     /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
+    compressionAlgo algo;        /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
     uint8_t stream_kind;         /* Parsed VKCS stream kind. Ignore when compressed is false. */
 } streamReaderInfo;
 
@@ -86,8 +86,8 @@ typedef ssize_t (*streamReaderReadFn)(void *ctx, void *buf, size_t len);
  * Threading: streamWriter is NOT thread-safe; all API calls on a given
  * instance must be externally serialized and single-owner at any instant. */
 streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
-                                      vkcsEmitFn emit_cb,
-                                      void *emit_ctx);
+                                 vkcsEmitFn emit_cb,
+                                 void *emit_ctx);
 /* Returns emitted bytes for this call (>=0), -1 on error.
  * NOTE: the return value is the number of *compressed* bytes emitted to the
  * output sink, NOT the number of input bytes consumed (which is always `len`
@@ -109,8 +109,8 @@ void streamWriterSetError(streamWriter *t);
 /* Streaming reader API.
  * Ownership: returned context is owned by caller and must be destroyed. */
 streamReader *streamReaderCreate(const streamReaderConfig *cfg,
-                                      streamReaderReadFn read_cb,
-                                      void *read_ctx);
+                                 streamReaderReadFn read_cb,
+                                 void *read_ctx);
 /* Ensure stream mode is detected and metadata is available.
  * Safe to call more than once.
  * Returns 0 on success, -1 on error. */

--- a/src/config.c
+++ b/src/config.c
@@ -3286,7 +3286,7 @@ static int validateRdbCompressionSettings(const char **err) {
 }
 
 static int validateRdbCompressionSettingsFinal(const char **err) {
-    if (!compressionAlgoSupportsLevel((compression_algo_t)server.rdb_compression_algo) &&
+    if (!compressionAlgoSupportsLevel((compressionAlgo)server.rdb_compression_algo) &&
         server.rdb_compression_level != RDB_COMPRESSION_LEVEL_DEFAULT) {
         *err = "rdb-compression-level is supported only for compression algorithms that accept a level (currently: lz4)";
         return 0;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -72,7 +72,7 @@
 /* Returns true if streaming compression is enabled for RDB saves. */
 static inline bool isRdbStreamingCompressionEnabled(void) {
     return server.rdb_compression &&
-           compressionAlgoSupportsStreaming((compression_algo_t)server.rdb_compression_algo);
+           compressionAlgoSupportsStreaming((compressionAlgo)server.rdb_compression_algo);
 }
 
 /* This macro tells if we are in the context of a RESTORE command, and not loading an RDB or AOF. */
@@ -1571,7 +1571,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     int saved_errno;
     char *err_op; /* For a detailed log */
     bool use_streaming_compression = isRdbStreamingCompressionEnabled();
-    compress_rio_t cr;
+    compressRio cr;
     bool cr_initialized = false;
 
     FILE *fp = fopen(filename, "w");
@@ -1596,12 +1596,12 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     }
 
     /* When streaming compression is enabled, wrap the file rio with
-     * compress_rio_t. rdbSaveRio writes through the compressor transparently.
+     * compressRio. rdbSaveRio writes through the compressor transparently.
      * Per-string LZF is already disabled in rdbSaveRawString when algo != LZF. */
     rio *save_rio = &rdb;
     if (use_streaming_compression) {
-        stream_writer_config_t cfg = {
-            .algo = (compression_algo_t)server.rdb_compression_algo,
+        streamWriterConfig cfg = {
+            .algo = (compressionAlgo)server.rdb_compression_algo,
             .level = server.rdb_compression_level,
             .stream_kind = STREAM_KIND_RDB,
             .codec_checksum_enabled = server.rdb_checksum != 0,
@@ -1724,7 +1724,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
     serverLog(LL_NOTICE, "DB saved on disk");
     if (isRdbStreamingCompressionEnabled()) {
         serverLog(LL_VERBOSE, "RDB saved with %s streaming compression",
-                  compressionAlgoName((compression_algo_t)server.rdb_compression_algo));
+                  compressionAlgoName((compressionAlgo)server.rdb_compression_algo));
     }
     server.dirty = 0;
     server.lastsave = time(NULL);
@@ -3150,8 +3150,8 @@ void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio) {
     input->rdb_rio = raw_rio;
 }
 
-decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input) {
-    stream_reader_config_t reader_cfg = {
+decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
+    streamReaderConfig reader_cfg = {
         .expected_stream_kind = STREAM_KIND_RDB,
         .allow_passthrough = true,
         .buffer_size = 0,
@@ -3159,7 +3159,7 @@ decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input) {
 
     if (!input || !input->raw_rio) return DECOMPRESS_RIO_INIT_ERROR;
 
-    decompress_rio_init_result_t init_rc =
+    decompressRioInitResult init_rc =
         rioInitWithDecompress(&input->decompressor, input->raw_rio, &reader_cfg, &input->stream_info);
     if (init_rc == DECOMPRESS_RIO_INIT_OK) {
         input->initialized = true;
@@ -3179,7 +3179,7 @@ void rdbInputStreamDestroy(rdbInputStream *input) {
 
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
     return (rdb->flags & RIO_FLAG_STREAMING_DECOMPRESSION) &&
-           decompress_rio_get_error((const decompress_rio_t *)rdb) == STREAM_READER_ERROR_CORRUPT;
+           decompress_rio_get_error((const decompressRio *)rdb) == STREAM_READER_ERROR_CORRUPT;
 }
 
 /* Save the given functions_ctx to the rdb.
@@ -3745,7 +3745,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     rioInitWithFile(&rdb, fp);
     rdbInputStreamInit(&input, &rdb);
 
-    decompress_rio_init_result_t init_rc = rdbInputStreamPrepare(&input);
+    decompressRioInitResult init_rc = rdbInputStreamPrepare(&input);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         serverLog(LL_WARNING, "Invalid RDB stream envelope in %s", filename);
         retval = RDB_INCOMPATIBLE;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1628,14 +1628,14 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
 
     /* Finalize the compression frame before flushing to disk. */
     if (cr_initialized) {
-        if (compress_rio_finish(&cr) != 0) {
+        if (compressRioFinish(&cr) != 0) {
             errno = EIO; /* Compression finalization failure */
-            err_op = "compress_rio_finish";
-            compress_rio_destroy(&cr);
+            err_op = "compressRioFinish";
+            compressRioDestroy(&cr);
             cr_initialized = false;
             goto werr;
         }
-        compress_rio_destroy(&cr);
+        compressRioDestroy(&cr);
         cr_initialized = false;
     }
 
@@ -1665,7 +1665,7 @@ werr:
     if (cr_initialized) {
         /* Skip finish on error — output is being discarded (unlink below).
          * Just release resources. */
-        compress_rio_destroy(&cr);
+        compressRioDestroy(&cr);
     }
     if (fp) fclose(fp);
     unlink(filename);
@@ -3171,7 +3171,7 @@ decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
 void rdbInputStreamDestroy(rdbInputStream *input) {
     if (!input) return;
     if (input->initialized) {
-        decompress_rio_destroy(&input->decompressor);
+        decompressRioDestroy(&input->decompressor);
         input->initialized = false;
     }
     input->rdb_rio = input->raw_rio;
@@ -3179,7 +3179,7 @@ void rdbInputStreamDestroy(rdbInputStream *input) {
 
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
     return (rdb->flags & RIO_FLAG_STREAMING_DECOMPRESSION) &&
-           decompress_rio_get_error((const decompressRio *)rdb) == STREAM_READER_ERROR_CORRUPT;
+           decompressRioGetError((const decompressRio *)rdb) == STREAM_READER_ERROR_CORRUPT;
 }
 
 /* Save the given functions_ctx to the rdb.

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -203,8 +203,8 @@ enum RdbType {
 typedef struct {
     rio *raw_rio;
     rio *rdb_rio;
-    decompress_rio_t decompressor;
-    stream_reader_info_t stream_info;
+    decompressRio decompressor;
+    streamReaderInfo stream_info;
     bool initialized;
 } rdbInputStream;
 
@@ -244,7 +244,7 @@ int rdbLoadBinaryFloatValue(rio *rdb, float *val);
 int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtxScopedRdb(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
 void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
-decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input);
+decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input);
 void rdbInputStreamDestroy(rdbInputStream *input);
 bool rdbRioHasCorruptCompressedInput(const rio *rdb);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, sds *err);

--- a/src/server.h
+++ b/src/server.h
@@ -2053,7 +2053,7 @@ struct valkeyServer {
     int saveparamslen;                    /* Number of saving points */
     char *rdb_filename;                   /* Name of RDB file */
     int rdb_compression;                  /* Use compression in RDB? */
-    int rdb_compression_algo;             /* RDB compression algorithm (compression_algo_t):
+    int rdb_compression_algo;             /* RDB compression algorithm (compressionAlgo):
                                            * ALGO_LZF (default), ALGO_LZ4 */
     int rdb_compression_level;            /* Compression level for streaming RDB codecs that support one. */
     int rdb_checksum;                     /* Use RDB checksum? */

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -398,30 +398,30 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
         mr.len = cases[i].input_len;
         mr.max_chunk = cases[i].max_chunk;
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
-        streamReader *t = stream_reader_create(&cfg, memReaderRead, &mr);
+        streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
         ASSERT_TRUE(t != NULL) << cases[i].name;
 
         streamReaderInfo info;
         if (cases[i].expect_probe_ok) {
-            ASSERT_TRUE(stream_reader_probe(t) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(t, &info) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(t) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(t, &info) == 0) << cases[i].name;
             ASSERT_TRUE(info.compressed == 0) << cases[i].name;
 
             uint8_t out[16] = {0};
-            ASSERT_TRUE(stream_reader_read(t, out, cases[i].expected_read_len) == (ssize_t)cases[i].expected_read_len)
+            ASSERT_TRUE(streamReaderRead(t, out, cases[i].expected_read_len) == (ssize_t)cases[i].expected_read_len)
                 << cases[i].name;
             ASSERT_TRUE(memcmp(out, cases[i].input, cases[i].expected_read_len) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_read(t, out, sizeof(out)) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == 0) << cases[i].name;
         } else {
-            ASSERT_TRUE(stream_reader_probe(t) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(t, &info) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_error(t) == cases[i].expected_error) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(t) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(t, &info) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetError(t) == cases[i].expected_error) << cases[i].name;
 
             uint8_t out[8] = {0};
-            ASSERT_TRUE(stream_reader_read(t, out, sizeof(out)) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == -1) << cases[i].name;
         }
 
-        stream_reader_destroy(t);
+        streamReaderDestroy(t);
     }
     return;
 }
@@ -434,23 +434,23 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
     mr.max_chunk = 2;
     streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
 
-    streamReader *t = stream_reader_create(&cfg, memReaderRead, &mr);
-    ASSERT_TRUE(t != NULL) << "stream_reader_create should succeed";
+    streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
+    ASSERT_TRUE(t != NULL) << "streamReaderCreate should succeed";
 
     uint8_t out[8] = {0};
     size_t oversized = (size_t)std::numeric_limits<ssize_t>::max() + 1;
-    ASSERT_TRUE(stream_reader_read(t, out, oversized) == -1)
+    ASSERT_TRUE(streamReaderRead(t, out, oversized) == -1)
         << "oversized reads should fail before touching stream state";
 
     streamReaderInfo info;
-    ASSERT_TRUE(stream_reader_get_info(t, &info) == 0)
+    ASSERT_TRUE(streamReaderGetInfo(t, &info) == 0)
         << "oversized read failure should not poison the reader";
     ASSERT_TRUE(info.compressed == 0) << "plain input should still probe as passthrough";
 
-    ASSERT_TRUE(stream_reader_read(t, out, sizeof(input)) == (ssize_t)sizeof(input));
+    ASSERT_TRUE(streamReaderRead(t, out, sizeof(input)) == (ssize_t)sizeof(input));
     ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
 
-    stream_reader_destroy(t);
+    streamReaderDestroy(t);
     return;
 }
 
@@ -533,42 +533,42 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
         dynamicBufInit(&db);
 
         streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
-        streamWriter *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+        streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(w != NULL) << cases[i].name;
-        ASSERT_TRUE(stream_writer_write(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
-        ASSERT_TRUE(stream_writer_finish(w) == 0) << cases[i].name;
-        stream_writer_destroy(w);
+        ASSERT_TRUE(streamWriterWrite(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
+        ASSERT_TRUE(streamWriterFinish(w) == 0) << cases[i].name;
+        streamWriterDestroy(w);
 
         mem_reader_t mr = {};
         mr.data = db.data;
         mr.len = sdslen((const char *)db.data);
         mr.max_chunk = cases[i].max_chunk;
         streamReaderConfig rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
-        streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+        streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
         ASSERT_TRUE(r != NULL) << cases[i].name;
 
         streamReaderInfo info;
         if (cases[i].expect_ok) {
-            ASSERT_TRUE(stream_reader_probe(r) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(r, &info) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(r) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(r, &info) == 0) << cases[i].name;
             ASSERT_TRUE(info.compressed) << cases[i].name;
             ASSERT_TRUE(info.algo == ALGO_LZ4) << cases[i].name;
             ASSERT_TRUE(info.stream_kind == cases[i].expected_kind) << cases[i].name;
 
             uint8_t out[64] = {0};
-            ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len) << cases[i].name;
             ASSERT_TRUE(memcmp(out, cases[i].payload, payload_len) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0) << cases[i].name;
         } else {
-            ASSERT_TRUE(stream_reader_probe(r) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(r, &info) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_error(r) == STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(r) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(r, &info) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetError(r) == STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
 
             uint8_t out[32] = {0};
-            ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == -1) << cases[i].name;
         }
 
-        stream_reader_destroy(r);
+        streamReaderDestroy(r);
         dynamicBufFree(&db);
     }
     return;
@@ -591,11 +591,11 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL) << "stream_writer_create should succeed";
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL) << "streamWriterCreate should succeed";
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     flaky_reader_t fr = {};
     fr.data = db.data;
@@ -605,17 +605,17 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
      * output with an 8 KB window, but not enough to satisfy the full request. */
     fr.fail_after_success_reads = 3;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
-    streamReader *r = stream_reader_create(&rcfg, flakyReaderRead, &fr);
-    ASSERT_TRUE(r != NULL) << "stream_reader_create should succeed";
+    streamReader *r = streamReaderCreate(&rcfg, flakyReaderRead, &fr);
+    ASSERT_TRUE(r != NULL) << "streamReaderCreate should succeed";
 
     const size_t out_len = 16 * 1024;
     uint8_t *out = (uint8_t *)zmalloc(out_len);
     ASSERT_TRUE(out != NULL);
-    ssize_t n1 = stream_reader_read(r, out, out_len);
+    ssize_t n1 = streamReaderRead(r, out, out_len);
     ASSERT_TRUE(n1 > 0) << "first read should return partial output";
-    ASSERT_TRUE(stream_reader_read(r, out, out_len) == -1) << "second read should fail immediately";
+    ASSERT_TRUE(streamReaderRead(r, out, out_len) == -1) << "second read should fail immediately";
 
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
 
     /* Passthrough mode should also preserve partial bytes when source read
      * fails after probe/prefix buffering, then latch sticky error state. */
@@ -626,15 +626,15 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     fr_passthrough.max_chunk = 0;
     fr_passthrough.fail_after_success_reads = 1; /* probe succeeds, next read fails */
     streamReaderConfig pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-    streamReader *rp = stream_reader_create(&pass_cfg, flakyReaderRead, &fr_passthrough);
+    streamReader *rp = streamReaderCreate(&pass_cfg, flakyReaderRead, &fr_passthrough);
     ASSERT_TRUE(rp != NULL) << "passthrough reader create should succeed";
 
     uint8_t pass_out[64];
-    ssize_t p1 = stream_reader_read(rp, pass_out, sizeof(pass_out));
+    ssize_t p1 = streamReaderRead(rp, pass_out, sizeof(pass_out));
     ASSERT_TRUE(p1 > 0) << "passthrough first read should return partial output";
     ASSERT_TRUE(memcmp(pass_out, plain, (size_t)p1) == 0) << "passthrough partial bytes should match input prefix";
-    ASSERT_TRUE(stream_reader_read(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
-    stream_reader_destroy(rp);
+    ASSERT_TRUE(streamReaderRead(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
+    streamReaderDestroy(rp);
     zfree(out);
 
     dynamicBufFree(&db);
@@ -642,39 +642,39 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     return;
 }
 
-/* --- Test: stream_writer_create/destroy --- */
+/* --- Test: streamWriterCreate/destroy --- */
 TEST(compression, streamWriterCreateDestroy) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL) << "create should succeed for LZ4";
-    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored";
+    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored";
 
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
 
     /* NULL config should fail */
-    ASSERT_TRUE(stream_writer_create(NULL, emitToDynamicBuf, &db) == NULL) << "NULL config should return NULL";
+    ASSERT_TRUE(streamWriterCreate(NULL, emitToDynamicBuf, &db) == NULL) << "NULL config should return NULL";
 
     /* NULL emit_cb should fail */
-    ASSERT_TRUE(stream_writer_create(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
 
     /* ALGO_NONE should fail */
     streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
     bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
 
     /* Concrete stream kinds outside the currently named ones are valid. */
     streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
-    streamWriter *future_t = stream_writer_create(&future_kind_cfg, emitToDynamicBuf, &db);
+    streamWriter *future_t = streamWriterCreate(&future_kind_cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(future_t != NULL) << "custom stream_kind should succeed with envelope";
-    stream_writer_destroy(future_t);
+    streamWriterDestroy(future_t);
 
     /* destroy NULL should be safe */
-    stream_writer_destroy(NULL);
+    streamWriterDestroy(NULL);
 
     return;
 }
@@ -685,19 +685,19 @@ TEST(compression, streamWriterRoundTrip) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     /* Write some data */
     const char *test_data = "Hello, compression world! This is a test of the stream writer API.";
     size_t data_len = strlen(test_data);
-    ASSERT_TRUE(stream_writer_write(t, test_data, data_len) >= 0);
-    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored after write";
+    ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
+    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored after write";
     ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "write should emit envelope";
 
     /* Finalize */
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
-    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored after finish";
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored after finish";
 
     /* Verify output starts with VKCS envelope */
     ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "output should have at least envelope size";
@@ -737,7 +737,7 @@ TEST(compression, streamWriterRoundTrip) {
     ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match original";
 
     streamDecompressorDestroy(&sd);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -755,33 +755,33 @@ TEST(compression, streamWriterLargeSingleWrite) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
-    ASSERT_TRUE(stream_writer_write(t, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
-    stream_writer_destroy(t);
+    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    streamWriterDestroy(t);
 
     mem_reader_t mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 0;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
-    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
     size_t total = 0;
     while (total < payload_len) {
-        ssize_t nread = stream_reader_read(r, out + total, payload_len - total);
-        ASSERT_TRUE(nread > 0) << "stream_reader_read should keep making progress";
+        ssize_t nread = streamReaderRead(r, out + total, payload_len - total);
+        ASSERT_TRUE(nread > 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(stream_reader_read(r, out, 1) == 0) << "reader should stop at frame end";
+    ASSERT_TRUE(streamReaderRead(r, out, 1) == 0) << "reader should stop at frame end";
 
     zfree(out);
     zfree(payload);
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     dynamicBufFree(&db);
     return;
 }
@@ -800,18 +800,18 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     dynamicBufInit(&db);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
-    streamWriter *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     mem_reader_t mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 4096;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
-    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
@@ -820,37 +820,37 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     while (total < payload_len) {
         size_t step = payload_len - total;
         if (step > 17) step = 17;
-        ssize_t nread = stream_reader_read(r, out + total, step);
-        ASSERT_TRUE(nread > 0) << "stream_reader_read should keep making progress";
+        ssize_t nread = streamReaderRead(r, out + total, step);
+        ASSERT_TRUE(nread > 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
 
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(stream_reader_read(r, out, 1) == 0) << "reader should stop at frame end";
+    ASSERT_TRUE(streamReaderRead(r, out, 1) == 0) << "reader should stop at frame end";
 
     zfree(out);
     zfree(payload);
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     dynamicBufFree(&db);
     return;
 }
 
-/* --- Test: stream_writer_flush semantics (no-op before writes, valid mid-stream) --- */
+/* --- Test: streamWriterFlush semantics (no-op before writes, valid mid-stream) --- */
 TEST(compression, streamWriterFlushBehavior) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush before write should be no-op success";
+    ASSERT_TRUE(streamWriterFlush(t) == 0) << "flush before write should be no-op success";
     ASSERT_TRUE(sdslen((const char *)db.data) == 0) << "flush before write should not emit bytes";
 
-    ASSERT_TRUE(stream_writer_write(t, "first chunk", 11) >= 0);
-    ASSERT_TRUE(stream_writer_flush(t) == 0);
-    ASSERT_TRUE(stream_writer_write(t, "second chunk", 12) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(streamWriterWrite(t, "first chunk", 11) >= 0);
+    ASSERT_TRUE(streamWriterFlush(t) == 0);
+    ASSERT_TRUE(streamWriterWrite(t, "second chunk", 12) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
@@ -879,7 +879,7 @@ TEST(compression, streamWriterFlushBehavior) {
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0);
 
     streamDecompressorDestroy(&sd);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -889,17 +889,17 @@ TEST(compression, streamWriterFlushAfterFinishIsNoop) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    ASSERT_TRUE(stream_writer_write(t, "payload", 7) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(streamWriterWrite(t, "payload", 7) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
-    ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush after finish should be a no-op success";
+    ASSERT_TRUE(streamWriterFlush(t) == 0) << "flush after finish should be a no-op success";
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "flush after finish should not emit bytes";
 
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -913,17 +913,17 @@ TEST(compression, streamWriterCodecChecksumToggle) {
 
         streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
                                                       codec_checksum);
-        streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+        streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(t != NULL);
-        ASSERT_TRUE(stream_writer_write(t, payload, strlen(payload)) >= 0);
-        ASSERT_TRUE(stream_writer_finish(t) == 0);
+        ASSERT_TRUE(streamWriterWrite(t, payload, strlen(payload)) >= 0);
+        ASSERT_TRUE(streamWriterFinish(t) == 0);
 
         ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
         ASSERT_TRUE(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
                                              sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE) == codec_checksum)
             << "LZ4 frame should reflect configured codec checksum setting";
 
-        stream_writer_destroy(t);
+        streamWriterDestroy(t);
         dynamicBufFree(&db);
     }
 }
@@ -944,7 +944,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(rioWrite((rio *)&cr, test_data, data_len) != 0) << "rioWrite should succeed";
 
     /* Finalize and destroy */
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
 
     /* Get the compressed output from the buffer rio */
     sds compressed = buffer_rio.io.buffer.ptr;
@@ -984,7 +984,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match";
 
     streamDecompressorDestroy(&sd);
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(compressed);
     return;
 }
@@ -1006,8 +1006,8 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     rioGenericUpdateChecksum(&expected, payload, payload_len);
     ASSERT_TRUE(cr.base.cksum == expected.cksum) << "compress_rio should track the checksum of uncompressed bytes";
 
-    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
-    compress_rio_destroy(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1027,8 +1027,8 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
     ASSERT_TRUE(cr.base.cksum == 0) << "skip-checksum should disable uncompressed RDB checksum tracking";
 
-    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
-    compress_rio_destroy(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1048,8 +1048,8 @@ TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) 
     ASSERT_TRUE(cr.base.cksum == 0)
         << "codec checksums should disable standard RDB checksum tracking for compressed RDB";
 
-    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
-    compress_rio_destroy(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1063,7 +1063,7 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &wcfg) == 0);
     ASSERT_TRUE(rioCheckType((rio *)&cr) == RIO_TYPE_BUFFER);
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 
     sds raw = sdsnew("plain-rdb-prefix");
@@ -1073,7 +1073,7 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     decompressRio dr;
     ASSERT_TRUE(rioInitWithDecompress(&dr, &raw_rio, &rcfg, NULL) == DECOMPRESS_RIO_INIT_OK);
     ASSERT_TRUE(rioCheckType((rio *)&dr) == RIO_TYPE_BUFFER);
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
 }
 
@@ -1084,15 +1084,15 @@ TEST(compression, decompressRioRoundTrip) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     const char *test_data = "Decompression rio test data. "
                             "This should round-trip through compress then decompress.";
     size_t data_len = strlen(test_data);
-    stream_writer_write(t, test_data, data_len);
-    stream_writer_finish(t);
-    stream_writer_destroy(t);
+    streamWriterWrite(t, test_data, data_len);
+    streamWriterFinish(t);
+    streamWriterDestroy(t);
 
     /* Create a buffer rio with the full VKCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1109,7 +1109,7 @@ TEST(compression, decompressRioRoundTrip) {
     ASSERT_TRUE(rioRead((rio *)&dr, result, data_len) != 0) << "rioRead should succeed";
     ASSERT_TRUE(memcmp(result, test_data, data_len) == 0) << "decompressed data should match original";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
     return;
@@ -1121,11 +1121,11 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
 
     std::string payload(4096, 'A');
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
-    ASSERT_TRUE(stream_writer_write(t, payload.data(), payload.size()) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
-    stream_writer_destroy(t);
+    ASSERT_TRUE(streamWriterWrite(t, payload.data(), payload.size()) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    streamWriterDestroy(t);
 
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
@@ -1140,7 +1140,7 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     ASSERT_TRUE((size_t)rioTell((rio *)&dr) < sizeof(out))
         << "decompress rio tell should track source bytes, not logical output bytes";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
 }
@@ -1164,7 +1164,7 @@ TEST(compression, decompressRioClassifiesInput) {
         ASSERT_TRUE(rioRead((rio *)&dr, result, payload_len) != 0) << "rioRead should succeed";
         ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "payload should be replayed exactly";
 
-        decompress_rio_destroy(&dr);
+        decompressRioDestroy(&dr);
         sdsfree(buf);
     }
 
@@ -1186,7 +1186,7 @@ TEST(compression, decompressRioClassifiesInput) {
     return;
 }
 
-/* --- Test: compress_rio_finish is idempotent --- */
+/* --- Test: compressRioFinish is idempotent --- */
 TEST(compression, compressRioFinishIdempotent) {
     sds buf = sdsempty();
     rio buffer_rio;
@@ -1197,15 +1197,15 @@ TEST(compression, compressRioFinishIdempotent) {
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     rioWrite((rio *)&cr, "test", 4);
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
     size_t len_after_first = sdslen(buffer_rio.io.buffer.ptr);
 
     /* Second finish should be a no-op */
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
     size_t len_after_second = sdslen(buffer_rio.io.buffer.ptr);
     ASSERT_TRUE(len_after_first == len_after_second) << "second finish should not produce more output";
 
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1230,7 +1230,7 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(rioWrite((rio *)&cr, "second chunk", 12) != 0) << "write after flush should succeed";
 
     /* Now finalize */
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
 
     /* Verify the entire stream decompresses correctly */
     sds compressed = buffer_rio.io.buffer.ptr;
@@ -1263,7 +1263,7 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0) << "decompressed should match concatenated input";
 
     streamDecompressorDestroy(&sd);
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(compressed);
     return;
 }
@@ -1285,7 +1285,7 @@ TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
 
     ASSERT_TRUE((cr.base.flags & RIO_FLAG_READ_ERROR) == 0) << "write-side streaming rio must not set read error";
 
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(inner.io.buffer.ptr);
     return;
 }
@@ -1309,12 +1309,12 @@ TEST(compression, decompressRioLargePayload) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    stream_writer_write(t, payload, payload_len);
-    stream_writer_finish(t);
-    stream_writer_destroy(t);
+    streamWriterWrite(t, payload, payload_len);
+    streamWriterFinish(t);
+    streamWriterDestroy(t);
 
     /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1338,7 +1338,7 @@ TEST(compression, decompressRioLargePayload) {
 
     ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     zfree(result);
     zfree(payload);
@@ -1361,12 +1361,12 @@ TEST(compression, decompressRioDirectPath) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    stream_writer_write(t, payload, payload_len);
-    stream_writer_finish(t);
-    stream_writer_destroy(t);
+    streamWriterWrite(t, payload, payload_len);
+    streamWriterFinish(t);
+    streamWriterDestroy(t);
 
     /* Decompress via decompress_rio with a single large read. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1381,7 +1381,7 @@ TEST(compression, decompressRioDirectPath) {
     ASSERT_TRUE(ret != 0) << "single large rioRead should succeed";
     ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     zfree(result);
     zfree(payload);
@@ -1402,11 +1402,11 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     sds input = sdsnewlen(db.data, sdslen((const char *)db.data));
     input = sdscatlen(input, trailer, trailer_len);
@@ -1416,19 +1416,19 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     mr.len = sdslen(input);
     mr.max_chunk = 3;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
-    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     char out[128];
     memset(out, 0, sizeof(out));
-    ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len);
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
 
     /* The reader must stop cleanly at frame end instead of trying to decode
      * trailing bytes as part of the same compressed frame. */
-    ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == 0);
+    ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0);
 
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     sdsfree(input);
     dynamicBufFree(&db);
     return;
@@ -1445,11 +1445,11 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE + 1);
     mem_reader_t mr = {};
@@ -1457,41 +1457,41 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
     mr.len = sdslen((const char *)db.data) - 1;
     mr.max_chunk = 7;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
-    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t out[payload_len];
-    ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len);
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(stream_reader_read(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
-    ASSERT_TRUE(stream_reader_get_error(r) == STREAM_READER_ERROR_CORRUPT)
+    ASSERT_TRUE(streamReaderRead(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
+    ASSERT_TRUE(streamReaderGetError(r) == STREAM_READER_ERROR_CORRUPT)
         << "truncated compressed frame should latch corruption, not I/O";
 
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     dynamicBufFree(&db);
     return;
 }
 
-/* --- Test: stream_writer_write after finish is rejected.
+/* --- Test: streamWriterWrite after finish is rejected.
  * Writes after finish must fail and must not emit bytes. --- */
 TEST(compression, streamWriterWriteAfterFinish) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    stream_writer_write(t, "hello", 5);
-    stream_writer_finish(t);
+    streamWriterWrite(t, "hello", 5);
+    streamWriterFinish(t);
     size_t len_after_finish = sdslen((const char *)db.data);
 
     /* Write after finish must fail and emit no output. */
-    ASSERT_TRUE(stream_writer_write(t, "world", 5) < 0);
+    ASSERT_TRUE(streamWriterWrite(t, "world", 5) < 0);
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "write after finish should not produce output";
 
     /* Second finish — should also be a no-op */
-    stream_writer_finish(t);
+    streamWriterFinish(t);
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "second finish should not produce output";
 
     /* Verify the stream is still valid: one envelope + one frame */
@@ -1518,7 +1518,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
     ASSERT_TRUE(total == 5 && memcmp(decompressed, "hello", 5) == 0) << "should decompress to 'hello' only";
 
     streamDecompressorDestroy(&sd);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -1532,21 +1532,21 @@ TEST(compression, independentStreamsCoexist) {
     dynamicBufInit(&db2);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t1 = stream_writer_create(&cfg, emitToDynamicBuf, &db1);
-    streamWriter *t2 = stream_writer_create(&cfg, emitToDynamicBuf, &db2);
+    streamWriter *t1 = streamWriterCreate(&cfg, emitToDynamicBuf, &db1);
+    streamWriter *t2 = streamWriterCreate(&cfg, emitToDynamicBuf, &db2);
     ASSERT_TRUE(t1 != NULL && t2 != NULL);
 
     const char *data1 = "Stream one data - unique content for first stream AAAA";
     const char *data2 = "Stream two data - different content for second stream BBBB";
 
     /* Interleave writes to both streams */
-    stream_writer_write(t1, data1, strlen(data1));
-    stream_writer_write(t2, data2, strlen(data2));
-    stream_writer_write(t1, data1, strlen(data1)); /* write again to stream 1 */
-    stream_writer_write(t2, data2, strlen(data2)); /* write again to stream 2 */
+    streamWriterWrite(t1, data1, strlen(data1));
+    streamWriterWrite(t2, data2, strlen(data2));
+    streamWriterWrite(t1, data1, strlen(data1)); /* write again to stream 1 */
+    streamWriterWrite(t2, data2, strlen(data2)); /* write again to stream 2 */
 
-    stream_writer_finish(t1);
-    stream_writer_finish(t2);
+    streamWriterFinish(t1);
+    streamWriterFinish(t2);
 
     /* Decompress both and verify independently */
     for (int i = 0; i < 2; i++) {
@@ -1567,12 +1567,12 @@ TEST(compression, independentStreamsCoexist) {
         ASSERT_TRUE(memcmp(result, expected, strlen(expected)) == 0) << "first half should match";
         ASSERT_TRUE(memcmp(result + strlen(expected), expected, strlen(expected)) == 0) << "second half should match";
 
-        decompress_rio_destroy(&dr);
+        decompressRioDestroy(&dr);
         sdsfree(comp);
     }
 
-    stream_writer_destroy(t1);
-    stream_writer_destroy(t2);
+    streamWriterDestroy(t1);
+    streamWriterDestroy(t2);
     dynamicBufFree(&db1);
     dynamicBufFree(&db2);
     return;
@@ -1585,16 +1585,16 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     /* Write repetitive data to a single stream */
     char pattern[4096];
     memset(pattern, 'X', sizeof(pattern));
     for (int i = 0; i < 32; i++) {
-        ASSERT_TRUE(stream_writer_write(t, pattern, sizeof(pattern)) >= 0);
+        ASSERT_TRUE(streamWriterWrite(t, pattern, sizeof(pattern)) >= 0);
     }
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
 
     sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buf_rio;
@@ -1612,10 +1612,10 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
         ASSERT_TRUE(result[i] == 'X');
     }
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp);
     zfree(result);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -46,21 +46,21 @@ typedef struct {
     int success_reads;
 } flaky_reader_t;
 
-static stream_reader_config_t makeReaderConfig(uint8_t expected_stream_kind,
+static streamReaderConfig makeReaderConfig(uint8_t expected_stream_kind,
                                                bool allow_passthrough,
                                                size_t buffer_size) {
-    stream_reader_config_t cfg = {};
+    streamReaderConfig cfg = {};
     cfg.expected_stream_kind = expected_stream_kind;
     cfg.allow_passthrough = allow_passthrough;
     cfg.buffer_size = buffer_size;
     return cfg;
 }
 
-static stream_writer_config_t makeWriterConfig(compression_algo_t algo,
+static streamWriterConfig makeWriterConfig(compressionAlgo algo,
                                                int level,
                                                uint8_t stream_kind,
                                                bool codec_checksum_enabled = false) {
-    stream_writer_config_t cfg = {};
+    streamWriterConfig cfg = {};
     cfg.algo = algo;
     cfg.level = level;
     cfg.stream_kind = stream_kind;
@@ -118,7 +118,7 @@ static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
 
 /* --- Test: LZ4 compressor init/destroy lifecycle --- */
 TEST(compression, streamCompressorInitDestroy) {
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
     ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
     ASSERT_TRUE(sc.frame_started == false) << "frame_started should be false";
@@ -128,7 +128,7 @@ TEST(compression, streamCompressorInitDestroy) {
     ASSERT_TRUE(sc.algo == ALGO_NONE) << "algo should be NONE after destroy";
 
     /* ALGO_NONE should fail */
-    stream_compressor_t sc3;
+    streamCompressor sc3;
     ASSERT_TRUE(streamCompressorInit(&sc3, ALGO_NONE, 0) == -1) << "NONE init should fail";
 
     /* NULL should fail */
@@ -137,7 +137,7 @@ TEST(compression, streamCompressorInitDestroy) {
 
 /* --- Test: LZ4 decompressor init/destroy lifecycle --- */
 TEST(compression, streamDecompressorInitDestroy) {
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0) << "LZ4 decomp init should succeed";
     ASSERT_TRUE(sd.algo == ALGO_LZ4) << "algo should be LZ4";
     ASSERT_TRUE(sd.ctx != NULL) << "ctx should be non-NULL";
@@ -154,7 +154,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
     size_t input_len = strlen(input);
 
     /* Compress */
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
 
     size_t bound = streamCompressOutputBound(&sc, input_len);
@@ -170,7 +170,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
     streamCompressorDestroy(&sc);
 
     /* Decompress */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -190,7 +190,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
 
 /* --- Test: streamCompressOutputBound returns sane values --- */
 TEST(compression, streamCompressOutputBound) {
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
 
     /* Basic: bound for 1KB input should be > 0 */
@@ -226,7 +226,7 @@ TEST(compression, streamCompressFeedErrors) {
         << "NULL sc should return -1";
 
     /* NULL output buffer */
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
     ASSERT_TRUE(streamCompressFeed(&sc, NULL, sizeof(buf),
                                    (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
@@ -249,7 +249,7 @@ TEST(compression, streamDecompressFeedErrors) {
         << "NULL sd should return -1";
 
     /* NULL input_consumed */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
     ASSERT_TRUE(streamDecompressFeed(&sd, buf, sizeof(buf),
                                      (const uint8_t *)"x", 1, NULL) == -1)
@@ -263,7 +263,7 @@ TEST(compression, streamDecompressFeedErrors) {
     ASSERT_TRUE(sd.errored == true) << "decompressor should enter sticky errored state";
 
     /* Once errored, all subsequent feeds fail immediately. */
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
     size_t bound = streamCompressOutputBound(&sc, strlen(payload));
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
@@ -286,7 +286,7 @@ TEST(compression, streamDecompressFeedErrors) {
 
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
 TEST(compression, streamCompressFeedErrorRecovery) {
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
 
     /* Pre-frame error: compressBegin fails with tiny buffer, but no frame
@@ -308,7 +308,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     streamCompressorDestroy(&sc);
 
     /* Mid-frame error: start a frame, then force an error — this is permanent. */
-    stream_compressor_t sc2;
+    streamCompressor sc2;
     ASSERT_TRUE(streamCompressorInit(&sc2, ALGO_LZ4, 0) == 0);
 
     /* First call with enough space to start the frame */
@@ -355,7 +355,7 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
         size_t max_chunk;
         bool allow_passthrough;
         bool expect_probe_ok;
-        stream_reader_error_t expected_error;
+        streamReaderError expected_error;
         size_t expected_read_len;
     } cases[] = {
         {"plain passthrough",
@@ -397,11 +397,11 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
         mr.data = cases[i].input;
         mr.len = cases[i].input_len;
         mr.max_chunk = cases[i].max_chunk;
-        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
-        stream_reader_t *t = stream_reader_create(&cfg, memReaderRead, &mr);
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
+        streamReader *t = stream_reader_create(&cfg, memReaderRead, &mr);
         ASSERT_TRUE(t != NULL) << cases[i].name;
 
-        stream_reader_info_t info;
+        streamReaderInfo info;
         if (cases[i].expect_probe_ok) {
             ASSERT_TRUE(stream_reader_probe(t) == 0) << cases[i].name;
             ASSERT_TRUE(stream_reader_get_info(t, &info) == 0) << cases[i].name;
@@ -432,9 +432,9 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
     mr.data = input;
     mr.len = sizeof(input);
     mr.max_chunk = 2;
-    stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
 
-    stream_reader_t *t = stream_reader_create(&cfg, memReaderRead, &mr);
+    streamReader *t = stream_reader_create(&cfg, memReaderRead, &mr);
     ASSERT_TRUE(t != NULL) << "stream_reader_create should succeed";
 
     uint8_t out[8] = {0};
@@ -442,7 +442,7 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
     ASSERT_TRUE(stream_reader_read(t, out, oversized) == -1)
         << "oversized reads should fail before touching stream state";
 
-    stream_reader_info_t info;
+    streamReaderInfo info;
     ASSERT_TRUE(stream_reader_get_info(t, &info) == 0)
         << "oversized read failure should not poison the reader";
     ASSERT_TRUE(info.compressed == 0) << "plain input should still probe as passthrough";
@@ -482,8 +482,8 @@ static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
     return db->data != NULL ? 0 : -1;
 }
 
-static int initVkcsRdbDecompressRio(decompress_rio_t *dr, rio *inner) {
-    stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+static int initVkcsRdbDecompressRio(decompressRio *dr, rio *inner) {
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
     return rioInitWithDecompress(dr, inner, &cfg, NULL) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
 
@@ -532,8 +532,8 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
         dynamic_buf_t db;
         dynamicBufInit(&db);
 
-        stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
-        stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+        streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
+        streamWriter *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(w != NULL) << cases[i].name;
         ASSERT_TRUE(stream_writer_write(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
         ASSERT_TRUE(stream_writer_finish(w) == 0) << cases[i].name;
@@ -543,11 +543,11 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
         mr.data = db.data;
         mr.len = sdslen((const char *)db.data);
         mr.max_chunk = cases[i].max_chunk;
-        stream_reader_config_t rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
-        stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+        streamReaderConfig rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
+        streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
         ASSERT_TRUE(r != NULL) << cases[i].name;
 
-        stream_reader_info_t info;
+        streamReaderInfo info;
         if (cases[i].expect_ok) {
             ASSERT_TRUE(stream_reader_probe(r) == 0) << cases[i].name;
             ASSERT_TRUE(stream_reader_get_info(r, &info) == 0) << cases[i].name;
@@ -590,8 +590,8 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
 
     dynamic_buf_t db;
     dynamicBufInit(&db);
-    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL) << "stream_writer_create should succeed";
     ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
     ASSERT_TRUE(stream_writer_finish(w) == 0);
@@ -604,8 +604,8 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     /* One probe read plus two 4 KB payload reads is enough to produce some
      * output with an 8 KB window, but not enough to satisfy the full request. */
     fr.fail_after_success_reads = 3;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
-    stream_reader_t *r = stream_reader_create(&rcfg, flakyReaderRead, &fr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
+    streamReader *r = stream_reader_create(&rcfg, flakyReaderRead, &fr);
     ASSERT_TRUE(r != NULL) << "stream_reader_create should succeed";
 
     const size_t out_len = 16 * 1024;
@@ -625,8 +625,8 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     fr_passthrough.len = sizeof(plain) - 1;
     fr_passthrough.max_chunk = 0;
     fr_passthrough.fail_after_success_reads = 1; /* probe succeeds, next read fails */
-    stream_reader_config_t pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-    stream_reader_t *rp = stream_reader_create(&pass_cfg, flakyReaderRead, &fr_passthrough);
+    streamReaderConfig pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReader *rp = stream_reader_create(&pass_cfg, flakyReaderRead, &fr_passthrough);
     ASSERT_TRUE(rp != NULL) << "passthrough reader create should succeed";
 
     uint8_t pass_out[64];
@@ -647,8 +647,8 @@ TEST(compression, streamWriterCreateDestroy) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL) << "create should succeed for LZ4";
     ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored";
 
@@ -662,14 +662,14 @@ TEST(compression, streamWriterCreateDestroy) {
     ASSERT_TRUE(stream_writer_create(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
 
     /* ALGO_NONE should fail */
-    stream_writer_config_t bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
+    streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
     ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
     bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
     ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
 
     /* Concrete stream kinds outside the currently named ones are valid. */
-    stream_writer_config_t future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
-    stream_writer_t *future_t = stream_writer_create(&future_kind_cfg, emitToDynamicBuf, &db);
+    streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
+    streamWriter *future_t = stream_writer_create(&future_kind_cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(future_t != NULL) << "custom stream_kind should succeed with envelope";
     stream_writer_destroy(future_t);
 
@@ -684,8 +684,8 @@ TEST(compression, streamWriterRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     /* Write some data */
@@ -711,7 +711,7 @@ TEST(compression, streamWriterRoundTrip) {
     ASSERT_TRUE(db.data[7] == STREAM_KIND_RDB) << "stream_kind RDB";
 
     /* Decompress and verify round-trip */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -754,8 +754,8 @@ TEST(compression, streamWriterLargeSingleWrite) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
     ASSERT_TRUE(stream_writer_write(t, payload, payload_len) >= 0);
     ASSERT_TRUE(stream_writer_finish(t) == 0);
@@ -765,8 +765,8 @@ TEST(compression, streamWriterLargeSingleWrite) {
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 0;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
+    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
@@ -799,8 +799,8 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
+    streamWriter *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
     ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
     ASSERT_TRUE(stream_writer_finish(w) == 0);
@@ -810,8 +810,8 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 4096;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
+    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
@@ -840,8 +840,8 @@ TEST(compression, streamWriterFlushBehavior) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush before write should be no-op success";
@@ -853,7 +853,7 @@ TEST(compression, streamWriterFlushBehavior) {
     ASSERT_TRUE(stream_writer_finish(t) == 0);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -888,8 +888,8 @@ TEST(compression, streamWriterFlushAfterFinishIsNoop) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     ASSERT_TRUE(stream_writer_write(t, "payload", 7) >= 0);
@@ -911,9 +911,9 @@ TEST(compression, streamWriterCodecChecksumToggle) {
         dynamic_buf_t db;
         dynamicBufInit(&db);
 
-        stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
+        streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
                                                       codec_checksum);
-        stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+        streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(t != NULL);
         ASSERT_TRUE(stream_writer_write(t, payload, strlen(payload)) >= 0);
         ASSERT_TRUE(stream_writer_finish(t) == 0);
@@ -928,15 +928,15 @@ TEST(compression, streamWriterCodecChecksumToggle) {
     }
 }
 
-/* --- Test: compress_rio_t write + finish round-trip --- */
+/* --- Test: compressRio write + finish round-trip --- */
 TEST(compression, compressRioRoundTrip) {
     /* Use a buffer rio as the inner rio */
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
                             "Pack my box with five dozen liquor jugs.";
@@ -958,7 +958,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(compressed[3] == (char)VKCS_MAGIC_3) << "magic S";
 
     /* Decompress and verify */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[512];
@@ -994,8 +994,8 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     const char *payload = "checksum-payload-for-compressed-rio";
@@ -1018,8 +1018,8 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     rioInitWithBuffer(&buffer_rio, buf);
     buffer_rio.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0);
 
@@ -1038,8 +1038,8 @@ TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) 
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) != 0);
 
@@ -1059,8 +1059,8 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &wcfg) == 0);
     ASSERT_TRUE(rioCheckType((rio *)&cr) == RIO_TYPE_BUFFER);
     compress_rio_destroy(&cr);
@@ -1069,22 +1069,22 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     sds raw = sdsnew("plain-rdb-prefix");
     rio raw_rio;
     rioInitWithBuffer(&raw_rio, raw);
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-    decompress_rio_t dr;
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    decompressRio dr;
     ASSERT_TRUE(rioInitWithDecompress(&dr, &raw_rio, &rcfg, NULL) == DECOMPRESS_RIO_INIT_OK);
     ASSERT_TRUE(rioCheckType((rio *)&dr) == RIO_TYPE_BUFFER);
     decompress_rio_destroy(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
 }
 
-/* --- Test: decompress_rio_t read round-trip --- */
+/* --- Test: decompressRio read round-trip --- */
 TEST(compression, decompressRioRoundTrip) {
     /* First, produce compressed data using stream writer */
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     const char *test_data = "Decompression rio test data. "
@@ -1100,7 +1100,7 @@ TEST(compression, decompressRioRoundTrip) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     /* Create decompress rio */
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     /* Read decompressed data */
@@ -1120,8 +1120,8 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     dynamicBufInit(&db);
 
     std::string payload(4096, 'A');
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
     ASSERT_TRUE(stream_writer_write(t, payload.data(), payload.size()) >= 0);
     ASSERT_TRUE(stream_writer_finish(t) == 0);
@@ -1131,7 +1131,7 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     char out[2048];
@@ -1153,9 +1153,9 @@ TEST(compression, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-        decompress_rio_t dr;
-        stream_reader_info_t info;
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        decompressRio dr;
+        streamReaderInfo info;
         ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info) == DECOMPRESS_RIO_INIT_OK);
         ASSERT_TRUE(info.compressed == 0) << "passthrough stream should not be compressed";
 
@@ -1176,8 +1176,8 @@ TEST(compression, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-        decompress_rio_t dr;
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        decompressRio dr;
         ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, NULL) ==
                     DECOMPRESS_RIO_INIT_INCOMPATIBLE);
 
@@ -1192,8 +1192,8 @@ TEST(compression, compressRioFinishIdempotent) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     rioWrite((rio *)&cr, "test", 4);
@@ -1216,8 +1216,8 @@ TEST(compression, compressRioFlushMidStream) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     /* Write some data */
@@ -1237,7 +1237,7 @@ TEST(compression, compressRioFlushMidStream) {
     size_t compressed_len = sdslen(compressed);
     ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE);
 
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -1269,15 +1269,15 @@ TEST(compression, compressRioFlushMidStream) {
 }
 
 /* --- Test: rdbLoadProgressCallback does not cast write-side streaming rios
- * to decompress_rio_t. This protects save/async paths that also use
+ * to decompressRio. This protects save/async paths that also use
  * RIO_FLAG_STREAMING_COMPRESSION. --- */
 TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
     sds buf = sdsempty();
     rio inner;
     rioInitWithBuffer(&inner, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &inner, &cfg) == 0);
 
     const char sample[] = "progress-guard";
@@ -1308,8 +1308,8 @@ TEST(compression, decompressRioLargePayload) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     stream_writer_write(t, payload, payload_len);
@@ -1321,7 +1321,7 @@ TEST(compression, decompressRioLargePayload) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     /* Read in small chunks (4KB) to force multiple iterations through
@@ -1360,8 +1360,8 @@ TEST(compression, decompressRioDirectPath) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     stream_writer_write(t, payload, payload_len);
@@ -1373,7 +1373,7 @@ TEST(compression, decompressRioDirectPath) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     uint8_t *result = (uint8_t *)zmalloc(payload_len);
@@ -1401,8 +1401,8 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
     ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
     ASSERT_TRUE(stream_writer_finish(w) == 0);
@@ -1415,8 +1415,8 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     mr.data = (const uint8_t *)input;
     mr.len = sdslen(input);
     mr.max_chunk = 3;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
+    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     char out[128];
@@ -1444,8 +1444,8 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
     ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
     ASSERT_TRUE(stream_writer_finish(w) == 0);
@@ -1456,8 +1456,8 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data) - 1;
     mr.max_chunk = 7;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
+    streamReader *r = stream_reader_create(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t out[payload_len];
@@ -1478,8 +1478,8 @@ TEST(compression, streamWriterWriteAfterFinish) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     stream_writer_write(t, "hello", 5);
@@ -1496,7 +1496,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
 
     /* Verify the stream is still valid: one envelope + one frame */
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[64];
@@ -1531,9 +1531,9 @@ TEST(compression, independentStreamsCoexist) {
     dynamicBufInit(&db1);
     dynamicBufInit(&db2);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t1 = stream_writer_create(&cfg, emitToDynamicBuf, &db1);
-    stream_writer_t *t2 = stream_writer_create(&cfg, emitToDynamicBuf, &db2);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t1 = stream_writer_create(&cfg, emitToDynamicBuf, &db1);
+    streamWriter *t2 = stream_writer_create(&cfg, emitToDynamicBuf, &db2);
     ASSERT_TRUE(t1 != NULL && t2 != NULL);
 
     const char *data1 = "Stream one data - unique content for first stream AAAA";
@@ -1558,7 +1558,7 @@ TEST(compression, independentStreamsCoexist) {
         rio buf_rio;
         rioInitWithBuffer(&buf_rio, comp);
 
-        decompress_rio_t dr;
+        decompressRio dr;
         ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
 
         char result[256];
@@ -1584,8 +1584,8 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     /* Write repetitive data to a single stream */
@@ -1600,7 +1600,7 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     rio buf_rio;
     rioInitWithBuffer(&buf_rio, comp);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
 
     size_t total_len = sizeof(pattern) * 32;

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -627,7 +627,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     rdbInputStreamInit(&input, &file_rdb);
 
     /* Support both plain RDB files and VKCS-wrapped streaming-compressed RDBs. */
-    decompress_rio_init_result_t init_rc = rdbInputStreamPrepare(&input);
+    decompressRioInitResult init_rc = rdbInputStreamPrepare(&input);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         rdbCheckError("Invalid RDB stream envelope");
         goto err;

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -53,6 +53,33 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_rdb_test_dataset r $prefix
     }
 
+    test {BGSAVE with LZ4 compression round-trips correctly} {
+        set prefix "lz4-bgsave"
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r config set rdb-compression-level 0
+        write_rdb_test_dataset r $prefix
+        set digest [debug_digest]
+
+        r bgsave
+        waitForBgsave r
+        r config rewrite
+        restart_server 0 true false
+
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_rdb_test_dataset r $prefix
+    }
+
+    test {Empty database LZ4 save and load} {
+        r config set rdb-compression-algo lz4
+        r flushall
+        assert_equal 0 [r dbsize]
+        assert_equal "OK" [r save]
+        restart_server 0 true false
+        assert_equal 0 [r dbsize]
+    }
+
     test {RDB save with LZF (default) round-trips correctly} {
         set prefix "lzf-round-trip"
         r config set rdbcompression yes

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -63,6 +63,8 @@ start_server {overrides {save "" enable-debug-command local}} {
 
         r bgsave
         waitForBgsave r
+        set header [read_dump_rdb_header_bytes r]
+        assert_equal "VKCS" [string range $header 0 3]
         r config rewrite
         restart_server 0 true false
 
@@ -72,10 +74,14 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {Empty database LZ4 save and load} {
+        r config set rdbcompression yes
         r config set rdb-compression-algo lz4
+        r config set rdb-compression-level 0
         r flushall
         assert_equal 0 [r dbsize]
         assert_equal "OK" [r save]
+        set header [read_dump_rdb_header_bytes r]
+        assert_equal "VKCS" [string range $header 0 3]
         restart_server 0 true false
         assert_equal 0 [r dbsize]
     }

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -189,7 +189,11 @@ tags {"repl external:skip"} {
                     fail "Replica removed the synced RDB before BGREWRITEAOF fallback completed"
                 }
 
-                after 1000
+                wait_for_condition 50 200 {
+                    [log_file_matches $replica_log "*Background AOF rewrite*"]
+                } else {
+                    fail "Replica did not trigger background AOF rewrite"
+                }
                 assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
                 waitForBgrewriteaof $replica
 


### PR DESCRIPTION
## Summary

Addresses style and correctness issues identified during code review audit of the streaming-compression-rio-pr branch against Valkey coding conventions.

## Changes

### Naming Convention Fixes (3 commits)
- **Type renames**: All `snake_case_t` typedefs → `camelCase` (e.g., `compression_algo_t` → `compressionAlgo`, `stream_writer_t` → `streamWriter`, `compress_rio_t` → `compressRio`). Valkey uses zero `_t` suffixed typedefs.
- **Function renames**: All `snake_case` public functions → `camelCase` (e.g., `stream_writer_create` → `streamWriterCreate`, `compress_rio_finish` → `compressRioFinish`). Also renamed static helpers `write_vkcs_envelope`/`read_vkcs_envelope`.
- **Local variable/field renames**: Internal struct fields and local variables → `camelCase` (e.g., `out_buf` → `outBuf`, `emit_cb` → `emitCb`, `compressed_buf` → `compressedBuf`). Public config struct fields preserved as-is since they're used with designated initializers.

### Correctness Fixes
- **`rioReadPartial()` missing `RIO_TYPE_FD` case**: Added `rioFdReadSome()` and the corresponding switch case. Without this, FD-backed rios (used in diskless replication) would fail with `RIO_FLAG_READ_ERROR`.
- **`rioConnsetIO` type confusion**: Added `RIO_TYPE_CONNSET` define and set `rioConnsetIO.type` to it (was incorrectly `RIO_TYPE_CONN`). Prevents potential wrong-union-member access if `rioReadPartial` is ever called on a connset rio.

### Build System
- **Removed orphan `ENGINE_UNIT_TESTS` Makefile rule**: Referenced undefined variables `ENGINE_UNIT_TESTS` and `ENGINE_TEST_OBJ` — dead code.

### Test Additions
- **BGSAVE integration test**: Exercises background save (fork+COW) with LZ4 compression — the production save path.
- **Empty database LZ4 save/load test**: Edge case where VKCS envelope is the only content.
- **Fixed flaky `after 1000` pattern**: Replaced timing-dependent sleep in replication-aof-sync.tcl with `wait_for_condition` polling.

## Files Changed (19 files, +819/-778)
Mechanical renames account for the bulk of the diff. Functional changes are limited to `rio.c`, `rio.h`, `Makefile`, and the test files.

## Testing
- Build passes (`make -j$(nproc)`)
- All changes are backward-compatible (no public API behavior changes)