### PR TITLE
compression: naming cleanup for streaming compression

### DIFF
--- a/src/compression.c
+++ b/src/compression.c
@@ -132,6 +132,10 @@ void streamDecompressorDestroy(stream_decompressor_t *sd) {
     memset(sd, 0, sizeof(*sd));
 }
 
+bool streamDecompressorFrameDone(const stream_decompressor_t *sd) {
+    return sd && sd->frame_done;
+}
+
 size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len) {
     if (!sc) return 0;
     const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);

--- a/src/compression.h
+++ b/src/compression.h
@@ -32,7 +32,7 @@ typedef struct {
     compression_algo_t algo;
     int level;
     void *ctx; /* Private codec-specific compressor context. */
-    bool frame_started;
+    bool stream_started;
     bool errored;        /* Permanently failed — algorithm state is undefined after
                           * an error. All subsequent streamCompressFeed calls return
                           * -1 immediately. The caller must tear down the stream
@@ -70,6 +70,9 @@ void streamCompressorDestroy(stream_compressor_t *sc);
 /* Initialize/destroy streaming decompressor. */
 int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo);
 void streamDecompressorDestroy(stream_decompressor_t *sd);
+
+/* Returns true when the codec frame has been fully decoded. */
+bool streamDecompressorFrameDone(const stream_decompressor_t *sd);
 
 /* Return upper bound on compressed output size.
  * The bound is conservative: it includes frame header, data, and flush/end

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -87,7 +87,7 @@ ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
     cctx = (LZ4F_cctx *)sc->ctx;
 
     /* Begin frame on first call */
-    if (!sc->frame_started) {
+    if (!sc->stream_started) {
         /* Local copy of shared prefs so we can set the actual level
          * and checksum mode per-stream. */
         LZ4F_preferences_t prefs = lz4f_prefs;
@@ -105,7 +105,7 @@ ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
             return -1;
         }
         offset = r;
-        sc->frame_started = true;
+        sc->stream_started = true;
     }
 
     /* Compress input data */
@@ -134,7 +134,7 @@ ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
         r = LZ4F_compressEnd(cctx, output + offset, output_capacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
         offset += r;
-        sc->frame_started = false;
+        sc->stream_started = false;
     }
 
     if (offset > (size_t)SSIZE_MAX) goto lz4_error;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -73,11 +73,11 @@ static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
 /* rio vtable: write callback — compress then delegate to inner rio */
 static size_t compressRioWrite(rio *r, const void *buf, size_t len) {
     compress_rio_t *cr = (compress_rio_t *)r;
-    if (!cr->compressor || cr->finalized || stream_writer_is_errored(cr->compressor)) {
+    if (!cr->writer || cr->finalized || stream_writer_is_errored(cr->writer)) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
-    if (stream_writer_write(cr->compressor, buf, len) < 0) {
+    if (stream_writer_write(cr->writer, buf, len) < 0) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
@@ -94,13 +94,13 @@ static off_t compressRioTell(rio *r) {
  * This is critical because some call sites flush mid-stream. */
 static int compressRioFlush(rio *r) {
     compress_rio_t *cr = (compress_rio_t *)r;
-    if (!cr->compressor || stream_writer_is_errored(cr->compressor)) return 0;
+    if (!cr->writer || stream_writer_is_errored(cr->writer)) return 0;
     if (cr->finalized) return 1;
 
-    if (stream_writer_flush(cr->compressor) != 0) return 0;
+    if (stream_writer_flush(cr->writer) != 0) return 0;
 
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->compressor);
+        stream_writer_set_error(cr->writer);
         return 0;
     }
     return 1;
@@ -131,8 +131,8 @@ int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_conf
 
     cr->inner = inner;
     cr->finalized = 0;
-    cr->compressor = stream_writer_create(cfg, compressRioEmit, cr);
-    return cr->compressor ? 0 : -1;
+    cr->writer = stream_writer_create(cfg, compressRioEmit, cr);
+    return cr->writer ? 0 : -1;
 }
 
 /* Finalize the compression frame and flush inner rio.
@@ -141,11 +141,11 @@ int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_conf
 /* Returns 0 on success, -1 if the compressor or inner flush errored. */
 int compress_rio_finish(compress_rio_t *cr) {
     if (!cr) return -1;
-    if (!cr->compressor) return -1;
-    if (cr->finalized) return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    if (!cr->writer) return -1;
+    if (cr->finalized) return stream_writer_is_errored(cr->writer) ? -1 : 0;
     cr->finalized = 1;
 
-    if (stream_writer_finish(cr->compressor) != 0) {
+    if (stream_writer_finish(cr->writer) != 0) {
         return -1;
     }
 
@@ -153,18 +153,18 @@ int compress_rio_finish(compress_rio_t *cr) {
      * Propagate flush failure to the compressor error state so
      * callers can detect it. */
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->compressor);
+        stream_writer_set_error(cr->writer);
     }
-    return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    return stream_writer_is_errored(cr->writer) ? -1 : 0;
 }
 
 /* Free compressor context and buffers. Does NOT finalize the frame.
  * Call compress_rio_finish() first on all exit paths. */
 void compress_rio_destroy(compress_rio_t *cr) {
     if (!cr) return;
-    if (cr->compressor) {
-        stream_writer_destroy(cr->compressor);
-        cr->compressor = NULL;
+    if (cr->writer) {
+        stream_writer_destroy(cr->writer);
+        cr->writer = NULL;
     }
 }
 

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -14,7 +14,7 @@
 typedef struct {
     rio base; /* Must be first — allows casting to (rio *) */
     rio *inner;
-    stream_writer_t *compressor;
+    stream_writer_t *writer;
     bool finalized;
 } compress_rio_t;
 

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -398,7 +398,7 @@ int stream_writer_flush(stream_writer_t *t) {
     /* Flush-after-finish is a harmless no-op: frame is already closed. */
     if (t->finished) return 0;
 
-    if (!t->envelope_written || !t->compressor.frame_started) return 0;
+    if (!t->envelope_written || !t->compressor.stream_started) return 0;
     if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_SYNC) != 0) return -1;
     return 0;
 }
@@ -735,7 +735,7 @@ static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size
                     t->error_kind == STREAM_READER_ERROR_NONE ? STREAM_READER_ERROR_IO
                                                               : t->error_kind);
             }
-            if (filled == 0 && !t->decompressor.frame_done) {
+            if (filled == 0 && !streamDecompressorFrameDone(&t->decompressor)) {
                 return streamReaderFailWithError(t, total, STREAM_READER_ERROR_CORRUPT);
             }
             if (filled == 0) break;

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -121,7 +121,7 @@ TEST(compression, streamCompressorInitDestroy) {
     stream_compressor_t sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
     ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
-    ASSERT_TRUE(sc.frame_started == false) << "frame_started should be false";
+    ASSERT_TRUE(sc.stream_started == false) << "stream_started should be false";
     ASSERT_TRUE(sc.ctx != NULL) << "ctx should be non-NULL";
     streamCompressorDestroy(&sc);
     ASSERT_TRUE(sc.ctx == NULL) << "ctx should be NULL after destroy";
@@ -166,7 +166,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
                                                 (const uint8_t *)input, input_len,
                                                 FLUSH_END);
     ASSERT_TRUE(compressed_len > 0) << "compress should succeed";
-    ASSERT_TRUE(sc.frame_started == false) << "frame should be closed after FLUSH_END";
+    ASSERT_TRUE(sc.stream_started == false) << "frame should be closed after FLUSH_END";
     streamCompressorDestroy(&sc);
 
     /* Decompress */
@@ -296,7 +296,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
                                      (const uint8_t *)"test data", 9, FLUSH_END);
     ASSERT_TRUE(ret == -1) << "should fail with tiny buffer";
     ASSERT_TRUE(sc.errored == false) << "errored should NOT be set (pre-frame failure)";
-    ASSERT_TRUE(sc.frame_started == false) << "frame_started should still be false";
+    ASSERT_TRUE(sc.stream_started == false) << "stream_started should still be false";
 
     /* Retry with a proper buffer — should succeed */
     size_t bound = streamCompressOutputBound(&sc, 9);
@@ -317,7 +317,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     ssize_t ret3 = streamCompressFeed(&sc2, buf2, bound2,
                                       (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
     ASSERT_TRUE(ret3 >= 0) << "first write should succeed";
-    ASSERT_TRUE(sc2.frame_started == true) << "frame should be started";
+    ASSERT_TRUE(sc2.stream_started == true) << "stream should be started";
 
     /* Now force a mid-frame error with a tiny buffer */
     uint8_t tiny2[1];


### PR DESCRIPTION
Naming improvements from code review discussion:

- Rename `frame_started` → `stream_started` in `stream_compressor_t` — "frame" is LZ4-specific jargon leaking into the generic abstraction
- Expose `frame_done` via `streamDecompressorFrameDone()` function instead of direct field access from the stream reader layer (fixes layer violation)
- Rename `compressor` → `writer` in `compress_rio_t` — the rio decorator IS the compressor; its inner `stream_writer_t` is the writer it delegates to

7 files changed, +33 / -26. Pure rename/accessor refactor, no behavioral changes.