### PR TITLE
compression: fix must-fix review findings

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -121,7 +121,11 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/vset.c
     ${CMAKE_SOURCE_DIR}/src/fifo.c
     ${CMAKE_SOURCE_DIR}/src/mutexqueue.c
-    ${CMAKE_SOURCE_DIR}/src/queues.c)
+    ${CMAKE_SOURCE_DIR}/src/queues.c
+    ${CMAKE_SOURCE_DIR}/src/compression.c
+    ${CMAKE_SOURCE_DIR}/src/compression_lz4.c
+    ${CMAKE_SOURCE_DIR}/src/compression_stream.c
+    ${CMAKE_SOURCE_DIR}/src/compression_rio.c)
 
 
 # valkey-cli

--- a/cmake/Modules/ValkeySetup.cmake
+++ b/cmake/Modules/ValkeySetup.cmake
@@ -282,6 +282,7 @@ include_directories("${CMAKE_SOURCE_DIR}/src/modules/lua")
 include_directories("${CMAKE_SOURCE_DIR}/deps/linenoise")
 include_directories("${CMAKE_SOURCE_DIR}/deps/hdr_histogram")
 include_directories("${CMAKE_SOURCE_DIR}/deps/fpconv")
+include_directories("${CMAKE_SOURCE_DIR}/deps/lz4")
 
 add_subdirectory("${CMAKE_SOURCE_DIR}/deps")
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory(linenoise)
 add_subdirectory(fpconv)
 add_subdirectory(hdr_histogram)
 add_subdirectory(fast_float)
+add_subdirectory(lz4)
 
 # Clear any cached variables passed to libvalkey from the cache
 unset(BUILD_SHARED_LIBS CACHE)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -134,8 +134,6 @@ gtest-parallel: .make-prerequisites
 		git clone --depth 1 https://github.com/google/gtest-parallel.git gtest-parallel; \
 	fi
 
-.PHONY: gtest-parallel
-
 lz4: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
 	cd lz4 && $(MAKE) CFLAGS="$(CFLAGS)"

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -42,6 +42,7 @@ distclean:
 	-(cd jemalloc && [ -f Makefile ] && $(MAKE) distclean) > /dev/null || true
 	-(cd hdr_histogram && $(MAKE) clean) > /dev/null || true
 	-(cd fpconv && $(MAKE) clean) > /dev/null || true
+	-(cd lz4 && $(MAKE) clean) > /dev/null || true
 	-(rm -f .make-*)
 
 .PHONY: distclean
@@ -132,3 +133,11 @@ gtest-parallel: .make-prerequisites
 		rm -rf gtest-parallel; \
 		git clone --depth 1 https://github.com/google/gtest-parallel.git gtest-parallel; \
 	fi
+
+.PHONY: gtest-parallel
+
+lz4: .make-prerequisites
+	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
+	cd lz4 && $(MAKE) CFLAGS="$(CFLAGS)"
+
+.PHONY: lz4

--- a/deps/lz4/CMakeLists.txt
+++ b/deps/lz4/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(lz4)
+
+set(SRCS
+    "${CMAKE_CURRENT_LIST_DIR}/lz4.c"
+    "${CMAKE_CURRENT_LIST_DIR}/lz4.h"
+    "${CMAKE_CURRENT_LIST_DIR}/lz4hc.c"
+    "${CMAKE_CURRENT_LIST_DIR}/lz4hc.h"
+    "${CMAKE_CURRENT_LIST_DIR}/lz4frame.c"
+    "${CMAKE_CURRENT_LIST_DIR}/lz4frame.h"
+    "${CMAKE_CURRENT_LIST_DIR}/xxhash.c"
+    "${CMAKE_CURRENT_LIST_DIR}/xxhash.h")
+
+add_library(lz4 STATIC ${SRCS})
+set_target_properties(lz4 PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/deps/lz4/LICENSE
+++ b/deps/lz4/LICENSE
@@ -1,0 +1,24 @@
+LZ4 Library
+Copyright (c) 2011-2020, Yann Collet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/deps/lz4/Makefile
+++ b/deps/lz4/Makefile
@@ -1,0 +1,28 @@
+STD=
+WARN= -Wall
+OPT= -O3
+
+R_CFLAGS= $(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS)
+R_LDFLAGS= $(LDFLAGS)
+DEBUG= -g
+
+R_CC=$(CC) $(R_CFLAGS)
+R_LD=$(CC) $(R_LDFLAGS)
+
+AR= ar
+ARFLAGS= rcs
+
+liblz4.a: lz4.o lz4hc.o lz4frame.o xxhash.o
+	$(AR) $(ARFLAGS) $@ $^
+
+lz4.o: lz4.c lz4.h
+lz4hc.o: lz4hc.c lz4hc.h lz4.h
+lz4frame.o: lz4frame.c lz4frame.h lz4.h lz4hc.h xxhash.h
+xxhash.o: xxhash.c xxhash.h
+
+.c.o:
+	$(R_CC) -fPIC -c $<
+
+clean:
+	rm -f *.o
+	rm -f *.a

--- a/deps/lz4/lz4.c
+++ b/deps/lz4/lz4.c
@@ -1,0 +1,2829 @@
+/*
+   LZ4 - Fast LZ compression algorithm
+   Copyright (C) 2011-2023, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+    - LZ4 homepage : http://www.lz4.org
+    - LZ4 source repository : https://github.com/lz4/lz4
+*/
+
+/*-************************************
+*  Tuning parameters
+**************************************/
+/*
+ * LZ4_HEAPMODE :
+ * Select how stateless compression functions like `LZ4_compress_default()`
+ * allocate memory for their hash table,
+ * in memory stack (0:default, fastest), or in memory heap (1:requires malloc()).
+ */
+#ifndef LZ4_HEAPMODE
+#  define LZ4_HEAPMODE 0
+#endif
+
+/*
+ * LZ4_ACCELERATION_DEFAULT :
+ * Select "acceleration" for LZ4_compress_fast() when parameter value <= 0
+ */
+#define LZ4_ACCELERATION_DEFAULT 1
+/*
+ * LZ4_ACCELERATION_MAX :
+ * Any "acceleration" value higher than this threshold
+ * get treated as LZ4_ACCELERATION_MAX instead (fix #876)
+ */
+#define LZ4_ACCELERATION_MAX 65537
+
+
+/*-************************************
+*  CPU Feature Detection
+**************************************/
+/* LZ4_FORCE_MEMORY_ACCESS
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is safe and portable.
+ * Unfortunately, on some target/compiler combinations, the generated assembly is sub-optimal.
+ * The below switch allow to select different access method for improved performance.
+ * Method 0 (default) : use `memcpy()`. Safe and portable.
+ * Method 1 : `__packed` statement. It depends on compiler extension (ie, not portable).
+ *            This method is safe if your compiler supports it, and *generally* as fast or faster than `memcpy`.
+ * Method 2 : direct access. This method is portable but violate C standard.
+ *            It can generate buggy code on targets which assembly generation depends on alignment.
+ *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
+ * See https://fastcompression.blogspot.fr/2015/08/accessing-unaligned-memory.html for details.
+ * Prefer these methods in priority order (0 > 1 > 2)
+ */
+#ifndef LZ4_FORCE_MEMORY_ACCESS   /* can be defined externally */
+#  if defined(__GNUC__) && \
+  ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) \
+  || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+#    define LZ4_FORCE_MEMORY_ACCESS 2
+#  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || defined(__GNUC__) || defined(_MSC_VER)
+#    define LZ4_FORCE_MEMORY_ACCESS 1
+#  endif
+#endif
+
+/*
+ * LZ4_FORCE_SW_BITCOUNT
+ * Define this parameter if your target system or compiler does not support hardware bit count
+ */
+#if defined(_MSC_VER) && defined(_WIN32_WCE)   /* Visual Studio for WinCE doesn't support Hardware bit count */
+#  undef  LZ4_FORCE_SW_BITCOUNT  /* avoid double def */
+#  define LZ4_FORCE_SW_BITCOUNT
+#endif
+
+
+
+/*-************************************
+*  Dependency
+**************************************/
+/*
+ * LZ4_SRC_INCLUDED:
+ * Amalgamation flag, whether lz4.c is included
+ */
+#ifndef LZ4_SRC_INCLUDED
+#  define LZ4_SRC_INCLUDED 1
+#endif
+
+#ifndef LZ4_DISABLE_DEPRECATE_WARNINGS
+#  define LZ4_DISABLE_DEPRECATE_WARNINGS /* due to LZ4_decompress_safe_withPrefix64k */
+#endif
+
+#ifndef LZ4_STATIC_LINKING_ONLY
+#  define LZ4_STATIC_LINKING_ONLY
+#endif
+#include "lz4.h"
+/* see also "memory routines" below */
+
+
+/*-************************************
+*  Compiler Options
+**************************************/
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Visual Studio 2005+ */
+#  include <intrin.h>               /* only present in VS2005+ */
+#  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
+#  pragma warning(disable : 6237)   /* disable: C6237: conditional expression is always 0 */
+#  pragma warning(disable : 6239)   /* disable: C6239: (<non-zero constant> && <expression>) always evaluates to the result of <expression> */
+#  pragma warning(disable : 6240)   /* disable: C6240: (<expression> && <non-zero constant>) always evaluates to the result of <expression> */
+#  pragma warning(disable : 6326)   /* disable: C6326: Potential comparison of a constant with another constant */
+#endif  /* _MSC_VER */
+
+#ifndef LZ4_FORCE_INLINE
+#  if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
+#    define LZ4_FORCE_INLINE static __forceinline
+#  else
+#    if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#      if defined (__GNUC__) || defined (__clang__)
+#        define LZ4_FORCE_INLINE static inline __attribute__((always_inline))
+#      else
+#        define LZ4_FORCE_INLINE static inline
+#      endif
+#    else
+#      define LZ4_FORCE_INLINE static
+#    endif /* __STDC_VERSION__ */
+#  endif  /* _MSC_VER */
+#endif /* LZ4_FORCE_INLINE */
+
+/* LZ4_FORCE_O2 and LZ4_FORCE_INLINE
+ * gcc on ppc64le generates an unrolled SIMDized loop for LZ4_wildCopy8,
+ * together with a simple 8-byte copy loop as a fall-back path.
+ * However, this optimization hurts the decompression speed by >30%,
+ * because the execution does not go to the optimized loop
+ * for typical compressible data, and all of the preamble checks
+ * before going to the fall-back path become useless overhead.
+ * This optimization happens only with the -O3 flag, and -O2 generates
+ * a simple 8-byte copy loop.
+ * With gcc on ppc64le, all of the LZ4_decompress_* and LZ4_wildCopy8
+ * functions are annotated with __attribute__((optimize("O2"))),
+ * and also LZ4_wildCopy8 is forcibly inlined, so that the O2 attribute
+ * of LZ4_wildCopy8 does not affect the compression speed.
+ */
+#if defined(__PPC64__) && defined(__LITTLE_ENDIAN__) && defined(__GNUC__) && !defined(__clang__)
+#  define LZ4_FORCE_O2  __attribute__((optimize("O2")))
+#  undef LZ4_FORCE_INLINE
+#  define LZ4_FORCE_INLINE  static __inline __attribute__((optimize("O2"),always_inline))
+#else
+#  define LZ4_FORCE_O2
+#endif
+
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || defined(__clang__)
+#  define expect(expr,value)    (__builtin_expect ((expr),(value)) )
+#else
+#  define expect(expr,value)    (expr)
+#endif
+
+#ifndef likely
+#define likely(expr)     expect((expr) != 0, 1)
+#endif
+#ifndef unlikely
+#define unlikely(expr)   expect((expr) != 0, 0)
+#endif
+
+/* Should the alignment test prove unreliable, for some reason,
+ * it can be disabled by setting LZ4_ALIGN_TEST to 0 */
+#ifndef LZ4_ALIGN_TEST  /* can be externally provided */
+# define LZ4_ALIGN_TEST 1
+#endif
+
+
+/*-************************************
+*  Memory routines
+**************************************/
+
+/*! LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION :
+ *  Disable relatively high-level LZ4/HC functions that use dynamic memory
+ *  allocation functions (malloc(), calloc(), free()).
+ *
+ *  Note that this is a compile-time switch. And since it disables
+ *  public/stable LZ4 v1 API functions, we don't recommend using this
+ *  symbol to generate a library for distribution.
+ *
+ *  The following public functions are removed when this symbol is defined.
+ *  - lz4   : LZ4_createStream, LZ4_freeStream,
+ *            LZ4_createStreamDecode, LZ4_freeStreamDecode, LZ4_create (deprecated)
+ *  - lz4hc : LZ4_createStreamHC, LZ4_freeStreamHC,
+ *            LZ4_createHC (deprecated), LZ4_freeHC  (deprecated)
+ *  - lz4frame, lz4file : All LZ4F_* functions
+ */
+#if defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  define ALLOC(s)          lz4_error_memory_allocation_is_disabled
+#  define ALLOC_AND_ZERO(s) lz4_error_memory_allocation_is_disabled
+#  define FREEMEM(p)        lz4_error_memory_allocation_is_disabled
+#elif defined(LZ4_USER_MEMORY_FUNCTIONS)
+/* memory management functions can be customized by user project.
+ * Below functions must exist somewhere in the Project
+ * and be available at link time */
+void* LZ4_malloc(size_t s);
+void* LZ4_calloc(size_t n, size_t s);
+void  LZ4_free(void* p);
+# define ALLOC(s)          LZ4_malloc(s)
+# define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
+# define FREEMEM(p)        LZ4_free(p)
+#else
+# include <stdlib.h>   /* malloc, calloc, free */
+# define ALLOC(s)          malloc(s)
+# define ALLOC_AND_ZERO(s) calloc(1,s)
+# define FREEMEM(p)        free(p)
+#endif
+
+#if ! LZ4_FREESTANDING
+#  include <string.h>   /* memset, memcpy */
+#endif
+#if !defined(LZ4_memset)
+#  define LZ4_memset(p,v,s) memset((p),(v),(s))
+#endif
+#define MEM_INIT(p,v,s)   LZ4_memset((p),(v),(s))
+
+
+/*-************************************
+*  Common Constants
+**************************************/
+#define MINMATCH 4
+
+#define WILDCOPYLENGTH 8
+#define LASTLITERALS   5   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MFLIMIT       12   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MATCH_SAFEGUARD_DISTANCE  ((2*WILDCOPYLENGTH) - MINMATCH)   /* ensure it's possible to write 2 x wildcopyLength without overflowing output buffer */
+#define FASTLOOP_SAFE_DISTANCE 64
+static const int LZ4_minLength = (MFLIMIT+1);
+
+#define KB *(1 <<10)
+#define MB *(1 <<20)
+#define GB *(1U<<30)
+
+#define LZ4_DISTANCE_ABSOLUTE_MAX 65535
+#if (LZ4_DISTANCE_MAX > LZ4_DISTANCE_ABSOLUTE_MAX)   /* max supported by LZ4 format */
+#  error "LZ4_DISTANCE_MAX is too big : must be <= 65535"
+#endif
+
+#define ML_BITS  4
+#define ML_MASK  ((1U<<ML_BITS)-1)
+#define RUN_BITS (8-ML_BITS)
+#define RUN_MASK ((1U<<RUN_BITS)-1)
+
+
+/*-************************************
+*  Error detection
+**************************************/
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#  include <assert.h>
+#else
+#  ifndef assert
+#    define assert(condition) ((void)0)
+#  endif
+#endif
+
+#define LZ4_STATIC_ASSERT(c)   { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use after variable declarations */
+
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2)
+#  include <stdio.h>
+   static int g_debuglog_enable = 1;
+#  define DEBUGLOG(l, ...) {                          \
+        if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
+            fprintf(stderr, __FILE__  " %i: ", __LINE__); \
+            fprintf(stderr, __VA_ARGS__);             \
+            fprintf(stderr, " \n");                   \
+    }   }
+#else
+#  define DEBUGLOG(l, ...) {}    /* disabled */
+#endif
+
+static int LZ4_isAligned(const void* ptr, size_t alignment)
+{
+    return ((size_t)ptr & (alignment -1)) == 0;
+}
+
+
+/*-************************************
+*  Types
+**************************************/
+#include <limits.h>
+#if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+# include <stdint.h>
+  typedef  uint8_t BYTE;
+  typedef uint16_t U16;
+  typedef uint32_t U32;
+  typedef  int32_t S32;
+  typedef uint64_t U64;
+  typedef uintptr_t uptrval;
+#else
+# if UINT_MAX != 4294967295UL
+#   error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"
+# endif
+  typedef unsigned char       BYTE;
+  typedef unsigned short      U16;
+  typedef unsigned int        U32;
+  typedef   signed int        S32;
+  typedef unsigned long long  U64;
+  typedef size_t              uptrval;   /* generally true, except OpenVMS-64 */
+#endif
+
+#if defined(__x86_64__)
+  typedef U64    reg_t;   /* 64-bits in x32 mode */
+#else
+  typedef size_t reg_t;   /* 32-bits in x32 mode */
+#endif
+
+typedef enum {
+    notLimited = 0,
+    limitedOutput = 1,
+    fillOutput = 2
+} limitedOutput_directive;
+
+
+/*-************************************
+*  Reading and writing into memory
+**************************************/
+
+/**
+ * LZ4 relies on memcpy with a constant size being inlined. In freestanding
+ * environments, the compiler can't assume the implementation of memcpy() is
+ * standard compliant, so it can't apply its specialized memcpy() inlining
+ * logic. When possible, use __builtin_memcpy() to tell the compiler to analyze
+ * memcpy() as if it were standard compliant, so it can inline it in freestanding
+ * environments. This is needed when decompressing the Linux Kernel, for example.
+ */
+#if !defined(LZ4_memcpy)
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4_memcpy(dst, src, size) __builtin_memcpy(dst, src, size)
+#  else
+#    define LZ4_memcpy(dst, src, size) memcpy(dst, src, size)
+#  endif
+#endif
+
+#if !defined(LZ4_memmove)
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4_memmove __builtin_memmove
+#  else
+#    define LZ4_memmove memmove
+#  endif
+#endif
+
+static unsigned LZ4_isLittleEndian(void)
+{
+    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental */
+    return one.c[0];
+}
+
+#if defined(__GNUC__) || defined(__INTEL_COMPILER)
+#define LZ4_PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#elif defined(_MSC_VER)
+#define LZ4_PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
+#endif
+
+#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
+/* lie to the compiler about data alignment; use with caution */
+
+static U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
+static U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
+static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
+
+static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
+static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+
+#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+LZ4_PACK(typedef struct { U16 u16; }) LZ4_unalign16;
+LZ4_PACK(typedef struct { U32 u32; }) LZ4_unalign32;
+LZ4_PACK(typedef struct { reg_t uArch; }) LZ4_unalignST;
+
+static U16 LZ4_read16(const void* ptr) { return ((const LZ4_unalign16*)ptr)->u16; }
+static U32 LZ4_read32(const void* ptr) { return ((const LZ4_unalign32*)ptr)->u32; }
+static reg_t LZ4_read_ARCH(const void* ptr) { return ((const LZ4_unalignST*)ptr)->uArch; }
+
+static void LZ4_write16(void* memPtr, U16 value) { ((LZ4_unalign16*)memPtr)->u16 = value; }
+static void LZ4_write32(void* memPtr, U32 value) { ((LZ4_unalign32*)memPtr)->u32 = value; }
+
+#else  /* safe and portable access using memcpy() */
+
+static U16 LZ4_read16(const void* memPtr)
+{
+    U16 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+static U32 LZ4_read32(const void* memPtr)
+{
+    U32 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+static reg_t LZ4_read_ARCH(const void* memPtr)
+{
+    reg_t val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+static void LZ4_write16(void* memPtr, U16 value)
+{
+    LZ4_memcpy(memPtr, &value, sizeof(value));
+}
+
+static void LZ4_write32(void* memPtr, U32 value)
+{
+    LZ4_memcpy(memPtr, &value, sizeof(value));
+}
+
+#endif /* LZ4_FORCE_MEMORY_ACCESS */
+
+
+static U16 LZ4_readLE16(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read16(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        return (U16)((U16)p[0] | (p[1]<<8));
+    }
+}
+
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
+static U32 LZ4_readLE32(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read32(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        return (U32)p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24);
+    }
+}
+#endif
+
+static void LZ4_writeLE16(void* memPtr, U16 value)
+{
+    if (LZ4_isLittleEndian()) {
+        LZ4_write16(memPtr, value);
+    } else {
+        BYTE* p = (BYTE*)memPtr;
+        p[0] = (BYTE) value;
+        p[1] = (BYTE)(value>>8);
+    }
+}
+
+/* customized variant of memcpy, which can overwrite up to 8 bytes beyond dstEnd */
+LZ4_FORCE_INLINE
+void LZ4_wildCopy8(void* dstPtr, const void* srcPtr, void* dstEnd)
+{
+    BYTE* d = (BYTE*)dstPtr;
+    const BYTE* s = (const BYTE*)srcPtr;
+    BYTE* const e = (BYTE*)dstEnd;
+
+    do { LZ4_memcpy(d,s,8); d+=8; s+=8; } while (d<e);
+}
+
+static const unsigned inc32table[8] = {0, 1, 2,  1,  0,  4, 4, 4};
+static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
+
+
+#ifndef LZ4_FAST_DEC_LOOP
+#  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
+#    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__aarch64__) && defined(__APPLE__)
+#    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__aarch64__) && !defined(__clang__)
+     /* On non-Apple aarch64, we disable this optimization for clang because
+      * on certain mobile chipsets, performance is reduced with clang. For
+      * more information refer to https://github.com/lz4/lz4/pull/707 */
+#    define LZ4_FAST_DEC_LOOP 1
+#  else
+#    define LZ4_FAST_DEC_LOOP 0
+#  endif
+#endif
+
+#if LZ4_FAST_DEC_LOOP
+
+LZ4_FORCE_INLINE void
+LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+{
+    assert(srcPtr + offset == dstPtr);
+    if (offset < 8) {
+        LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
+        dstPtr[0] = srcPtr[0];
+        dstPtr[1] = srcPtr[1];
+        dstPtr[2] = srcPtr[2];
+        dstPtr[3] = srcPtr[3];
+        srcPtr += inc32table[offset];
+        LZ4_memcpy(dstPtr+4, srcPtr, 4);
+        srcPtr -= dec64table[offset];
+        dstPtr += 8;
+    } else {
+        LZ4_memcpy(dstPtr, srcPtr, 8);
+        dstPtr += 8;
+        srcPtr += 8;
+    }
+
+    LZ4_wildCopy8(dstPtr, srcPtr, dstEnd);
+}
+
+/* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
+ * this version copies two times 16 bytes (instead of one time 32 bytes)
+ * because it must be compatible with offsets >= 16. */
+LZ4_FORCE_INLINE void
+LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
+{
+    BYTE* d = (BYTE*)dstPtr;
+    const BYTE* s = (const BYTE*)srcPtr;
+    BYTE* const e = (BYTE*)dstEnd;
+
+    do { LZ4_memcpy(d,s,16); LZ4_memcpy(d+16,s+16,16); d+=32; s+=32; } while (d<e);
+}
+
+/* LZ4_memcpy_using_offset()  presumes :
+ * - dstEnd >= dstPtr + MINMATCH
+ * - there is at least 12 bytes available to write after dstEnd */
+LZ4_FORCE_INLINE void
+LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+{
+    BYTE v[8];
+
+    assert(dstEnd >= dstPtr + MINMATCH);
+
+    switch(offset) {
+    case 1:
+        MEM_INIT(v, *srcPtr, 8);
+        break;
+    case 2:
+        LZ4_memcpy(v, srcPtr, 2);
+        LZ4_memcpy(&v[2], srcPtr, 2);
+#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#  pragma warning(push)
+#  pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
+#endif
+        LZ4_memcpy(&v[4], v, 4);
+#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#  pragma warning(pop)
+#endif
+        break;
+    case 4:
+        LZ4_memcpy(v, srcPtr, 4);
+        LZ4_memcpy(&v[4], srcPtr, 4);
+        break;
+    default:
+        LZ4_memcpy_using_offset_base(dstPtr, srcPtr, dstEnd, offset);
+        return;
+    }
+
+    LZ4_memcpy(dstPtr, v, 8);
+    dstPtr += 8;
+    while (dstPtr < dstEnd) {
+        LZ4_memcpy(dstPtr, v, 8);
+        dstPtr += 8;
+    }
+}
+#endif
+
+
+/*-************************************
+*  Common functions
+**************************************/
+static unsigned LZ4_NbCommonBytes (reg_t val)
+{
+    assert(val != 0);
+    if (LZ4_isLittleEndian()) {
+        if (sizeof(val) == 8) {
+#       if defined(_MSC_VER) && (_MSC_VER >= 1800) && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+/*-*************************************************************************************************
+* ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.
+* The ARM64EC ABI does not support AVX/AVX2/AVX512 instructions, nor their relevant intrinsics
+* including _tzcnt_u64. Therefore, we need to neuter the _tzcnt_u64 code path for ARM64EC.
+****************************************************************************************************/
+#         if defined(__clang__) && (__clang_major__ < 10)
+            /* Avoid undefined clang-cl intrinsics issue.
+             * See https://github.com/lz4/lz4/pull/1017 for details. */
+            return (unsigned)__builtin_ia32_tzcnt_u64(val) >> 3;
+#         else
+            /* x64 CPUS without BMI support interpret `TZCNT` as `REP BSF` */
+            return (unsigned)_tzcnt_u64(val) >> 3;
+#         endif
+#       elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            unsigned long r = 0;
+            _BitScanForward64(&r, (U64)val);
+            return (unsigned)r >> 3;
+#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_ctzll((U64)val) >> 3;
+#       else
+            const U64 m = 0x0101010101010101ULL;
+            val ^= val - 1;
+            return (unsigned)(((U64)((val & (m - 1)) * m)) >> 56);
+#       endif
+        } else /* 32 bits */ {
+#       if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            unsigned long r;
+            _BitScanForward(&r, (U32)val);
+            return (unsigned)r >> 3;
+#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_ctz((U32)val) >> 3;
+#       else
+            const U32 m = 0x01010101;
+            return (unsigned)((((val - 1) ^ val) & (m - 1)) * m) >> 24;
+#       endif
+        }
+    } else   /* Big Endian CPU */ {
+        if (sizeof(val)==8) {
+#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_clzll((U64)val) >> 3;
+#       else
+#if 1
+            /* this method is probably faster,
+             * but adds a 128 bytes lookup table */
+            static const unsigned char ctz7_tab[128] = {
+                7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+            };
+            U64 const mask = 0x0101010101010101ULL;
+            U64 const t = (((val >> 8) - mask) | val) & mask;
+            return ctz7_tab[(t * 0x0080402010080402ULL) >> 57];
+#else
+            /* this method doesn't consume memory space like the previous one,
+             * but it contains several branches,
+             * that may end up slowing execution */
+            static const U32 by32 = sizeof(val)*4;  /* 32 on 64 bits (goal), 16 on 32 bits.
+            Just to avoid some static analyzer complaining about shift by 32 on 32-bits target.
+            Note that this code path is never triggered in 32-bits mode. */
+            unsigned r;
+            if (!(val>>by32)) { r=4; } else { r=0; val>>=by32; }
+            if (!(val>>16)) { r+=2; val>>=8; } else { val>>=24; }
+            r += (!val);
+            return r;
+#endif
+#       endif
+        } else /* 32 bits */ {
+#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_clz((U32)val) >> 3;
+#       else
+            val >>= 8;
+            val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) |
+              (val + 0x00FF0000)) >> 24;
+            return (unsigned)val ^ 3;
+#       endif
+        }
+    }
+}
+
+
+#define STEPSIZE sizeof(reg_t)
+LZ4_FORCE_INLINE
+unsigned LZ4_count(const BYTE* pIn, const BYTE* pMatch, const BYTE* pInLimit)
+{
+    const BYTE* const pStart = pIn;
+
+    if (likely(pIn < pInLimit-(STEPSIZE-1))) {
+        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+        if (!diff) {
+            pIn+=STEPSIZE; pMatch+=STEPSIZE;
+        } else {
+            return LZ4_NbCommonBytes(diff);
+    }   }
+
+    while (likely(pIn < pInLimit-(STEPSIZE-1))) {
+        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+        if (!diff) { pIn+=STEPSIZE; pMatch+=STEPSIZE; continue; }
+        pIn += LZ4_NbCommonBytes(diff);
+        return (unsigned)(pIn - pStart);
+    }
+
+    if ((STEPSIZE==8) && (pIn<(pInLimit-3)) && (LZ4_read32(pMatch) == LZ4_read32(pIn))) { pIn+=4; pMatch+=4; }
+    if ((pIn<(pInLimit-1)) && (LZ4_read16(pMatch) == LZ4_read16(pIn))) { pIn+=2; pMatch+=2; }
+    if ((pIn<pInLimit) && (*pMatch == *pIn)) pIn++;
+    return (unsigned)(pIn - pStart);
+}
+
+
+#ifndef LZ4_COMMONDEFS_ONLY
+/*-************************************
+*  Local Constants
+**************************************/
+static const int LZ4_64Klimit = ((64 KB) + (MFLIMIT-1));
+static const U32 LZ4_skipTrigger = 6;  /* Increase this value ==> compression run slower on incompressible data */
+
+
+/*-************************************
+*  Local Structures and types
+**************************************/
+typedef enum { clearedTable = 0, byPtr, byU32, byU16 } tableType_t;
+
+/**
+ * This enum distinguishes several different modes of accessing previous
+ * content in the stream.
+ *
+ * - noDict        : There is no preceding content.
+ * - withPrefix64k : Table entries up to ctx->dictSize before the current blob
+ *                   blob being compressed are valid and refer to the preceding
+ *                   content (of length ctx->dictSize), which is available
+ *                   contiguously preceding in memory the content currently
+ *                   being compressed.
+ * - usingExtDict  : Like withPrefix64k, but the preceding content is somewhere
+ *                   else in memory, starting at ctx->dictionary with length
+ *                   ctx->dictSize.
+ * - usingDictCtx  : Everything concerning the preceding content is
+ *                   in a separate context, pointed to by ctx->dictCtx.
+ *                   ctx->dictionary, ctx->dictSize, and table entries
+ *                   in the current context that refer to positions
+ *                   preceding the beginning of the current compression are
+ *                   ignored. Instead, ctx->dictCtx->dictionary and ctx->dictCtx
+ *                   ->dictSize describe the location and size of the preceding
+ *                   content, and matches are found by looking in the ctx
+ *                   ->dictCtx->hashTable.
+ */
+typedef enum { noDict = 0, withPrefix64k, usingExtDict, usingDictCtx } dict_directive;
+typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
+
+
+/*-************************************
+*  Local Utils
+**************************************/
+int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
+const char* LZ4_versionString(void) { return LZ4_VERSION_STRING; }
+int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
+int LZ4_sizeofState(void) { return sizeof(LZ4_stream_t); }
+
+
+/*-****************************************
+*  Internal Definitions, used only in Tests
+*******************************************/
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize);
+
+int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int maxOutputSize,
+                                     const void* dictStart, size_t dictSize);
+int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int targetOutputSize, int dstCapacity,
+                                     const void* dictStart, size_t dictSize);
+#if defined (__cplusplus)
+}
+#endif
+
+/*-******************************
+*  Compression functions
+********************************/
+LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
+{
+    if (tableType == byU16)
+        return ((sequence * 2654435761U) >> ((MINMATCH*8)-(LZ4_HASHLOG+1)));
+    else
+        return ((sequence * 2654435761U) >> ((MINMATCH*8)-LZ4_HASHLOG));
+}
+
+LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
+{
+    const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG+1 : LZ4_HASHLOG;
+    if (LZ4_isLittleEndian()) {
+        const U64 prime5bytes = 889523592379ULL;
+        return (U32)(((sequence << 24) * prime5bytes) >> (64 - hashLog));
+    } else {
+        const U64 prime8bytes = 11400714785074694791ULL;
+        return (U32)(((sequence >> 24) * prime8bytes) >> (64 - hashLog));
+    }
+}
+
+LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
+{
+    if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
+
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
+    return LZ4_hash4(LZ4_readLE32(p), tableType);
+#else
+    return LZ4_hash4(LZ4_read32(p), tableType);
+#endif
+}
+
+LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
+{
+    switch (tableType)
+    {
+    default: /* fallthrough */
+    case clearedTable: { /* illegal! */ assert(0); return; }
+    case byPtr: { const BYTE** hashTable = (const BYTE**)tableBase; hashTable[h] = NULL; return; }
+    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = 0; return; }
+    case byU16: { U16* hashTable = (U16*) tableBase; hashTable[h] = 0; return; }
+    }
+}
+
+LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t const tableType)
+{
+    switch (tableType)
+    {
+    default: /* fallthrough */
+    case clearedTable: /* fallthrough */
+    case byPtr: { /* illegal! */ assert(0); return; }
+    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = idx; return; }
+    case byU16: { U16* hashTable = (U16*) tableBase; assert(idx < 65536); hashTable[h] = (U16)idx; return; }
+    }
+}
+
+/* LZ4_putPosition*() : only used in byPtr mode */
+LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h,
+                                  void* tableBase, tableType_t const tableType)
+{
+    const BYTE** const hashTable = (const BYTE**)tableBase;
+    assert(tableType == byPtr); (void)tableType;
+    hashTable[h] = p;
+}
+
+LZ4_FORCE_INLINE void LZ4_putPosition(const BYTE* p, void* tableBase, tableType_t tableType)
+{
+    U32 const h = LZ4_hashPosition(p, tableType);
+    LZ4_putPositionOnHash(p, h, tableBase, tableType);
+}
+
+/* LZ4_getIndexOnHash() :
+ * Index of match position registered in hash table.
+ * hash position must be calculated by using base+index, or dictBase+index.
+ * Assumption 1 : only valid if tableType == byU32 or byU16.
+ * Assumption 2 : h is presumed valid (within limits of hash table)
+ */
+LZ4_FORCE_INLINE U32 LZ4_getIndexOnHash(U32 h, const void* tableBase, tableType_t tableType)
+{
+    LZ4_STATIC_ASSERT(LZ4_MEMORY_USAGE > 2);
+    if (tableType == byU32) {
+        const U32* const hashTable = (const U32*) tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE-2)));
+        return hashTable[h];
+    }
+    if (tableType == byU16) {
+        const U16* const hashTable = (const U16*) tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE-1)));
+        return hashTable[h];
+    }
+    assert(0); return 0;  /* forbidden case */
+}
+
+static const BYTE* LZ4_getPositionOnHash(U32 h, const void* tableBase, tableType_t tableType)
+{
+    assert(tableType == byPtr); (void)tableType;
+    { const BYTE* const* hashTable = (const BYTE* const*) tableBase; return hashTable[h]; }
+}
+
+LZ4_FORCE_INLINE const BYTE*
+LZ4_getPosition(const BYTE* p,
+                const void* tableBase, tableType_t tableType)
+{
+    U32 const h = LZ4_hashPosition(p, tableType);
+    return LZ4_getPositionOnHash(h, tableBase, tableType);
+}
+
+LZ4_FORCE_INLINE void
+LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
+           const int inputSize,
+           const tableType_t tableType) {
+    /* If the table hasn't been used, it's guaranteed to be zeroed out, and is
+     * therefore safe to use no matter what mode we're in. Otherwise, we figure
+     * out if it's safe to leave as is or whether it needs to be reset.
+     */
+    if ((tableType_t)cctx->tableType != clearedTable) {
+        assert(inputSize >= 0);
+        if ((tableType_t)cctx->tableType != tableType
+          || ((tableType == byU16) && cctx->currentOffset + (unsigned)inputSize >= 0xFFFFU)
+          || ((tableType == byU32) && cctx->currentOffset > 1 GB)
+          || tableType == byPtr
+          || inputSize >= 4 KB)
+        {
+            DEBUGLOG(4, "LZ4_prepareTable: Resetting table in %p", cctx);
+            MEM_INIT(cctx->hashTable, 0, LZ4_HASHTABLESIZE);
+            cctx->currentOffset = 0;
+            cctx->tableType = (U32)clearedTable;
+        } else {
+            DEBUGLOG(4, "LZ4_prepareTable: Re-use hash table (no reset)");
+        }
+    }
+
+    /* Adding a gap, so all previous entries are > LZ4_DISTANCE_MAX back,
+     * is faster than compressing without a gap.
+     * However, compressing with currentOffset == 0 is faster still,
+     * so we preserve that case.
+     */
+    if (cctx->currentOffset != 0 && tableType == byU32) {
+        DEBUGLOG(5, "LZ4_prepareTable: adding 64KB to currentOffset");
+        cctx->currentOffset += 64 KB;
+    }
+
+    /* Finally, clear history */
+    cctx->dictCtx = NULL;
+    cctx->dictionary = NULL;
+    cctx->dictSize = 0;
+}
+
+/** LZ4_compress_generic_validated() :
+ *  inlined, to ensure branches are decided at compilation time.
+ *  The following conditions are presumed already validated:
+ *  - source != NULL
+ *  - inputSize > 0
+ */
+LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
+                 LZ4_stream_t_internal* const cctx,
+                 const char* const source,
+                 char* const dest,
+                 const int inputSize,
+                 int*  inputConsumed, /* only written when outputDirective == fillOutput */
+                 const int maxOutputSize,
+                 const limitedOutput_directive outputDirective,
+                 const tableType_t tableType,
+                 const dict_directive dictDirective,
+                 const dictIssue_directive dictIssue,
+                 const int acceleration)
+{
+    int result;
+    const BYTE* ip = (const BYTE*)source;
+
+    U32 const startIndex = cctx->currentOffset;
+    const BYTE* base = (const BYTE*)source - startIndex;
+    const BYTE* lowLimit;
+
+    const LZ4_stream_t_internal* dictCtx = (const LZ4_stream_t_internal*) cctx->dictCtx;
+    const BYTE* const dictionary =
+        dictDirective == usingDictCtx ? dictCtx->dictionary : cctx->dictionary;
+    const U32 dictSize =
+        dictDirective == usingDictCtx ? dictCtx->dictSize : cctx->dictSize;
+    const U32 dictDelta =
+        (dictDirective == usingDictCtx) ? startIndex - dictCtx->currentOffset : 0;   /* make indexes in dictCtx comparable with indexes in current context */
+
+    int const maybe_extMem = (dictDirective == usingExtDict) || (dictDirective == usingDictCtx);
+    U32 const prefixIdxLimit = startIndex - dictSize;   /* used when dictDirective == dictSmall */
+    const BYTE* const dictEnd = dictionary ? dictionary + dictSize : dictionary;
+    const BYTE* anchor = (const BYTE*) source;
+    const BYTE* const iend = ip + inputSize;
+    const BYTE* const mflimitPlusOne = iend - MFLIMIT + 1;
+    const BYTE* const matchlimit = iend - LASTLITERALS;
+
+    /* the dictCtx currentOffset is indexed on the start of the dictionary,
+     * while a dictionary in the current context precedes the currentOffset */
+    const BYTE* dictBase = (dictionary == NULL) ? NULL :
+                           (dictDirective == usingDictCtx) ?
+                            dictionary + dictSize - dictCtx->currentOffset :
+                            dictionary + dictSize - startIndex;
+
+    BYTE* op = (BYTE*) dest;
+    BYTE* const olimit = op + maxOutputSize;
+
+    U32 offset = 0;
+    U32 forwardH;
+
+    DEBUGLOG(5, "LZ4_compress_generic_validated: srcSize=%i, tableType=%u", inputSize, tableType);
+    assert(ip != NULL);
+    if (tableType == byU16) assert(inputSize<LZ4_64Klimit);  /* Size too large (not within 64K limit) */
+    if (tableType == byPtr) assert(dictDirective==noDict);   /* only supported use case with byPtr */
+    /* If init conditions are not met, we don't have to mark stream
+     * as having dirty context, since no action was taken yet */
+    if (outputDirective == fillOutput && maxOutputSize < 1) { return 0; } /* Impossible to store anything */
+    assert(acceleration >= 1);
+
+    lowLimit = (const BYTE*)source - (dictDirective == withPrefix64k ? dictSize : 0);
+
+    /* Update context state */
+    if (dictDirective == usingDictCtx) {
+        /* Subsequent linked blocks can't use the dictionary. */
+        /* Instead, they use the block we just compressed. */
+        cctx->dictCtx = NULL;
+        cctx->dictSize = (U32)inputSize;
+    } else {
+        cctx->dictSize += (U32)inputSize;
+    }
+    cctx->currentOffset += (U32)inputSize;
+    cctx->tableType = (U32)tableType;
+
+    if (inputSize<LZ4_minLength) goto _last_literals;        /* Input too small, no compression (all literals) */
+
+    /* First Byte */
+    {   U32 const h = LZ4_hashPosition(ip, tableType);
+        if (tableType == byPtr) {
+            LZ4_putPositionOnHash(ip, h, cctx->hashTable, byPtr);
+        } else {
+            LZ4_putIndexOnHash(startIndex, h, cctx->hashTable, tableType);
+    }   }
+    ip++; forwardH = LZ4_hashPosition(ip, tableType);
+
+    /* Main Loop */
+    for ( ; ; ) {
+        const BYTE* match;
+        BYTE* token;
+        const BYTE* filledIp;
+
+        /* Find a match */
+        if (tableType == byPtr) {
+            const BYTE* forwardIp = ip;
+            int step = 1;
+            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            do {
+                U32 const h = forwardH;
+                ip = forwardIp;
+                forwardIp += step;
+                step = (searchMatchNb++ >> LZ4_skipTrigger);
+
+                if (unlikely(forwardIp > mflimitPlusOne)) goto _last_literals;
+                assert(ip < mflimitPlusOne);
+
+                match = LZ4_getPositionOnHash(h, cctx->hashTable, tableType);
+                forwardH = LZ4_hashPosition(forwardIp, tableType);
+                LZ4_putPositionOnHash(ip, h, cctx->hashTable, tableType);
+
+            } while ( (match+LZ4_DISTANCE_MAX < ip)
+                   || (LZ4_read32(match) != LZ4_read32(ip)) );
+
+        } else {   /* byU32, byU16 */
+
+            const BYTE* forwardIp = ip;
+            int step = 1;
+            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            do {
+                U32 const h = forwardH;
+                U32 const current = (U32)(forwardIp - base);
+                U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+                assert(matchIndex <= current);
+                assert(forwardIp - base < (ptrdiff_t)(2 GB - 1));
+                ip = forwardIp;
+                forwardIp += step;
+                step = (searchMatchNb++ >> LZ4_skipTrigger);
+
+                if (unlikely(forwardIp > mflimitPlusOne)) goto _last_literals;
+                assert(ip < mflimitPlusOne);
+
+                if (dictDirective == usingDictCtx) {
+                    if (matchIndex < startIndex) {
+                        /* there was no match, try the dictionary */
+                        assert(tableType == byU32);
+                        matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
+                        match = dictBase + matchIndex;
+                        matchIndex += dictDelta;   /* make dictCtx index comparable with current context */
+                        lowLimit = dictionary;
+                    } else {
+                        match = base + matchIndex;
+                        lowLimit = (const BYTE*)source;
+                    }
+                } else if (dictDirective == usingExtDict) {
+                    if (matchIndex < startIndex) {
+                        DEBUGLOG(7, "extDict candidate: matchIndex=%5u  <  startIndex=%5u", matchIndex, startIndex);
+                        assert(startIndex - matchIndex >= MINMATCH);
+                        assert(dictBase);
+                        match = dictBase + matchIndex;
+                        lowLimit = dictionary;
+                    } else {
+                        match = base + matchIndex;
+                        lowLimit = (const BYTE*)source;
+                    }
+                } else {   /* single continuous memory segment */
+                    match = base + matchIndex;
+                }
+                forwardH = LZ4_hashPosition(forwardIp, tableType);
+                LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
+
+                DEBUGLOG(7, "candidate at pos=%u  (offset=%u \n", matchIndex, current - matchIndex);
+                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) { continue; }    /* match outside of valid area */
+                assert(matchIndex < current);
+                if ( ((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX))
+                  && (matchIndex+LZ4_DISTANCE_MAX < current)) {
+                    continue;
+                } /* too far */
+                assert((current - matchIndex) <= LZ4_DISTANCE_MAX);  /* match now expected within distance */
+
+                if (LZ4_read32(match) == LZ4_read32(ip)) {
+                    if (maybe_extMem) offset = current - matchIndex;
+                    break;   /* match found */
+                }
+
+            } while(1);
+        }
+
+        /* Catch up */
+        filledIp = ip;
+        assert(ip > anchor); /* this is always true as ip has been advanced before entering the main loop */
+        if ((match > lowLimit) && unlikely(ip[-1] == match[-1])) {
+            do { ip--; match--; } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
+        }
+
+        /* Encode Literals */
+        {   unsigned const litLength = (unsigned)(ip - anchor);
+            token = op++;
+            if ((outputDirective == limitedOutput) &&  /* Check output buffer overflow */
+                (unlikely(op + litLength + (2 + 1 + LASTLITERALS) + (litLength/255) > olimit)) ) {
+                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+            }
+            if ((outputDirective == fillOutput) &&
+                (unlikely(op + (litLength+240)/255 /* litlen */ + litLength /* literals */ + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit))) {
+                op--;
+                goto _last_literals;
+            }
+            if (litLength >= RUN_MASK) {
+                unsigned len = litLength - RUN_MASK;
+                *token = (RUN_MASK<<ML_BITS);
+                for(; len >= 255 ; len-=255) *op++ = 255;
+                *op++ = (BYTE)len;
+            }
+            else *token = (BYTE)(litLength<<ML_BITS);
+
+            /* Copy Literals */
+            LZ4_wildCopy8(op, anchor, op+litLength);
+            op+=litLength;
+            DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
+                        (int)(anchor-(const BYTE*)source), litLength, (int)(ip-(const BYTE*)source));
+        }
+
+_next_match:
+        /* at this stage, the following variables must be correctly set :
+         * - ip : at start of LZ operation
+         * - match : at start of previous pattern occurrence; can be within current prefix, or within extDict
+         * - offset : if maybe_ext_memSegment==1 (constant)
+         * - lowLimit : must be == dictionary to mean "match is within extDict"; must be == source otherwise
+         * - token and *token : position to write 4-bits for match length; higher 4-bits for literal length supposed already written
+         */
+
+        if ((outputDirective == fillOutput) &&
+            (op + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit)) {
+            /* the match was too close to the end, rewind and go to last literals */
+            op = token;
+            goto _last_literals;
+        }
+
+        /* Encode Offset */
+        if (maybe_extMem) {   /* static test */
+            DEBUGLOG(6, "             with offset=%u  (ext if > %i)", offset, (int)(ip - (const BYTE*)source));
+            assert(offset <= LZ4_DISTANCE_MAX && offset > 0);
+            LZ4_writeLE16(op, (U16)offset); op+=2;
+        } else  {
+            DEBUGLOG(6, "             with offset=%u  (same segment)", (U32)(ip - match));
+            assert(ip-match <= LZ4_DISTANCE_MAX);
+            LZ4_writeLE16(op, (U16)(ip - match)); op+=2;
+        }
+
+        /* Encode MatchLength */
+        {   unsigned matchCode;
+
+            if ( (dictDirective==usingExtDict || dictDirective==usingDictCtx)
+              && (lowLimit==dictionary) /* match within extDict */ ) {
+                const BYTE* limit = ip + (dictEnd-match);
+                assert(dictEnd > match);
+                if (limit > matchlimit) limit = matchlimit;
+                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, limit);
+                ip += (size_t)matchCode + MINMATCH;
+                if (ip==limit) {
+                    unsigned const more = LZ4_count(limit, (const BYTE*)source, matchlimit);
+                    matchCode += more;
+                    ip += more;
+                }
+                DEBUGLOG(6, "             with matchLength=%u starting in extDict", matchCode+MINMATCH);
+            } else {
+                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, matchlimit);
+                ip += (size_t)matchCode + MINMATCH;
+                DEBUGLOG(6, "             with matchLength=%u", matchCode+MINMATCH);
+            }
+
+            if ((outputDirective) &&    /* Check output buffer overflow */
+                (unlikely(op + (1 + LASTLITERALS) + (matchCode+240)/255 > olimit)) ) {
+                if (outputDirective == fillOutput) {
+                    /* Match description too long : reduce it */
+                    U32 newMatchCode = 15 /* in token */ - 1 /* to avoid needing a zero byte */ + ((U32)(olimit - op) - 1 - LASTLITERALS) * 255;
+                    ip -= matchCode - newMatchCode;
+                    assert(newMatchCode < matchCode);
+                    matchCode = newMatchCode;
+                    if (unlikely(ip <= filledIp)) {
+                        /* We have already filled up to filledIp so if ip ends up less than filledIp
+                         * we have positions in the hash table beyond the current position. This is
+                         * a problem if we reuse the hash table. So we have to remove these positions
+                         * from the hash table.
+                         */
+                        const BYTE* ptr;
+                        DEBUGLOG(5, "Clearing %u positions", (U32)(filledIp - ip));
+                        for (ptr = ip; ptr <= filledIp; ++ptr) {
+                            U32 const h = LZ4_hashPosition(ptr, tableType);
+                            LZ4_clearHash(h, cctx->hashTable, tableType);
+                        }
+                    }
+                } else {
+                    assert(outputDirective == limitedOutput);
+                    return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+                }
+            }
+            if (matchCode >= ML_MASK) {
+                *token += ML_MASK;
+                matchCode -= ML_MASK;
+                LZ4_write32(op, 0xFFFFFFFF);
+                while (matchCode >= 4*255) {
+                    op+=4;
+                    LZ4_write32(op, 0xFFFFFFFF);
+                    matchCode -= 4*255;
+                }
+                op += matchCode / 255;
+                *op++ = (BYTE)(matchCode % 255);
+            } else
+                *token += (BYTE)(matchCode);
+        }
+        /* Ensure we have enough space for the last literals. */
+        assert(!(outputDirective == fillOutput && op + 1 + LASTLITERALS > olimit));
+
+        anchor = ip;
+
+        /* Test end of chunk */
+        if (ip >= mflimitPlusOne) break;
+
+        /* Fill table */
+        {   U32 const h = LZ4_hashPosition(ip-2, tableType);
+            if (tableType == byPtr) {
+                LZ4_putPositionOnHash(ip-2, h, cctx->hashTable, byPtr);
+            } else {
+                U32 const idx = (U32)((ip-2) - base);
+                LZ4_putIndexOnHash(idx, h, cctx->hashTable, tableType);
+        }   }
+
+        /* Test next position */
+        if (tableType == byPtr) {
+
+            match = LZ4_getPosition(ip, cctx->hashTable, tableType);
+            LZ4_putPosition(ip, cctx->hashTable, tableType);
+            if ( (match+LZ4_DISTANCE_MAX >= ip)
+              && (LZ4_read32(match) == LZ4_read32(ip)) )
+            { token=op++; *token=0; goto _next_match; }
+
+        } else {   /* byU32, byU16 */
+
+            U32 const h = LZ4_hashPosition(ip, tableType);
+            U32 const current = (U32)(ip-base);
+            U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+            assert(matchIndex < current);
+            if (dictDirective == usingDictCtx) {
+                if (matchIndex < startIndex) {
+                    /* there was no match, try the dictionary */
+                    assert(tableType == byU32);
+                    matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
+                    match = dictBase + matchIndex;
+                    lowLimit = dictionary;   /* required for match length counter */
+                    matchIndex += dictDelta;
+                } else {
+                    match = base + matchIndex;
+                    lowLimit = (const BYTE*)source;  /* required for match length counter */
+                }
+            } else if (dictDirective==usingExtDict) {
+                if (matchIndex < startIndex) {
+                    assert(dictBase);
+                    match = dictBase + matchIndex;
+                    lowLimit = dictionary;   /* required for match length counter */
+                } else {
+                    match = base + matchIndex;
+                    lowLimit = (const BYTE*)source;   /* required for match length counter */
+                }
+            } else {   /* single memory segment */
+                match = base + matchIndex;
+            }
+            LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
+            assert(matchIndex < current);
+            if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
+              && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
+              && (LZ4_read32(match) == LZ4_read32(ip)) ) {
+                token=op++;
+                *token=0;
+                if (maybe_extMem) offset = current - matchIndex;
+                DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
+                            (int)(anchor-(const BYTE*)source), 0, (int)(ip-(const BYTE*)source));
+                goto _next_match;
+            }
+        }
+
+        /* Prepare next loop */
+        forwardH = LZ4_hashPosition(++ip, tableType);
+
+    }
+
+_last_literals:
+    /* Encode Last Literals */
+    {   size_t lastRun = (size_t)(iend - anchor);
+        if ( (outputDirective) &&  /* Check output buffer overflow */
+            (op + lastRun + 1 + ((lastRun+255-RUN_MASK)/255) > olimit)) {
+            if (outputDirective == fillOutput) {
+                /* adapt lastRun to fill 'dst' */
+                assert(olimit >= op);
+                lastRun  = (size_t)(olimit-op) - 1/*token*/;
+                lastRun -= (lastRun + 256 - RUN_MASK) / 256;  /*additional length tokens*/
+            } else {
+                assert(outputDirective == limitedOutput);
+                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+            }
+        }
+        DEBUGLOG(6, "Final literal run : %i literals", (int)lastRun);
+        if (lastRun >= RUN_MASK) {
+            size_t accumulator = lastRun - RUN_MASK;
+            *op++ = RUN_MASK << ML_BITS;
+            for(; accumulator >= 255 ; accumulator-=255) *op++ = 255;
+            *op++ = (BYTE) accumulator;
+        } else {
+            *op++ = (BYTE)(lastRun<<ML_BITS);
+        }
+        LZ4_memcpy(op, anchor, lastRun);
+        ip = anchor + lastRun;
+        op += lastRun;
+    }
+
+    if (outputDirective == fillOutput) {
+        *inputConsumed = (int) (((const char*)ip)-source);
+    }
+    result = (int)(((char*)op) - dest);
+    assert(result > 0);
+    DEBUGLOG(5, "LZ4_compress_generic: compressed %i bytes into %i bytes", inputSize, result);
+    return result;
+}
+
+/** LZ4_compress_generic() :
+ *  inlined, to ensure branches are decided at compilation time;
+ *  takes care of src == (NULL, 0)
+ *  and forward the rest to LZ4_compress_generic_validated */
+LZ4_FORCE_INLINE int LZ4_compress_generic(
+                 LZ4_stream_t_internal* const cctx,
+                 const char* const src,
+                 char* const dst,
+                 const int srcSize,
+                 int *inputConsumed, /* only written when outputDirective == fillOutput */
+                 const int dstCapacity,
+                 const limitedOutput_directive outputDirective,
+                 const tableType_t tableType,
+                 const dict_directive dictDirective,
+                 const dictIssue_directive dictIssue,
+                 const int acceleration)
+{
+    DEBUGLOG(5, "LZ4_compress_generic: srcSize=%i, dstCapacity=%i",
+                srcSize, dstCapacity);
+
+    if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) { return 0; }  /* Unsupported srcSize, too large (or negative) */
+    if (srcSize == 0) {   /* src == NULL supported if srcSize == 0 */
+        if (outputDirective != notLimited && dstCapacity <= 0) return 0;  /* no output, can't write anything */
+        DEBUGLOG(5, "Generating an empty block");
+        assert(outputDirective == notLimited || dstCapacity >= 1);
+        assert(dst != NULL);
+        dst[0] = 0;
+        if (outputDirective == fillOutput) {
+            assert (inputConsumed != NULL);
+            *inputConsumed = 0;
+        }
+        return 1;
+    }
+    assert(src != NULL);
+
+    return LZ4_compress_generic_validated(cctx, src, dst, srcSize,
+                inputConsumed, /* only written into if outputDirective == fillOutput */
+                dstCapacity, outputDirective,
+                tableType, dictDirective, dictIssue, acceleration);
+}
+
+
+int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int inputSize, int maxOutputSize, int acceleration)
+{
+    LZ4_stream_t_internal* const ctx = & LZ4_initStream(state, sizeof(LZ4_stream_t)) -> internal_donotuse;
+    assert(ctx != NULL);
+    if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
+    if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
+    if (maxOutputSize >= LZ4_compressBound(inputSize)) {
+        if (inputSize < LZ4_64Klimit) {
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, byU16, noDict, noDictIssue, acceleration);
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+        }
+    } else {
+        if (inputSize < LZ4_64Klimit) {
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, byU16, noDict, noDictIssue, acceleration);
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+        }
+    }
+}
+
+/**
+ * LZ4_compress_fast_extState_fastReset() :
+ * A variant of LZ4_compress_fast_extState().
+ *
+ * Using this variant avoids an expensive initialization step. It is only safe
+ * to call if the state buffer is known to be correctly initialized already
+ * (see comment in lz4.h on LZ4_resetStream_fast() for a definition of
+ * "correctly initialized").
+ */
+int LZ4_compress_fast_extState_fastReset(void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration)
+{
+    LZ4_stream_t_internal* const ctx = &((LZ4_stream_t*)state)->internal_donotuse;
+    if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
+    if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
+    assert(ctx != NULL);
+
+    if (dstCapacity >= LZ4_compressBound(srcSize)) {
+        if (srcSize < LZ4_64Klimit) {
+            const tableType_t tableType = byU16;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            if (ctx->currentOffset) {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, dictSmall, acceleration);
+            } else {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+            }
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+        }
+    } else {
+        if (srcSize < LZ4_64Klimit) {
+            const tableType_t tableType = byU16;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            if (ctx->currentOffset) {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, dictSmall, acceleration);
+            } else {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+            }
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+        }
+    }
+}
+
+
+int LZ4_compress_fast(const char* src, char* dest, int srcSize, int dstCapacity, int acceleration)
+{
+    int result;
+#if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctxPtr = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+    if (ctxPtr == NULL) return 0;
+#else
+    LZ4_stream_t ctx;
+    LZ4_stream_t* const ctxPtr = &ctx;
+#endif
+    result = LZ4_compress_fast_extState(ctxPtr, src, dest, srcSize, dstCapacity, acceleration);
+
+#if (LZ4_HEAPMODE)
+    FREEMEM(ctxPtr);
+#endif
+    return result;
+}
+
+
+int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacity)
+{
+    return LZ4_compress_fast(src, dst, srcSize, dstCapacity, 1);
+}
+
+
+/* Note!: This function leaves the stream in an unclean/broken state!
+ * It is not safe to subsequently use the same state with a _fastReset() or
+ * _continue() call without resetting it. */
+static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+{
+    void* const s = LZ4_initStream(state, sizeof (*state));
+    assert(s != NULL); (void)s;
+
+    if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
+        return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, acceleration);
+    } else {
+        if (*srcSizePtr < LZ4_64Klimit) {
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
+        } else {
+            tableType_t const addrMode = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, addrMode, noDict, noDictIssue, acceleration);
+    }   }
+}
+
+int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+{
+    int const r = LZ4_compress_destSize_extState_internal((LZ4_stream_t*)state, src, dst, srcSizePtr, targetDstSize, acceleration);
+    /* clean the state on exit */
+    LZ4_initStream(state, sizeof (LZ4_stream_t));
+    return r;
+}
+
+
+int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize)
+{
+#if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctx = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+    if (ctx == NULL) return 0;
+#else
+    LZ4_stream_t ctxBody;
+    LZ4_stream_t* const ctx = &ctxBody;
+#endif
+
+    int result = LZ4_compress_destSize_extState_internal(ctx, src, dst, srcSizePtr, targetDstSize, 1);
+
+#if (LZ4_HEAPMODE)
+    FREEMEM(ctx);
+#endif
+    return result;
+}
+
+
+
+/*-******************************
+*  Streaming functions
+********************************/
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_stream_t* LZ4_createStream(void)
+{
+    LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
+    LZ4_STATIC_ASSERT(sizeof(LZ4_stream_t) >= sizeof(LZ4_stream_t_internal));
+    DEBUGLOG(4, "LZ4_createStream %p", lz4s);
+    if (lz4s == NULL) return NULL;
+    LZ4_initStream(lz4s, sizeof(*lz4s));
+    return lz4s;
+}
+#endif
+
+static size_t LZ4_stream_t_alignment(void)
+{
+#if LZ4_ALIGN_TEST
+    typedef struct { char c; LZ4_stream_t t; } t_a;
+    return sizeof(t_a) - sizeof(LZ4_stream_t);
+#else
+    return 1;  /* effectively disabled */
+#endif
+}
+
+LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
+{
+    DEBUGLOG(5, "LZ4_initStream");
+    if (buffer == NULL) { return NULL; }
+    if (size < sizeof(LZ4_stream_t)) { return NULL; }
+    if (!LZ4_isAligned(buffer, LZ4_stream_t_alignment())) return NULL;
+    MEM_INIT(buffer, 0, sizeof(LZ4_stream_t_internal));
+    return (LZ4_stream_t*)buffer;
+}
+
+/* resetStream is now deprecated,
+ * prefer initStream() which is more general */
+void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
+{
+    DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", LZ4_stream);
+    MEM_INIT(LZ4_stream, 0, sizeof(LZ4_stream_t_internal));
+}
+
+void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
+    LZ4_prepareTable(&(ctx->internal_donotuse), 0, byU32);
+}
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
+{
+    if (!LZ4_stream) return 0;   /* support free on NULL */
+    DEBUGLOG(5, "LZ4_freeStream %p", LZ4_stream);
+    FREEMEM(LZ4_stream);
+    return (0);
+}
+#endif
+
+
+typedef enum { _ld_fast, _ld_slow } LoadDict_mode_e;
+#define HASH_UNIT sizeof(reg_t)
+int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
+                    const char* dictionary, int dictSize,
+                    LoadDict_mode_e _ld)
+{
+    LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
+    const tableType_t tableType = byU32;
+    const BYTE* p = (const BYTE*)dictionary;
+    const BYTE* const dictEnd = p + dictSize;
+    U32 idx32;
+
+    DEBUGLOG(4, "LZ4_loadDict (%i bytes from %p into %p)", dictSize, dictionary, LZ4_dict);
+
+    /* It's necessary to reset the context,
+     * and not just continue it with prepareTable()
+     * to avoid any risk of generating overflowing matchIndex
+     * when compressing using this dictionary */
+    LZ4_resetStream(LZ4_dict);
+
+    /* We always increment the offset by 64 KB, since, if the dict is longer,
+     * we truncate it to the last 64k, and if it's shorter, we still want to
+     * advance by a whole window length so we can provide the guarantee that
+     * there are only valid offsets in the window, which allows an optimization
+     * in LZ4_compress_fast_continue() where it uses noDictIssue even when the
+     * dictionary isn't a full 64k. */
+    dict->currentOffset += 64 KB;
+
+    if (dictSize < (int)HASH_UNIT) {
+        return 0;
+    }
+
+    if ((dictEnd - p) > 64 KB) p = dictEnd - 64 KB;
+    dict->dictionary = p;
+    dict->dictSize = (U32)(dictEnd - p);
+    dict->tableType = (U32)tableType;
+    idx32 = dict->currentOffset - dict->dictSize;
+
+    while (p <= dictEnd-HASH_UNIT) {
+        U32 const h = LZ4_hashPosition(p, tableType);
+        /* Note: overwriting => favors positions end of dictionary */
+        LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
+        p+=3; idx32+=3;
+    }
+
+    if (_ld == _ld_slow) {
+        /* Fill hash table with additional references, to improve compression capability */
+        p = dict->dictionary;
+        idx32 = dict->currentOffset - dict->dictSize;
+        while (p <= dictEnd-HASH_UNIT) {
+            U32 const h = LZ4_hashPosition(p, tableType);
+            U32 const limit = dict->currentOffset - 64 KB;
+            if (LZ4_getIndexOnHash(h, dict->hashTable, tableType) <= limit) {
+                /* Note: not overwriting => favors positions beginning of dictionary */
+                LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
+            }
+            p++; idx32++;
+        }
+    }
+
+    return (int)dict->dictSize;
+}
+
+int LZ4_loadDict(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
+{
+    return LZ4_loadDict_internal(LZ4_dict, dictionary, dictSize, _ld_fast);
+}
+
+int LZ4_loadDictSlow(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
+{
+    return LZ4_loadDict_internal(LZ4_dict, dictionary, dictSize, _ld_slow);
+}
+
+void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dictionaryStream)
+{
+    const LZ4_stream_t_internal* dictCtx = (dictionaryStream == NULL) ? NULL :
+        &(dictionaryStream->internal_donotuse);
+
+    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)",
+             workingStream, dictionaryStream,
+             dictCtx != NULL ? dictCtx->dictSize : 0);
+
+    if (dictCtx != NULL) {
+        /* If the current offset is zero, we will never look in the
+         * external dictionary context, since there is no value a table
+         * entry can take that indicate a miss. In that case, we need
+         * to bump the offset to something non-zero.
+         */
+        if (workingStream->internal_donotuse.currentOffset == 0) {
+            workingStream->internal_donotuse.currentOffset = 64 KB;
+        }
+
+        /* Don't actually attach an empty dictionary.
+         */
+        if (dictCtx->dictSize == 0) {
+            dictCtx = NULL;
+        }
+    }
+    workingStream->internal_donotuse.dictCtx = dictCtx;
+}
+
+
+static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, int nextSize)
+{
+    assert(nextSize >= 0);
+    if (LZ4_dict->currentOffset + (unsigned)nextSize > 0x80000000) {   /* potential ptrdiff_t overflow (32-bits mode) */
+        /* rescale hash table */
+        U32 const delta = LZ4_dict->currentOffset - 64 KB;
+        const BYTE* dictEnd = LZ4_dict->dictionary + LZ4_dict->dictSize;
+        int i;
+        DEBUGLOG(4, "LZ4_renormDictT");
+        for (i=0; i<LZ4_HASH_SIZE_U32; i++) {
+            if (LZ4_dict->hashTable[i] < delta) LZ4_dict->hashTable[i]=0;
+            else LZ4_dict->hashTable[i] -= delta;
+        }
+        LZ4_dict->currentOffset = 64 KB;
+        if (LZ4_dict->dictSize > 64 KB) LZ4_dict->dictSize = 64 KB;
+        LZ4_dict->dictionary = dictEnd - LZ4_dict->dictSize;
+    }
+}
+
+
+int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
+                                const char* source, char* dest,
+                                int inputSize, int maxOutputSize,
+                                int acceleration)
+{
+    const tableType_t tableType = byU32;
+    LZ4_stream_t_internal* const streamPtr = &LZ4_stream->internal_donotuse;
+    const char* dictEnd = streamPtr->dictSize ? (const char*)streamPtr->dictionary + streamPtr->dictSize : NULL;
+
+    DEBUGLOG(5, "LZ4_compress_fast_continue (inputSize=%i, dictSize=%u)", inputSize, streamPtr->dictSize);
+
+    LZ4_renormDictT(streamPtr, inputSize);   /* fix index overflow */
+    if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
+    if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
+
+    /* invalidate tiny dictionaries */
+    if ( (streamPtr->dictSize < 4)     /* tiny dictionary : not enough for a hash */
+      && (dictEnd != source)           /* prefix mode */
+      && (inputSize > 0)               /* tolerance : don't lose history, in case next invocation would use prefix mode */
+      && (streamPtr->dictCtx == NULL)  /* usingDictCtx */
+      ) {
+        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize, streamPtr->dictionary);
+        /* remove dictionary existence from history, to employ faster prefix mode */
+        streamPtr->dictSize = 0;
+        streamPtr->dictionary = (const BYTE*)source;
+        dictEnd = source;
+    }
+
+    /* Check overlapping input/dictionary space */
+    {   const char* const sourceEnd = source + inputSize;
+        if ((sourceEnd > (const char*)streamPtr->dictionary) && (sourceEnd < dictEnd)) {
+            streamPtr->dictSize = (U32)(dictEnd - sourceEnd);
+            if (streamPtr->dictSize > 64 KB) streamPtr->dictSize = 64 KB;
+            if (streamPtr->dictSize < 4) streamPtr->dictSize = 0;
+            streamPtr->dictionary = (const BYTE*)dictEnd - streamPtr->dictSize;
+        }
+    }
+
+    /* prefix mode : source data follows dictionary */
+    if (dictEnd == source) {
+        if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset))
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, dictSmall, acceleration);
+        else
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, noDictIssue, acceleration);
+    }
+
+    /* external dictionary mode */
+    {   int result;
+        if (streamPtr->dictCtx) {
+            /* We depend here on the fact that dictCtx'es (produced by
+             * LZ4_loadDict) guarantee that their tables contain no references
+             * to offsets between dictCtx->currentOffset - 64 KB and
+             * dictCtx->currentOffset - dictCtx->dictSize. This makes it safe
+             * to use noDictIssue even when the dict isn't a full 64 KB.
+             */
+            if (inputSize > 4 KB) {
+                /* For compressing large blobs, it is faster to pay the setup
+                 * cost to copy the dictionary's tables into the active context,
+                 * so that the compression loop is only looking into one table.
+                 */
+                LZ4_memcpy(streamPtr, streamPtr->dictCtx, sizeof(*streamPtr));
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+            } else {
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingDictCtx, noDictIssue, acceleration);
+            }
+        } else {  /* small data <= 4 KB */
+            if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, dictSmall, acceleration);
+            } else {
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+            }
+        }
+        streamPtr->dictionary = (const BYTE*)source;
+        streamPtr->dictSize = (U32)inputSize;
+        return result;
+    }
+}
+
+
+/* Hidden debug function, to force-test external dictionary mode */
+int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize)
+{
+    LZ4_stream_t_internal* const streamPtr = &LZ4_dict->internal_donotuse;
+    int result;
+
+    LZ4_renormDictT(streamPtr, srcSize);
+
+    if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, dictSmall, 1);
+    } else {
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, noDictIssue, 1);
+    }
+
+    streamPtr->dictionary = (const BYTE*)source;
+    streamPtr->dictSize = (U32)srcSize;
+
+    return result;
+}
+
+
+/*! LZ4_saveDict() :
+ *  If previously compressed data block is not guaranteed to remain available at its memory location,
+ *  save it into a safer place (char* safeBuffer).
+ *  Note : no need to call LZ4_loadDict() afterwards, dictionary is immediately usable,
+ *         one can therefore call LZ4_compress_fast_continue() right after.
+ * @return : saved dictionary size in bytes (necessarily <= dictSize), or 0 if error.
+ */
+int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
+{
+    LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
+
+    DEBUGLOG(5, "LZ4_saveDict : dictSize=%i, safeBuffer=%p", dictSize, safeBuffer);
+
+    if ((U32)dictSize > 64 KB) { dictSize = 64 KB; } /* useless to define a dictionary > 64 KB */
+    if ((U32)dictSize > dict->dictSize) { dictSize = (int)dict->dictSize; }
+
+    if (safeBuffer == NULL) assert(dictSize == 0);
+    if (dictSize > 0) {
+        const BYTE* const previousDictEnd = dict->dictionary + dict->dictSize;
+        assert(dict->dictionary);
+        LZ4_memmove(safeBuffer, previousDictEnd - dictSize, (size_t)dictSize);
+    }
+
+    dict->dictionary = (const BYTE*)safeBuffer;
+    dict->dictSize = (U32)dictSize;
+
+    return dictSize;
+}
+
+
+
+/*-*******************************
+ *  Decompression functions
+ ********************************/
+
+typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
+
+#undef MIN
+#define MIN(a,b)    ( (a) < (b) ? (a) : (b) )
+
+
+/* variant for decompress_unsafe()
+ * does not know end of input
+ * presumes input is well formed
+ * note : will consume at least one byte */
+static size_t read_long_length_no_check(const BYTE** pp)
+{
+    size_t b, l = 0;
+    do { b = **pp; (*pp)++; l += b; } while (b==255);
+    DEBUGLOG(6, "read_long_length_no_check: +length=%zu using %zu input bytes", l, l/255 + 1)
+    return l;
+}
+
+/* core decoder variant for LZ4_decompress_fast*()
+ * for legacy support only : these entry points are deprecated.
+ * - Presumes input is correctly formed (no defense vs malformed inputs)
+ * - Does not know input size (presume input buffer is "large enough")
+ * - Decompress a full block (only)
+ * @return : nb of bytes read from input.
+ * Note : this variant is not optimized for speed, just for maintenance.
+ *        the goal is to remove support of decompress_fast*() variants by v2.0
+**/
+LZ4_FORCE_INLINE int
+LZ4_decompress_unsafe_generic(
+                 const BYTE* const istart,
+                 BYTE* const ostart,
+                 int decompressedSize,
+
+                 size_t prefixSize,
+                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
+                 const size_t dictSize         /* note: =0 if dictStart==NULL */
+                 )
+{
+    const BYTE* ip = istart;
+    BYTE* op = (BYTE*)ostart;
+    BYTE* const oend = ostart + decompressedSize;
+    const BYTE* const prefixStart = ostart - prefixSize;
+
+    DEBUGLOG(5, "LZ4_decompress_unsafe_generic");
+    if (dictStart == NULL) assert(dictSize == 0);
+
+    while (1) {
+        /* start new sequence */
+        unsigned token = *ip++;
+
+        /* literals */
+        {   size_t ll = token >> ML_BITS;
+            if (ll==15) {
+                /* long literal length */
+                ll += read_long_length_no_check(&ip);
+            }
+            if ((size_t)(oend-op) < ll) return -1; /* output buffer overflow */
+            LZ4_memmove(op, ip, ll); /* support in-place decompression */
+            op += ll;
+            ip += ll;
+            if ((size_t)(oend-op) < MFLIMIT) {
+                if (op==oend) break;  /* end of block */
+                DEBUGLOG(5, "invalid: literals end at distance %zi from end of block", oend-op);
+                /* incorrect end of block :
+                 * last match must start at least MFLIMIT==12 bytes before end of output block */
+                return -1;
+        }   }
+
+        /* match */
+        {   size_t ml = token & 15;
+            size_t const offset = LZ4_readLE16(ip);
+            ip+=2;
+
+            if (ml==15) {
+                /* long literal length */
+                ml += read_long_length_no_check(&ip);
+            }
+            ml += MINMATCH;
+
+            if ((size_t)(oend-op) < ml) return -1; /* output buffer overflow */
+
+            {   const BYTE* match = op - offset;
+
+                /* out of range */
+                if (offset > (size_t)(op - prefixStart) + dictSize) {
+                    DEBUGLOG(6, "offset out of range");
+                    return -1;
+                }
+
+                /* check special case : extDict */
+                if (offset > (size_t)(op - prefixStart)) {
+                    /* extDict scenario */
+                    const BYTE* const dictEnd = dictStart + dictSize;
+                    const BYTE* extMatch = dictEnd - (offset - (size_t)(op-prefixStart));
+                    size_t const extml = (size_t)(dictEnd - extMatch);
+                    if (extml > ml) {
+                        /* match entirely within extDict */
+                        LZ4_memmove(op, extMatch, ml);
+                        op += ml;
+                        ml = 0;
+                    } else {
+                        /* match split between extDict & prefix */
+                        LZ4_memmove(op, extMatch, extml);
+                        op += extml;
+                        ml -= extml;
+                    }
+                    match = prefixStart;
+                }
+
+                /* match copy - slow variant, supporting overlap copy */
+                {   size_t u;
+                    for (u=0; u<ml; u++) {
+                        op[u] = match[u];
+            }   }   }
+            op += ml;
+            if ((size_t)(oend-op) < LASTLITERALS) {
+                DEBUGLOG(5, "invalid: match ends at distance %zi from end of block", oend-op);
+                /* incorrect end of block :
+                 * last match must stop at least LASTLITERALS==5 bytes before end of output block */
+                return -1;
+            }
+        } /* match */
+    } /* main loop */
+    return (int)(ip - istart);
+}
+
+
+/* Read the variable-length literal or match length.
+ *
+ * @ip : input pointer
+ * @ilimit : position after which if length is not decoded, the input is necessarily corrupted.
+ * @initial_check - check ip >= ipmax before start of loop.  Returns initial_error if so.
+ * @error (output) - error code.  Must be set to 0 before call.
+**/
+typedef size_t Rvl_t;
+static const Rvl_t rvl_error = (Rvl_t)(-1);
+LZ4_FORCE_INLINE Rvl_t
+read_variable_length(const BYTE** ip, const BYTE* ilimit,
+                     int initial_check)
+{
+    Rvl_t s, length = 0;
+    assert(ip != NULL);
+    assert(*ip !=  NULL);
+    assert(ilimit != NULL);
+    if (initial_check && unlikely((*ip) >= ilimit)) {    /* read limit reached */
+        return rvl_error;
+    }
+    s = **ip;
+    (*ip)++;
+    length += s;
+    if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+        return rvl_error;
+    }
+    /* accumulator overflow detection (32-bit mode only) */
+    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        return rvl_error;
+    }
+    if (likely(s != 255)) return length;
+    do {
+        s = **ip;
+        (*ip)++;
+        length += s;
+        if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+            return rvl_error;
+        }
+        /* accumulator overflow detection (32-bit mode only) */
+        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+            return rvl_error;
+        }
+    } while (s == 255);
+
+    return length;
+}
+
+/*! LZ4_decompress_generic() :
+ *  This generic decompression function covers all use cases.
+ *  It shall be instantiated several times, using different sets of directives.
+ *  Note that it is important for performance that this function really get inlined,
+ *  in order to remove useless branches during compilation optimization.
+ */
+LZ4_FORCE_INLINE int
+LZ4_decompress_generic(
+                 const char* const src,
+                 char* const dst,
+                 int srcSize,
+                 int outputSize,         /* If endOnInput==endOnInputSize, this value is `dstCapacity` */
+
+                 earlyEnd_directive partialDecoding,  /* full, partial */
+                 dict_directive dict,                 /* noDict, withPrefix64k, usingExtDict */
+                 const BYTE* const lowPrefix,  /* always <= dst, == dst when no prefix */
+                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
+                 const size_t dictSize         /* note : = 0 if noDict */
+                 )
+{
+    if ((src == NULL) || (outputSize < 0)) { return -1; }
+
+    {   const BYTE* ip = (const BYTE*) src;
+        const BYTE* const iend = ip + srcSize;
+
+        BYTE* op = (BYTE*) dst;
+        BYTE* const oend = op + outputSize;
+        BYTE* cpy;
+
+        const BYTE* const dictEnd = (dictStart == NULL) ? NULL : dictStart + dictSize;
+
+        const int checkOffset = (dictSize < (int)(64 KB));
+
+
+        /* Set up the "end" pointers for the shortcut. */
+        const BYTE* const shortiend = iend - 14 /*maxLL*/ - 2 /*offset*/;
+        const BYTE* const shortoend = oend - 14 /*maxLL*/ - 18 /*maxML*/;
+
+        const BYTE* match;
+        size_t offset;
+        unsigned token;
+        size_t length;
+
+
+        DEBUGLOG(5, "LZ4_decompress_generic (srcSize:%i, dstSize:%i)", srcSize, outputSize);
+
+        /* Special cases */
+        assert(lowPrefix <= op);
+        if (unlikely(outputSize==0)) {
+            /* Empty output buffer */
+            if (partialDecoding) return 0;
+            return ((srcSize==1) && (*ip==0)) ? 0 : -1;
+        }
+        if (unlikely(srcSize==0)) { return -1; }
+
+    /* LZ4_FAST_DEC_LOOP:
+     * designed for modern OoO performance cpus,
+     * where copying reliably 32-bytes is preferable to an unpredictable branch.
+     * note : fast loop may show a regression for some client arm chips. */
+#if LZ4_FAST_DEC_LOOP
+        if ((oend - op) < FASTLOOP_SAFE_DISTANCE) {
+            DEBUGLOG(6, "move to safe decode loop");
+            goto safe_decode;
+        }
+
+        /* Fast loop : decode sequences as long as output < oend-FASTLOOP_SAFE_DISTANCE */
+        DEBUGLOG(6, "using fast decode loop");
+        while (1) {
+            /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
+            assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
+            assert(ip < iend);
+            token = *ip++;
+            length = token >> ML_BITS;  /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+
+            /* decode literal length */
+            if (length == RUN_MASK) {
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (addl == rvl_error) {
+                    DEBUGLOG(6, "error reading long literal length");
+                    goto _output_error;
+                }
+                length += addl;
+                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+
+                /* copy literals */
+                LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
+                if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
+                LZ4_wildCopy32(op, ip, op+length);
+                ip += length; op += length;
+            } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
+                /* We don't need to check oend, since we check it once for each loop below */
+                DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
+                /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
+                LZ4_memcpy(op, ip, 16);
+                ip += length; op += length;
+            } else {
+                goto safe_literal_copy;
+            }
+
+            /* get offset */
+            offset = LZ4_readLE16(ip); ip+=2;
+            DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op-(BYTE*)dst), (unsigned)offset);
+            match = op - offset;
+            assert(match <= op);  /* overflow check */
+
+            /* get matchlength */
+            length = token & ML_MASK;
+            DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
+
+            if (length == ML_MASK) {
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (addl == rvl_error) {
+                    DEBUGLOG(5, "error reading long match length");
+                    goto _output_error;
+                }
+                length += addl;
+                length += MINMATCH;
+                DEBUGLOG(7, "  long match length == %u", (unsigned)length);
+                if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
+                if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
+                    goto safe_match_copy;
+                }
+            } else {
+                length += MINMATCH;
+                if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
+                    DEBUGLOG(7, "moving to safe_match_copy (ml==%u)", (unsigned)length);
+                    goto safe_match_copy;
+                }
+
+                /* Fastpath check: skip LZ4_wildCopy32 when true */
+                if ((dict == withPrefix64k) || (match >= lowPrefix)) {
+                    if (offset >= 8) {
+                        assert(match >= lowPrefix);
+                        assert(match <= op);
+                        assert(op + 18 <= oend);
+
+                        LZ4_memcpy(op, match, 8);
+                        LZ4_memcpy(op+8, match+8, 8);
+                        LZ4_memcpy(op+16, match+16, 2);
+                        op += length;
+                        continue;
+            }   }   }
+
+            if ( checkOffset && (unlikely(match + dictSize < lowPrefix)) ) {
+                DEBUGLOG(5, "Error : pos=%zi, offset=%zi => outside buffers", op-lowPrefix, op-match);
+                goto _output_error;
+            }
+            /* match starting within external dictionary */
+            if ((dict==usingExtDict) && (match < lowPrefix)) {
+                assert(dictEnd != NULL);
+                if (unlikely(op+length > oend-LASTLITERALS)) {
+                    if (partialDecoding) {
+                        DEBUGLOG(7, "partialDecoding: dictionary match, close to dstEnd");
+                        length = MIN(length, (size_t)(oend-op));
+                    } else {
+                        DEBUGLOG(6, "end-of-block condition violated")
+                        goto _output_error;
+                }   }
+
+                if (length <= (size_t)(lowPrefix-match)) {
+                    /* match fits entirely within external dictionary : just copy */
+                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    op += length;
+                } else {
+                    /* match stretches into both external dictionary and current block */
+                    size_t const copySize = (size_t)(lowPrefix - match);
+                    size_t const restSize = length - copySize;
+                    LZ4_memcpy(op, dictEnd - copySize, copySize);
+                    op += copySize;
+                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                        BYTE* const endOfMatch = op + restSize;
+                        const BYTE* copyFrom = lowPrefix;
+                        while (op < endOfMatch) { *op++ = *copyFrom++; }
+                    } else {
+                        LZ4_memcpy(op, lowPrefix, restSize);
+                        op += restSize;
+                }   }
+                continue;
+            }
+
+            /* copy match within block */
+            cpy = op + length;
+
+            assert((op <= oend) && (oend-op >= 32));
+            if (unlikely(offset<16)) {
+                LZ4_memcpy_using_offset(op, match, cpy, offset);
+            } else {
+                LZ4_wildCopy32(op, match, cpy);
+            }
+
+            op = cpy;   /* wildcopy correction */
+        }
+    safe_decode:
+#endif
+
+        /* Main Loop : decode remaining sequences where output < FASTLOOP_SAFE_DISTANCE */
+        DEBUGLOG(6, "using safe decode loop");
+        while (1) {
+            assert(ip < iend);
+            token = *ip++;
+            length = token >> ML_BITS;  /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+
+            /* A two-stage shortcut for the most common case:
+             * 1) If the literal length is 0..14, and there is enough space,
+             * enter the shortcut and copy 16 bytes on behalf of the literals
+             * (in the fast mode, only 8 bytes can be safely copied this way).
+             * 2) Further if the match length is 4..18, copy 18 bytes in a similar
+             * manner; but we ensure that there's enough space in the output for
+             * those 18 bytes earlier, upon entering the shortcut (in other words,
+             * there is a combined check for both stages).
+             */
+            if ( (length != RUN_MASK)
+                /* strictly "less than" on input, to re-enter the loop with at least one byte */
+              && likely((ip < shortiend) & (op <= shortoend)) ) {
+                /* Copy the literals */
+                LZ4_memcpy(op, ip, 16);
+                op += length; ip += length;
+
+                /* The second stage: prepare for match copying, decode full info.
+                 * If it doesn't work out, the info won't be wasted. */
+                length = token & ML_MASK; /* match length */
+                DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op-(BYTE*)dst), (unsigned)length, (unsigned)length + 4);
+                offset = LZ4_readLE16(ip); ip += 2;
+                match = op - offset;
+                assert(match <= op); /* check overflow */
+
+                /* Do not deal with overlapping matches. */
+                if ( (length != ML_MASK)
+                  && (offset >= 8)
+                  && (dict==withPrefix64k || match >= lowPrefix) ) {
+                    /* Copy the match. */
+                    LZ4_memcpy(op + 0, match + 0, 8);
+                    LZ4_memcpy(op + 8, match + 8, 8);
+                    LZ4_memcpy(op +16, match +16, 2);
+                    op += length + MINMATCH;
+                    /* Both stages worked, load the next token. */
+                    continue;
+                }
+
+                /* The second stage didn't work out, but the info is ready.
+                 * Propel it right to the point of match copying. */
+                goto _copy_match;
+            }
+
+            /* decode literal length */
+            if (length == RUN_MASK) {
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (addl == rvl_error) { goto _output_error; }
+                length += addl;
+                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+            }
+
+#if LZ4_FAST_DEC_LOOP
+        safe_literal_copy:
+#endif
+            /* copy literals */
+            cpy = op+length;
+
+            LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
+            if ((cpy>oend-MFLIMIT) || (ip+length>iend-(2+1+LASTLITERALS))) {
+                /* We've either hit the input parsing restriction or the output parsing restriction.
+                 * In the normal scenario, decoding a full block, it must be the last sequence,
+                 * otherwise it's an error (invalid input or dimensions).
+                 * In partialDecoding scenario, it's necessary to ensure there is no buffer overflow.
+                 */
+                if (partialDecoding) {
+                    /* Since we are partial decoding we may be in this block because of the output parsing
+                     * restriction, which is not valid since the output buffer is allowed to be undersized.
+                     */
+                    DEBUGLOG(7, "partialDecoding: copying literals, close to input or output end")
+                    DEBUGLOG(7, "partialDecoding: literal length = %u", (unsigned)length);
+                    DEBUGLOG(7, "partialDecoding: remaining space in dstBuffer : %i", (int)(oend - op));
+                    DEBUGLOG(7, "partialDecoding: remaining space in srcBuffer : %i", (int)(iend - ip));
+                    /* Finishing in the middle of a literals segment,
+                     * due to lack of input.
+                     */
+                    if (ip+length > iend) {
+                        length = (size_t)(iend-ip);
+                        cpy = op + length;
+                    }
+                    /* Finishing in the middle of a literals segment,
+                     * due to lack of output space.
+                     */
+                    if (cpy > oend) {
+                        cpy = oend;
+                        assert(op<=oend);
+                        length = (size_t)(oend-op);
+                    }
+                } else {
+                     /* We must be on the last sequence (or invalid) because of the parsing limitations
+                      * so check that we exactly consume the input and don't overrun the output buffer.
+                      */
+                    if ((ip+length != iend) || (cpy > oend)) {
+                        DEBUGLOG(5, "should have been last run of literals")
+                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", ip, (int)length, ip+length, iend);
+                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", cpy, oend-MFLIMIT);
+                        DEBUGLOG(5, "after writing %u bytes / %i bytes available", (unsigned)(op-(BYTE*)dst), outputSize);
+                        goto _output_error;
+                    }
+                }
+                LZ4_memmove(op, ip, length);  /* supports overlapping memory regions, for in-place decompression scenarios */
+                ip += length;
+                op += length;
+                /* Necessarily EOF when !partialDecoding.
+                 * When partialDecoding, it is EOF if we've either
+                 * filled the output buffer or
+                 * can't proceed with reading an offset for following match.
+                 */
+                if (!partialDecoding || (cpy == oend) || (ip >= (iend-2))) {
+                    break;
+                }
+            } else {
+                LZ4_wildCopy8(op, ip, cpy);   /* can overwrite up to 8 bytes beyond cpy */
+                ip += length; op = cpy;
+            }
+
+            /* get offset */
+            offset = LZ4_readLE16(ip); ip+=2;
+            match = op - offset;
+
+            /* get matchlength */
+            length = token & ML_MASK;
+            DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+
+    _copy_match:
+            if (length == ML_MASK) {
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (addl == rvl_error) { goto _output_error; }
+                length += addl;
+                if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
+            }
+            length += MINMATCH;
+
+#if LZ4_FAST_DEC_LOOP
+        safe_match_copy:
+#endif
+            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) goto _output_error;   /* Error : offset outside buffers */
+            /* match starting within external dictionary */
+            if ((dict==usingExtDict) && (match < lowPrefix)) {
+                assert(dictEnd != NULL);
+                if (unlikely(op+length > oend-LASTLITERALS)) {
+                    if (partialDecoding) length = MIN(length, (size_t)(oend-op));
+                    else goto _output_error;   /* doesn't respect parsing restriction */
+                }
+
+                if (length <= (size_t)(lowPrefix-match)) {
+                    /* match fits entirely within external dictionary : just copy */
+                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    op += length;
+                } else {
+                    /* match stretches into both external dictionary and current block */
+                    size_t const copySize = (size_t)(lowPrefix - match);
+                    size_t const restSize = length - copySize;
+                    LZ4_memcpy(op, dictEnd - copySize, copySize);
+                    op += copySize;
+                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                        BYTE* const endOfMatch = op + restSize;
+                        const BYTE* copyFrom = lowPrefix;
+                        while (op < endOfMatch) *op++ = *copyFrom++;
+                    } else {
+                        LZ4_memcpy(op, lowPrefix, restSize);
+                        op += restSize;
+                }   }
+                continue;
+            }
+            assert(match >= lowPrefix);
+
+            /* copy match within block */
+            cpy = op + length;
+
+            /* partialDecoding : may end anywhere within the block */
+            assert(op<=oend);
+            if (partialDecoding && (cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
+                size_t const mlen = MIN(length, (size_t)(oend-op));
+                const BYTE* const matchEnd = match + mlen;
+                BYTE* const copyEnd = op + mlen;
+                if (matchEnd > op) {   /* overlap copy */
+                    while (op < copyEnd) { *op++ = *match++; }
+                } else {
+                    LZ4_memcpy(op, match, mlen);
+                }
+                op = copyEnd;
+                if (op == oend) { break; }
+                continue;
+            }
+
+            if (unlikely(offset<8)) {
+                LZ4_write32(op, 0);   /* silence msan warning when offset==0 */
+                op[0] = match[0];
+                op[1] = match[1];
+                op[2] = match[2];
+                op[3] = match[3];
+                match += inc32table[offset];
+                LZ4_memcpy(op+4, match, 4);
+                match -= dec64table[offset];
+            } else {
+                LZ4_memcpy(op, match, 8);
+                match += 8;
+            }
+            op += 8;
+
+            if (unlikely(cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
+                BYTE* const oCopyLimit = oend - (WILDCOPYLENGTH-1);
+                if (cpy > oend-LASTLITERALS) { goto _output_error; } /* Error : last LASTLITERALS bytes must be literals (uncompressed) */
+                if (op < oCopyLimit) {
+                    LZ4_wildCopy8(op, match, oCopyLimit);
+                    match += oCopyLimit - op;
+                    op = oCopyLimit;
+                }
+                while (op < cpy) { *op++ = *match++; }
+            } else {
+                LZ4_memcpy(op, match, 8);
+                if (length > 16) { LZ4_wildCopy8(op+8, match+8, cpy); }
+            }
+            op = cpy;   /* wildcopy correction */
+        }
+
+        /* end of decoding */
+        DEBUGLOG(5, "decoded %i bytes", (int) (((char*)op)-dst));
+        return (int) (((char*)op)-dst);     /* Nb of output bytes decoded */
+
+        /* Overflow error detected */
+    _output_error:
+        return (int) (-(((const char*)ip)-src))-1;
+    }
+}
+
+
+/*===== Instantiate the API decoding functions. =====*/
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe(const char* source, char* dest, int compressedSize, int maxDecompressedSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxDecompressedSize,
+                                  decode_full_block, noDict,
+                                  (BYTE*)dest, NULL, 0);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe_partial(const char* src, char* dst, int compressedSize, int targetOutputSize, int dstCapacity)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(src, dst, compressedSize, dstCapacity,
+                                  partial_decode,
+                                  noDict, (BYTE*)dst, NULL, 0);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_fast(const char* source, char* dest, int originalSize)
+{
+    DEBUGLOG(5, "LZ4_decompress_fast");
+    return LZ4_decompress_unsafe_generic(
+                (const BYTE*)source, (BYTE*)dest, originalSize,
+                0, NULL, 0);
+}
+
+/*===== Instantiate a few more decoding cases, used more than once. =====*/
+
+LZ4_FORCE_O2 /* Exported, an obsolete API function. */
+int LZ4_decompress_safe_withPrefix64k(const char* source, char* dest, int compressedSize, int maxOutputSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, withPrefix64k,
+                                  (BYTE*)dest - 64 KB, NULL, 0);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_safe_partial_withPrefix64k(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
+                                  partial_decode, withPrefix64k,
+                                  (BYTE*)dest - 64 KB, NULL, 0);
+}
+
+/* Another obsolete API function, paired with the previous one. */
+int LZ4_decompress_fast_withPrefix64k(const char* source, char* dest, int originalSize)
+{
+    return LZ4_decompress_unsafe_generic(
+                (const BYTE*)source, (BYTE*)dest, originalSize,
+                64 KB, NULL, 0);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_safe_withSmallPrefix(const char* source, char* dest, int compressedSize, int maxOutputSize,
+                                               size_t prefixSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, noDict,
+                                  (BYTE*)dest-prefixSize, NULL, 0);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_safe_partial_withSmallPrefix(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity,
+                                               size_t prefixSize)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
+                                  partial_decode, noDict,
+                                  (BYTE*)dest-prefixSize, NULL, 0);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int maxOutputSize,
+                                     const void* dictStart, size_t dictSize)
+{
+    DEBUGLOG(5, "LZ4_decompress_safe_forceExtDict");
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, usingExtDict,
+                                  (BYTE*)dest, (const BYTE*)dictStart, dictSize);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int targetOutputSize, int dstCapacity,
+                                     const void* dictStart, size_t dictSize)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
+                                  partial_decode, usingExtDict,
+                                  (BYTE*)dest, (const BYTE*)dictStart, dictSize);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_fast_extDict(const char* source, char* dest, int originalSize,
+                                       const void* dictStart, size_t dictSize)
+{
+    return LZ4_decompress_unsafe_generic(
+                (const BYTE*)source, (BYTE*)dest, originalSize,
+                0, (const BYTE*)dictStart, dictSize);
+}
+
+/* The "double dictionary" mode, for use with e.g. ring buffers: the first part
+ * of the dictionary is passed as prefix, and the second via dictStart + dictSize.
+ * These routines are used only once, in LZ4_decompress_*_continue().
+ */
+LZ4_FORCE_INLINE
+int LZ4_decompress_safe_doubleDict(const char* source, char* dest, int compressedSize, int maxOutputSize,
+                                   size_t prefixSize, const void* dictStart, size_t dictSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, usingExtDict,
+                                  (BYTE*)dest-prefixSize, (const BYTE*)dictStart, dictSize);
+}
+
+/*===== streaming decompression functions =====*/
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_streamDecode_t* LZ4_createStreamDecode(void)
+{
+    LZ4_STATIC_ASSERT(sizeof(LZ4_streamDecode_t) >= sizeof(LZ4_streamDecode_t_internal));
+    return (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
+}
+
+int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
+{
+    if (LZ4_stream == NULL) { return 0; }  /* support free on NULL */
+    FREEMEM(LZ4_stream);
+    return 0;
+}
+#endif
+
+/*! LZ4_setStreamDecode() :
+ *  Use this function to instruct where to find the dictionary.
+ *  This function is not necessary if previous data is still available where it was decoded.
+ *  Loading a size of 0 is allowed (same effect as no dictionary).
+ * @return : 1 if OK, 0 if error
+ */
+int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
+{
+    LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
+    lz4sd->prefixSize = (size_t)dictSize;
+    if (dictSize) {
+        assert(dictionary != NULL);
+        lz4sd->prefixEnd = (const BYTE*) dictionary + dictSize;
+    } else {
+        lz4sd->prefixEnd = (const BYTE*) dictionary;
+    }
+    lz4sd->externalDict = NULL;
+    lz4sd->extDictSize  = 0;
+    return 1;
+}
+
+/*! LZ4_decoderRingBufferSize() :
+ *  when setting a ring buffer for streaming decompression (optional scenario),
+ *  provides the minimum size of this ring buffer
+ *  to be compatible with any source respecting maxBlockSize condition.
+ *  Note : in a ring buffer scenario,
+ *  blocks are presumed decompressed next to each other.
+ *  When not enough space remains for next block (remainingSize < maxBlockSize),
+ *  decoding resumes from beginning of ring buffer.
+ * @return : minimum ring buffer size,
+ *           or 0 if there is an error (invalid maxBlockSize).
+ */
+int LZ4_decoderRingBufferSize(int maxBlockSize)
+{
+    if (maxBlockSize < 0) return 0;
+    if (maxBlockSize > LZ4_MAX_INPUT_SIZE) return 0;
+    if (maxBlockSize < 16) maxBlockSize = 16;
+    return LZ4_DECODER_RING_BUFFER_SIZE(maxBlockSize);
+}
+
+/*
+*_continue() :
+    These decoding functions allow decompression of multiple blocks in "streaming" mode.
+    Previously decoded blocks must still be available at the memory position where they were decoded.
+    If it's not possible, save the relevant part of decoded data into a safe buffer,
+    and indicate where it stands using LZ4_setStreamDecode()
+*/
+LZ4_FORCE_O2
+int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* source, char* dest, int compressedSize, int maxOutputSize)
+{
+    LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
+    int result;
+
+    if (lz4sd->prefixSize == 0) {
+        /* The first call, no dictionary yet. */
+        assert(lz4sd->extDictSize == 0);
+        result = LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)result;
+        lz4sd->prefixEnd = (BYTE*)dest + result;
+    } else if (lz4sd->prefixEnd == (BYTE*)dest) {
+        /* They're rolling the current segment. */
+        if (lz4sd->prefixSize >= 64 KB - 1)
+            result = LZ4_decompress_safe_withPrefix64k(source, dest, compressedSize, maxOutputSize);
+        else if (lz4sd->extDictSize == 0)
+            result = LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize,
+                                                         lz4sd->prefixSize);
+        else
+            result = LZ4_decompress_safe_doubleDict(source, dest, compressedSize, maxOutputSize,
+                                                    lz4sd->prefixSize, lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize += (size_t)result;
+        lz4sd->prefixEnd  += result;
+    } else {
+        /* The buffer wraps around, or they're switching to another buffer. */
+        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
+        result = LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize,
+                                                  lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)result;
+        lz4sd->prefixEnd  = (BYTE*)dest + result;
+    }
+
+    return result;
+}
+
+LZ4_FORCE_O2 int
+LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
+                        const char* source, char* dest, int originalSize)
+{
+    LZ4_streamDecode_t_internal* const lz4sd =
+        (assert(LZ4_streamDecode!=NULL), &LZ4_streamDecode->internal_donotuse);
+    int result;
+
+    DEBUGLOG(5, "LZ4_decompress_fast_continue (toDecodeSize=%i)", originalSize);
+    assert(originalSize >= 0);
+
+    if (lz4sd->prefixSize == 0) {
+        DEBUGLOG(5, "first invocation : no prefix nor extDict");
+        assert(lz4sd->extDictSize == 0);
+        result = LZ4_decompress_fast(source, dest, originalSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)originalSize;
+        lz4sd->prefixEnd = (BYTE*)dest + originalSize;
+    } else if (lz4sd->prefixEnd == (BYTE*)dest) {
+        DEBUGLOG(5, "continue using existing prefix");
+        result = LZ4_decompress_unsafe_generic(
+                        (const BYTE*)source, (BYTE*)dest, originalSize,
+                        lz4sd->prefixSize,
+                        lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize += (size_t)originalSize;
+        lz4sd->prefixEnd  += originalSize;
+    } else {
+        DEBUGLOG(5, "prefix becomes extDict");
+        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
+        result = LZ4_decompress_fast_extDict(source, dest, originalSize,
+                                             lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)originalSize;
+        lz4sd->prefixEnd  = (BYTE*)dest + originalSize;
+    }
+
+    return result;
+}
+
+
+/*
+Advanced decoding functions :
+*_usingDict() :
+    These decoding functions work the same as "_continue" ones,
+    the dictionary must be explicitly provided within parameters
+*/
+
+int LZ4_decompress_safe_usingDict(const char* source, char* dest, int compressedSize, int maxOutputSize, const char* dictStart, int dictSize)
+{
+    if (dictSize==0)
+        return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
+    if (dictStart+dictSize == dest) {
+        if (dictSize >= 64 KB - 1) {
+            return LZ4_decompress_safe_withPrefix64k(source, dest, compressedSize, maxOutputSize);
+        }
+        assert(dictSize >= 0);
+        return LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize, (size_t)dictSize);
+    }
+    assert(dictSize >= 0);
+    return LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize, dictStart, (size_t)dictSize);
+}
+
+int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity, const char* dictStart, int dictSize)
+{
+    if (dictSize==0)
+        return LZ4_decompress_safe_partial(source, dest, compressedSize, targetOutputSize, dstCapacity);
+    if (dictStart+dictSize == dest) {
+        if (dictSize >= 64 KB - 1) {
+            return LZ4_decompress_safe_partial_withPrefix64k(source, dest, compressedSize, targetOutputSize, dstCapacity);
+        }
+        assert(dictSize >= 0);
+        return LZ4_decompress_safe_partial_withSmallPrefix(source, dest, compressedSize, targetOutputSize, dstCapacity, (size_t)dictSize);
+    }
+    assert(dictSize >= 0);
+    return LZ4_decompress_safe_partial_forceExtDict(source, dest, compressedSize, targetOutputSize, dstCapacity, dictStart, (size_t)dictSize);
+}
+
+int LZ4_decompress_fast_usingDict(const char* source, char* dest, int originalSize, const char* dictStart, int dictSize)
+{
+    if (dictSize==0 || dictStart+dictSize == dest)
+        return LZ4_decompress_unsafe_generic(
+                        (const BYTE*)source, (BYTE*)dest, originalSize,
+                        (size_t)dictSize, NULL, 0);
+    assert(dictSize >= 0);
+    return LZ4_decompress_fast_extDict(source, dest, originalSize, dictStart, (size_t)dictSize);
+}
+
+
+/*=*************************************************
+*  Obsolete Functions
+***************************************************/
+/* obsolete compression functions */
+int LZ4_compress_limitedOutput(const char* source, char* dest, int inputSize, int maxOutputSize)
+{
+    return LZ4_compress_default(source, dest, inputSize, maxOutputSize);
+}
+int LZ4_compress(const char* src, char* dest, int srcSize)
+{
+    return LZ4_compress_default(src, dest, srcSize, LZ4_compressBound(srcSize));
+}
+int LZ4_compress_limitedOutput_withState (void* state, const char* src, char* dst, int srcSize, int dstSize)
+{
+    return LZ4_compress_fast_extState(state, src, dst, srcSize, dstSize, 1);
+}
+int LZ4_compress_withState (void* state, const char* src, char* dst, int srcSize)
+{
+    return LZ4_compress_fast_extState(state, src, dst, srcSize, LZ4_compressBound(srcSize), 1);
+}
+int LZ4_compress_limitedOutput_continue (LZ4_stream_t* LZ4_stream, const char* src, char* dst, int srcSize, int dstCapacity)
+{
+    return LZ4_compress_fast_continue(LZ4_stream, src, dst, srcSize, dstCapacity, 1);
+}
+int LZ4_compress_continue (LZ4_stream_t* LZ4_stream, const char* source, char* dest, int inputSize)
+{
+    return LZ4_compress_fast_continue(LZ4_stream, source, dest, inputSize, LZ4_compressBound(inputSize), 1);
+}
+
+/*
+These decompression functions are deprecated and should no longer be used.
+They are only provided here for compatibility with older user programs.
+- LZ4_uncompress is totally equivalent to LZ4_decompress_fast
+- LZ4_uncompress_unknownOutputSize is totally equivalent to LZ4_decompress_safe
+*/
+int LZ4_uncompress (const char* source, char* dest, int outputSize)
+{
+    return LZ4_decompress_fast(source, dest, outputSize);
+}
+int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize)
+{
+    return LZ4_decompress_safe(source, dest, isize, maxOutputSize);
+}
+
+/* Obsolete Streaming functions */
+
+int LZ4_sizeofStreamState(void) { return sizeof(LZ4_stream_t); }
+
+int LZ4_resetStreamState(void* state, char* inputBuffer)
+{
+    (void)inputBuffer;
+    LZ4_resetStream((LZ4_stream_t*)state);
+    return 0;
+}
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+void* LZ4_create (char* inputBuffer)
+{
+    (void)inputBuffer;
+    return LZ4_createStream();
+}
+#endif
+
+char* LZ4_slideInputBuffer (void* state)
+{
+    /* avoid const char * -> char * conversion warning */
+    return (char *)(uptrval)((LZ4_stream_t*)state)->internal_donotuse.dictionary;
+}
+
+#endif   /* LZ4_COMMONDEFS_ONLY */

--- a/deps/lz4/lz4.h
+++ b/deps/lz4/lz4.h
@@ -1,0 +1,884 @@
+/*
+ *  LZ4 - Fast LZ compression algorithm
+ *  Header File
+ *  Copyright (C) 2011-2023, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+    - LZ4 homepage : http://www.lz4.org
+    - LZ4 source repository : https://github.com/lz4/lz4
+*/
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#ifndef LZ4_H_2983827168210
+#define LZ4_H_2983827168210
+
+/* --- Dependency --- */
+#include <stddef.h>   /* size_t */
+
+
+/**
+  Introduction
+
+  LZ4 is lossless compression algorithm, providing compression speed >500 MB/s per core,
+  scalable with multi-cores CPU. It features an extremely fast decoder, with speed in
+  multiple GB/s per core, typically reaching RAM speed limits on multi-core systems.
+
+  The LZ4 compression library provides in-memory compression and decompression functions.
+  It gives full buffer control to user.
+  Compression can be done in:
+    - a single step (described as Simple Functions)
+    - a single step, reusing a context (described in Advanced Functions)
+    - unbounded multiple steps (described as Streaming compression)
+
+  lz4.h generates and decodes LZ4-compressed blocks (doc/lz4_Block_format.md).
+  Decompressing such a compressed block requires additional metadata.
+  Exact metadata depends on exact decompression function.
+  For the typical case of LZ4_decompress_safe(),
+  metadata includes block's compressed size, and maximum bound of decompressed size.
+  Each application is free to encode and pass such metadata in whichever way it wants.
+
+  lz4.h only handle blocks, it can not generate Frames.
+
+  Blocks are different from Frames (doc/lz4_Frame_format.md).
+  Frames bundle both blocks and metadata in a specified manner.
+  Embedding metadata is required for compressed data to be self-contained and portable.
+  Frame format is delivered through a companion API, declared in lz4frame.h.
+  The `lz4` CLI can only manage frames.
+*/
+
+/*^***************************************************************
+*  Export parameters
+*****************************************************************/
+/*
+*  LZ4_DLL_EXPORT :
+*  Enable exporting of functions when building a Windows DLL
+*  LZ4LIB_VISIBILITY :
+*  Control library symbols visibility.
+*/
+#ifndef LZ4LIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4LIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define LZ4LIB_VISIBILITY
+#  endif
+#endif
+#if defined(LZ4_DLL_EXPORT) && (LZ4_DLL_EXPORT==1)
+#  define LZ4LIB_API __declspec(dllexport) LZ4LIB_VISIBILITY
+#elif defined(LZ4_DLL_IMPORT) && (LZ4_DLL_IMPORT==1)
+#  define LZ4LIB_API __declspec(dllimport) LZ4LIB_VISIBILITY /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#else
+#  define LZ4LIB_API LZ4LIB_VISIBILITY
+#endif
+
+/*! LZ4_FREESTANDING :
+ *  When this macro is set to 1, it enables "freestanding mode" that is
+ *  suitable for typical freestanding environment which doesn't support
+ *  standard C library.
+ *
+ *  - LZ4_FREESTANDING is a compile-time switch.
+ *  - It requires the following macros to be defined:
+ *    LZ4_memcpy, LZ4_memmove, LZ4_memset.
+ *  - It only enables LZ4/HC functions which don't use heap.
+ *    All LZ4F_* functions are not supported.
+ *  - See tests/freestanding.c to check its basic setup.
+ */
+#if defined(LZ4_FREESTANDING) && (LZ4_FREESTANDING == 1)
+#  define LZ4_HEAPMODE 0
+#  define LZ4HC_HEAPMODE 0
+#  define LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION 1
+#  if !defined(LZ4_memcpy)
+#    error "LZ4_FREESTANDING requires macro 'LZ4_memcpy'."
+#  endif
+#  if !defined(LZ4_memset)
+#    error "LZ4_FREESTANDING requires macro 'LZ4_memset'."
+#  endif
+#  if !defined(LZ4_memmove)
+#    error "LZ4_FREESTANDING requires macro 'LZ4_memmove'."
+#  endif
+#elif ! defined(LZ4_FREESTANDING)
+#  define LZ4_FREESTANDING 0
+#endif
+
+
+/*------   Version   ------*/
+#define LZ4_VERSION_MAJOR    1    /* for breaking interface changes  */
+#define LZ4_VERSION_MINOR   10    /* for new (non-breaking) interface capabilities */
+#define LZ4_VERSION_RELEASE  0    /* for tweaks, bug-fixes, or development */
+
+#define LZ4_VERSION_NUMBER (LZ4_VERSION_MAJOR *100*100 + LZ4_VERSION_MINOR *100 + LZ4_VERSION_RELEASE)
+
+#define LZ4_LIB_VERSION LZ4_VERSION_MAJOR.LZ4_VERSION_MINOR.LZ4_VERSION_RELEASE
+#define LZ4_QUOTE(str) #str
+#define LZ4_EXPAND_AND_QUOTE(str) LZ4_QUOTE(str)
+#define LZ4_VERSION_STRING LZ4_EXPAND_AND_QUOTE(LZ4_LIB_VERSION)  /* requires v1.7.3+ */
+
+LZ4LIB_API int LZ4_versionNumber (void);  /**< library version number; useful to check dll version; requires v1.3.0+ */
+LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; useful to check dll version; requires v1.7.5+ */
+
+
+/*-************************************
+*  Tuning memory usage
+**************************************/
+/*!
+ * LZ4_MEMORY_USAGE :
+ * Can be selected at compile time, by setting LZ4_MEMORY_USAGE.
+ * Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB)
+ * Increasing memory usage improves compression ratio, generally at the cost of speed.
+ * Reduced memory usage may improve speed at the cost of ratio, thanks to better cache locality.
+ * Default value is 14, for 16KB, which nicely fits into most L1 caches.
+ */
+#ifndef LZ4_MEMORY_USAGE
+# define LZ4_MEMORY_USAGE LZ4_MEMORY_USAGE_DEFAULT
+#endif
+
+/* These are absolute limits, they should not be changed by users */
+#define LZ4_MEMORY_USAGE_MIN 10
+#define LZ4_MEMORY_USAGE_DEFAULT 14
+#define LZ4_MEMORY_USAGE_MAX 20
+
+#if (LZ4_MEMORY_USAGE < LZ4_MEMORY_USAGE_MIN)
+#  error "LZ4_MEMORY_USAGE is too small !"
+#endif
+
+#if (LZ4_MEMORY_USAGE > LZ4_MEMORY_USAGE_MAX)
+#  error "LZ4_MEMORY_USAGE is too large !"
+#endif
+
+/*-************************************
+*  Simple Functions
+**************************************/
+/*! LZ4_compress_default() :
+ *  Compresses 'srcSize' bytes from buffer 'src'
+ *  into already allocated 'dst' buffer of size 'dstCapacity'.
+ *  Compression is guaranteed to succeed if 'dstCapacity' >= LZ4_compressBound(srcSize).
+ *  It also runs faster, so it's a recommended setting.
+ *  If the function cannot compress 'src' into a more limited 'dst' budget,
+ *  compression stops *immediately*, and the function result is zero.
+ *  In which case, 'dst' content is undefined (invalid).
+ *      srcSize : max supported value is LZ4_MAX_INPUT_SIZE.
+ *      dstCapacity : size of buffer 'dst' (which must be already allocated)
+ *     @return  : the number of bytes written into buffer 'dst' (necessarily <= dstCapacity)
+ *                or 0 if compression fails
+ * Note : This function is protected against buffer overflow scenarios (never writes outside 'dst' buffer, nor read outside 'source' buffer).
+ */
+LZ4LIB_API int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacity);
+
+/*! LZ4_decompress_safe() :
+ * @compressedSize : is the exact complete size of the compressed block.
+ * @dstCapacity : is the size of destination buffer (which must be already allocated),
+ *                presumed an upper bound of decompressed size.
+ * @return : the number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
+ *           If destination buffer is not large enough, decoding will stop and output an error code (negative value).
+ *           If the source stream is detected malformed, the function will stop decoding and return a negative result.
+ * Note 1 : This function is protected against malicious data packets :
+ *          it will never writes outside 'dst' buffer, nor read outside 'source' buffer,
+ *          even if the compressed block is maliciously modified to order the decoder to do these actions.
+ *          In such case, the decoder stops immediately, and considers the compressed block malformed.
+ * Note 2 : compressedSize and dstCapacity must be provided to the function, the compressed block does not contain them.
+ *          The implementation is free to send / store / derive this information in whichever way is most beneficial.
+ *          If there is a need for a different format which bundles together both compressed data and its metadata, consider looking at lz4frame.h instead.
+ */
+LZ4LIB_API int LZ4_decompress_safe (const char* src, char* dst, int compressedSize, int dstCapacity);
+
+
+/*-************************************
+*  Advanced Functions
+**************************************/
+#define LZ4_MAX_INPUT_SIZE        0x7E000000   /* 2 113 929 216 bytes */
+#define LZ4_COMPRESSBOUND(isize)  ((unsigned)(isize) > (unsigned)LZ4_MAX_INPUT_SIZE ? 0 : (isize) + ((isize)/255) + 16)
+
+/*! LZ4_compressBound() :
+    Provides the maximum size that LZ4 compression may output in a "worst case" scenario (input data not compressible)
+    This function is primarily useful for memory allocation purposes (destination buffer size).
+    Macro LZ4_COMPRESSBOUND() is also provided for compilation-time evaluation (stack memory allocation for example).
+    Note that LZ4_compress_default() compresses faster when dstCapacity is >= LZ4_compressBound(srcSize)
+        inputSize  : max supported value is LZ4_MAX_INPUT_SIZE
+        return : maximum output size in a "worst case" scenario
+              or 0, if input size is incorrect (too large or negative)
+*/
+LZ4LIB_API int LZ4_compressBound(int inputSize);
+
+/*! LZ4_compress_fast() :
+    Same as LZ4_compress_default(), but allows selection of "acceleration" factor.
+    The larger the acceleration value, the faster the algorithm, but also the lesser the compression.
+    It's a trade-off. It can be fine tuned, with each successive value providing roughly +~3% to speed.
+    An acceleration value of "1" is the same as regular LZ4_compress_default()
+    Values <= 0 will be replaced by LZ4_ACCELERATION_DEFAULT (currently == 1, see lz4.c).
+    Values > LZ4_ACCELERATION_MAX will be replaced by LZ4_ACCELERATION_MAX (currently == 65537, see lz4.c).
+*/
+LZ4LIB_API int LZ4_compress_fast (const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+
+/*! LZ4_compress_fast_extState() :
+ *  Same as LZ4_compress_fast(), using an externally allocated memory space for its state.
+ *  Use LZ4_sizeofState() to know how much memory must be allocated,
+ *  and allocate it on 8-bytes boundaries (using `malloc()` typically).
+ *  Then, provide this buffer as `void* state` to compression function.
+ */
+LZ4LIB_API int LZ4_sizeofState(void);
+LZ4LIB_API int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_compress_destSize() :
+ *  Reverse the logic : compresses as much data as possible from 'src' buffer
+ *  into already allocated buffer 'dst', of size >= 'dstCapacity'.
+ *  This function either compresses the entire 'src' content into 'dst' if it's large enough,
+ *  or fill 'dst' buffer completely with as much data as possible from 'src'.
+ *  note: acceleration parameter is fixed to "default".
+ *
+ * *srcSizePtr : in+out parameter. Initially contains size of input.
+ *               Will be modified to indicate how many bytes where read from 'src' to fill 'dst'.
+ *               New value is necessarily <= input value.
+ * @return : Nb bytes written into 'dst' (necessarily <= dstCapacity)
+ *           or 0 if compression fails.
+ *
+ * Note : from v1.8.2 to v1.9.1, this function had a bug (fixed in v1.9.2+):
+ *        the produced compressed content could, in specific circumstances,
+ *        require to be decompressed into a destination buffer larger
+ *        by at least 1 byte than the content to decompress.
+ *        If an application uses `LZ4_compress_destSize()`,
+ *        it's highly recommended to update liblz4 to v1.9.2 or better.
+ *        If this can't be done or ensured,
+ *        the receiving decompression function should provide
+ *        a dstCapacity which is > decompressedSize, by at least 1 byte.
+ *        See https://github.com/lz4/lz4/issues/859 for details
+ */
+LZ4LIB_API int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize);
+
+/*! LZ4_decompress_safe_partial() :
+ *  Decompress an LZ4 compressed block, of size 'srcSize' at position 'src',
+ *  into destination buffer 'dst' of size 'dstCapacity'.
+ *  Up to 'targetOutputSize' bytes will be decoded.
+ *  The function stops decoding on reaching this objective.
+ *  This can be useful to boost performance
+ *  whenever only the beginning of a block is required.
+ *
+ * @return : the number of bytes decoded in `dst` (necessarily <= targetOutputSize)
+ *           If source stream is detected malformed, function returns a negative result.
+ *
+ *  Note 1 : @return can be < targetOutputSize, if compressed block contains less data.
+ *
+ *  Note 2 : targetOutputSize must be <= dstCapacity
+ *
+ *  Note 3 : this function effectively stops decoding on reaching targetOutputSize,
+ *           so dstCapacity is kind of redundant.
+ *           This is because in older versions of this function,
+ *           decoding operation would still write complete sequences.
+ *           Therefore, there was no guarantee that it would stop writing at exactly targetOutputSize,
+ *           it could write more bytes, though only up to dstCapacity.
+ *           Some "margin" used to be required for this operation to work properly.
+ *           Thankfully, this is no longer necessary.
+ *           The function nonetheless keeps the same signature, in an effort to preserve API compatibility.
+ *
+ *  Note 4 : If srcSize is the exact size of the block,
+ *           then targetOutputSize can be any value,
+ *           including larger than the block's decompressed size.
+ *           The function will, at most, generate block's decompressed size.
+ *
+ *  Note 5 : If srcSize is _larger_ than block's compressed size,
+ *           then targetOutputSize **MUST** be <= block's decompressed size.
+ *           Otherwise, *silent corruption will occur*.
+ */
+LZ4LIB_API int LZ4_decompress_safe_partial (const char* src, char* dst, int srcSize, int targetOutputSize, int dstCapacity);
+
+
+/*-*********************************************
+*  Streaming Compression Functions
+***********************************************/
+typedef union LZ4_stream_u LZ4_stream_t;  /* incomplete type (defined later) */
+
+/*!
+ Note about RC_INVOKED
+
+ - RC_INVOKED is predefined symbol of rc.exe (the resource compiler which is part of MSVC/Visual Studio).
+   https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros
+
+ - Since rc.exe is a legacy compiler, it truncates long symbol (> 30 chars)
+   and reports warning "RC4011: identifier truncated".
+
+ - To eliminate the warning, we surround long preprocessor symbol with
+   "#if !defined(RC_INVOKED) ... #endif" block that means
+   "skip this block when rc.exe is trying to read it".
+*/
+#if !defined(RC_INVOKED) /* https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4LIB_API LZ4_stream_t* LZ4_createStream(void);
+LZ4LIB_API int           LZ4_freeStream (LZ4_stream_t* streamPtr);
+#endif /* !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION) */
+#endif
+
+/*! LZ4_resetStream_fast() : v1.9.0+
+ *  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
+ *  (e.g., LZ4_compress_fast_continue()).
+ *
+ *  An LZ4_stream_t must be initialized once before usage.
+ *  This is automatically done when created by LZ4_createStream().
+ *  However, should the LZ4_stream_t be simply declared on stack (for example),
+ *  it's necessary to initialize it first, using LZ4_initStream().
+ *
+ *  After init, start any new stream with LZ4_resetStream_fast().
+ *  A same LZ4_stream_t can be re-used multiple times consecutively
+ *  and compress multiple streams,
+ *  provided that it starts each new stream with LZ4_resetStream_fast().
+ *
+ *  LZ4_resetStream_fast() is much faster than LZ4_initStream(),
+ *  but is not compatible with memory regions containing garbage data.
+ *
+ *  Note: it's only useful to call LZ4_resetStream_fast()
+ *        in the context of streaming compression.
+ *        The *extState* functions perform their own resets.
+ *        Invoking LZ4_resetStream_fast() before is redundant, and even counterproductive.
+ */
+LZ4LIB_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
+
+/*! LZ4_loadDict() :
+ *  Use this function to reference a static dictionary into LZ4_stream_t.
+ *  The dictionary must remain available during compression.
+ *  LZ4_loadDict() triggers a reset, so any previous data will be forgotten.
+ *  The same dictionary will have to be loaded on decompression side for successful decoding.
+ *  Dictionary are useful for better compression of small data (KB range).
+ *  While LZ4 itself accepts any input as dictionary, dictionary efficiency is also a topic.
+ *  When in doubt, employ the Zstandard's Dictionary Builder.
+ *  Loading a size of 0 is allowed, and is the same as reset.
+ * @return : loaded dictionary size, in bytes (note: only the last 64 KB are loaded)
+ */
+LZ4LIB_API int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
+
+/*! LZ4_loadDictSlow() : v1.10.0+
+ *  Same as LZ4_loadDict(),
+ *  but uses a bit more cpu to reference the dictionary content more thoroughly.
+ *  This is expected to slightly improve compression ratio.
+ *  The extra-cpu cost is likely worth it if the dictionary is re-used across multiple sessions.
+ * @return : loaded dictionary size, in bytes (note: only the last 64 KB are loaded)
+ */
+LZ4LIB_API int LZ4_loadDictSlow(LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
+
+/*! LZ4_attach_dictionary() : stable since v1.10.0
+ *
+ *  This allows efficient re-use of a static dictionary multiple times.
+ *
+ *  Rather than re-loading the dictionary buffer into a working context before
+ *  each compression, or copying a pre-loaded dictionary's LZ4_stream_t into a
+ *  working LZ4_stream_t, this function introduces a no-copy setup mechanism,
+ *  in which the working stream references @dictionaryStream in-place.
+ *
+ *  Several assumptions are made about the state of @dictionaryStream.
+ *  Currently, only states which have been prepared by LZ4_loadDict() or
+ *  LZ4_loadDictSlow() should be expected to work.
+ *
+ *  Alternatively, the provided @dictionaryStream may be NULL,
+ *  in which case any existing dictionary stream is unset.
+ *
+ *  If a dictionary is provided, it replaces any pre-existing stream history.
+ *  The dictionary contents are the only history that can be referenced and
+ *  logically immediately precede the data compressed in the first subsequent
+ *  compression call.
+ *
+ *  The dictionary will only remain attached to the working stream through the
+ *  first compression call, at the end of which it is cleared.
+ * @dictionaryStream stream (and source buffer) must remain in-place / accessible / unchanged
+ *  through the completion of the compression session.
+ *
+ *  Note: there is no equivalent LZ4_attach_*() method on the decompression side
+ *  because there is no initialization cost, hence no need to share the cost across multiple sessions.
+ *  To decompress LZ4 blocks using dictionary, attached or not,
+ *  just employ the regular LZ4_setStreamDecode() for streaming,
+ *  or the stateless LZ4_decompress_safe_usingDict() for one-shot decompression.
+ */
+LZ4LIB_API void
+LZ4_attach_dictionary(LZ4_stream_t* workingStream,
+                const LZ4_stream_t* dictionaryStream);
+
+/*! LZ4_compress_fast_continue() :
+ *  Compress 'src' content using data from previously compressed blocks, for better compression ratio.
+ * 'dst' buffer must be already allocated.
+ *  If dstCapacity >= LZ4_compressBound(srcSize), compression is guaranteed to succeed, and runs faster.
+ *
+ * @return : size of compressed block
+ *           or 0 if there is an error (typically, cannot fit into 'dst').
+ *
+ *  Note 1 : Each invocation to LZ4_compress_fast_continue() generates a new block.
+ *           Each block has precise boundaries.
+ *           Each block must be decompressed separately, calling LZ4_decompress_*() with relevant metadata.
+ *           It's not possible to append blocks together and expect a single invocation of LZ4_decompress_*() to decompress them together.
+ *
+ *  Note 2 : The previous 64KB of source data is __assumed__ to remain present, unmodified, at same address in memory !
+ *
+ *  Note 3 : When input is structured as a double-buffer, each buffer can have any size, including < 64 KB.
+ *           Make sure that buffers are separated, by at least one byte.
+ *           This construction ensures that each block only depends on previous block.
+ *
+ *  Note 4 : If input buffer is a ring-buffer, it can have any size, including < 64 KB.
+ *
+ *  Note 5 : After an error, the stream status is undefined (invalid), it can only be reset or freed.
+ */
+LZ4LIB_API int LZ4_compress_fast_continue (LZ4_stream_t* streamPtr, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_saveDict() :
+ *  If last 64KB data cannot be guaranteed to remain available at its current memory location,
+ *  save it into a safer place (char* safeBuffer).
+ *  This is schematically equivalent to a memcpy() followed by LZ4_loadDict(),
+ *  but is much faster, because LZ4_saveDict() doesn't need to rebuild tables.
+ * @return : saved dictionary size in bytes (necessarily <= maxDictSize), or 0 if error.
+ */
+LZ4LIB_API int LZ4_saveDict (LZ4_stream_t* streamPtr, char* safeBuffer, int maxDictSize);
+
+
+/*-**********************************************
+*  Streaming Decompression Functions
+*  Bufferless synchronous API
+************************************************/
+typedef union LZ4_streamDecode_u LZ4_streamDecode_t;   /* tracking context */
+
+/*! LZ4_createStreamDecode() and LZ4_freeStreamDecode() :
+ *  creation / destruction of streaming decompression tracking context.
+ *  A tracking context can be re-used multiple times.
+ */
+#if !defined(RC_INVOKED) /* https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4LIB_API LZ4_streamDecode_t* LZ4_createStreamDecode(void);
+LZ4LIB_API int                 LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream);
+#endif /* !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION) */
+#endif
+
+/*! LZ4_setStreamDecode() :
+ *  An LZ4_streamDecode_t context can be allocated once and re-used multiple times.
+ *  Use this function to start decompression of a new stream of blocks.
+ *  A dictionary can optionally be set. Use NULL or size 0 for a reset order.
+ *  Dictionary is presumed stable : it must remain accessible and unmodified during next decompression.
+ * @return : 1 if OK, 0 if error
+ */
+LZ4LIB_API int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize);
+
+/*! LZ4_decoderRingBufferSize() : v1.8.2+
+ *  Note : in a ring buffer scenario (optional),
+ *  blocks are presumed decompressed next to each other
+ *  up to the moment there is not enough remaining space for next block (remainingSize < maxBlockSize),
+ *  at which stage it resumes from beginning of ring buffer.
+ *  When setting such a ring buffer for streaming decompression,
+ *  provides the minimum size of this ring buffer
+ *  to be compatible with any source respecting maxBlockSize condition.
+ * @return : minimum ring buffer size,
+ *           or 0 if there is an error (invalid maxBlockSize).
+ */
+LZ4LIB_API int LZ4_decoderRingBufferSize(int maxBlockSize);
+#define LZ4_DECODER_RING_BUFFER_SIZE(maxBlockSize) (65536 + 14 + (maxBlockSize))  /* for static allocation; maxBlockSize presumed valid */
+
+/*! LZ4_decompress_safe_continue() :
+ *  This decoding function allows decompression of consecutive blocks in "streaming" mode.
+ *  The difference with the usual independent blocks is that
+ *  new blocks are allowed to find references into former blocks.
+ *  A block is an unsplittable entity, and must be presented entirely to the decompression function.
+ *  LZ4_decompress_safe_continue() only accepts one block at a time.
+ *  It's modeled after `LZ4_decompress_safe()` and behaves similarly.
+ *
+ * @LZ4_streamDecode : decompression state, tracking the position in memory of past data
+ * @compressedSize : exact complete size of one compressed block.
+ * @dstCapacity : size of destination buffer (which must be already allocated),
+ *                must be an upper bound of decompressed size.
+ * @return : number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
+ *           If destination buffer is not large enough, decoding will stop and output an error code (negative value).
+ *           If the source stream is detected malformed, the function will stop decoding and return a negative result.
+ *
+ *  The last 64KB of previously decoded data *must* remain available and unmodified
+ *  at the memory position where they were previously decoded.
+ *  If less than 64KB of data has been decoded, all the data must be present.
+ *
+ *  Special : if decompression side sets a ring buffer, it must respect one of the following conditions :
+ *  - Decompression buffer size is _at least_ LZ4_decoderRingBufferSize(maxBlockSize).
+ *    maxBlockSize is the maximum size of any single block. It can have any value > 16 bytes.
+ *    In which case, encoding and decoding buffers do not need to be synchronized.
+ *    Actually, data can be produced by any source compliant with LZ4 format specification, and respecting maxBlockSize.
+ *  - Synchronized mode :
+ *    Decompression buffer size is _exactly_ the same as compression buffer size,
+ *    and follows exactly same update rule (block boundaries at same positions),
+ *    and decoding function is provided with exact decompressed size of each block (exception for last block of the stream),
+ *    _then_ decoding & encoding ring buffer can have any size, including small ones ( < 64 KB).
+ *  - Decompression buffer is larger than encoding buffer, by a minimum of maxBlockSize more bytes.
+ *    In which case, encoding and decoding buffers do not need to be synchronized,
+ *    and encoding ring buffer can have any size, including small ones ( < 64 KB).
+ *
+ *  Whenever these conditions are not possible,
+ *  save the last 64KB of decoded data into a safe buffer where it can't be modified during decompression,
+ *  then indicate where this data is saved using LZ4_setStreamDecode(), before decompressing next block.
+*/
+LZ4LIB_API int
+LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode,
+                        const char* src, char* dst,
+                        int srcSize, int dstCapacity);
+
+
+/*! LZ4_decompress_safe_usingDict() :
+ *  Works the same as
+ *  a combination of LZ4_setStreamDecode() followed by LZ4_decompress_safe_continue()
+ *  However, it's stateless: it doesn't need any LZ4_streamDecode_t state.
+ *  Dictionary is presumed stable : it must remain accessible and unmodified during decompression.
+ *  Performance tip : Decompression speed can be substantially increased
+ *                    when dst == dictStart + dictSize.
+ */
+LZ4LIB_API int
+LZ4_decompress_safe_usingDict(const char* src, char* dst,
+                              int srcSize, int dstCapacity,
+                              const char* dictStart, int dictSize);
+
+/*! LZ4_decompress_safe_partial_usingDict() :
+ *  Behaves the same as LZ4_decompress_safe_partial()
+ *  with the added ability to specify a memory segment for past data.
+ *  Performance tip : Decompression speed can be substantially increased
+ *                    when dst == dictStart + dictSize.
+ */
+LZ4LIB_API int
+LZ4_decompress_safe_partial_usingDict(const char* src, char* dst,
+                                      int compressedSize,
+                                      int targetOutputSize, int maxOutputSize,
+                                      const char* dictStart, int dictSize);
+
+#endif /* LZ4_H_2983827168210 */
+
+
+/*^*************************************
+ * !!!!!!   STATIC LINKING ONLY   !!!!!!
+ ***************************************/
+
+/*-****************************************************************************
+ * Experimental section
+ *
+ * Symbols declared in this section must be considered unstable. Their
+ * signatures or semantics may change, or they may be removed altogether in the
+ * future. They are therefore only safe to depend on when the caller is
+ * statically linked against the library.
+ *
+ * To protect against unsafe usage, not only are the declarations guarded,
+ * the definitions are hidden by default
+ * when building LZ4 as a shared/dynamic library.
+ *
+ * In order to access these declarations,
+ * define LZ4_STATIC_LINKING_ONLY in your application
+ * before including LZ4's headers.
+ *
+ * In order to make their implementations accessible dynamically, you must
+ * define LZ4_PUBLISH_STATIC_FUNCTIONS when building the LZ4 library.
+ ******************************************************************************/
+
+#ifdef LZ4_STATIC_LINKING_ONLY
+
+#ifndef LZ4_STATIC_3504398509
+#define LZ4_STATIC_3504398509
+
+#ifdef LZ4_PUBLISH_STATIC_FUNCTIONS
+# define LZ4LIB_STATIC_API LZ4LIB_API
+#else
+# define LZ4LIB_STATIC_API
+#endif
+
+
+/*! LZ4_compress_fast_extState_fastReset() :
+ *  A variant of LZ4_compress_fast_extState().
+ *
+ *  Using this variant avoids an expensive initialization step.
+ *  It is only safe to call if the state buffer is known to be correctly initialized already
+ *  (see above comment on LZ4_resetStream_fast() for a definition of "correctly initialized").
+ *  From a high level, the difference is that
+ *  this function initializes the provided state with a call to something like LZ4_resetStream_fast()
+ *  while LZ4_compress_fast_extState() starts with a call to LZ4_resetStream().
+ */
+LZ4LIB_STATIC_API int LZ4_compress_fast_extState_fastReset (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_compress_destSize_extState() : introduced in v1.10.0
+ *  Same as LZ4_compress_destSize(), but using an externally allocated state.
+ *  Also: exposes @acceleration
+ */
+int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration);
+
+/*! In-place compression and decompression
+ *
+ * It's possible to have input and output sharing the same buffer,
+ * for highly constrained memory environments.
+ * In both cases, it requires input to lay at the end of the buffer,
+ * and decompression to start at beginning of the buffer.
+ * Buffer size must feature some margin, hence be larger than final size.
+ *
+ * |<------------------------buffer--------------------------------->|
+ *                             |<-----------compressed data--------->|
+ * |<-----------decompressed size------------------>|
+ *                                                  |<----margin---->|
+ *
+ * This technique is more useful for decompression,
+ * since decompressed size is typically larger,
+ * and margin is short.
+ *
+ * In-place decompression will work inside any buffer
+ * which size is >= LZ4_DECOMPRESS_INPLACE_BUFFER_SIZE(decompressedSize).
+ * This presumes that decompressedSize > compressedSize.
+ * Otherwise, it means compression actually expanded data,
+ * and it would be more efficient to store such data with a flag indicating it's not compressed.
+ * This can happen when data is not compressible (already compressed, or encrypted).
+ *
+ * For in-place compression, margin is larger, as it must be able to cope with both
+ * history preservation, requiring input data to remain unmodified up to LZ4_DISTANCE_MAX,
+ * and data expansion, which can happen when input is not compressible.
+ * As a consequence, buffer size requirements are much higher,
+ * and memory savings offered by in-place compression are more limited.
+ *
+ * There are ways to limit this cost for compression :
+ * - Reduce history size, by modifying LZ4_DISTANCE_MAX.
+ *   Note that it is a compile-time constant, so all compressions will apply this limit.
+ *   Lower values will reduce compression ratio, except when input_size < LZ4_DISTANCE_MAX,
+ *   so it's a reasonable trick when inputs are known to be small.
+ * - Require the compressor to deliver a "maximum compressed size".
+ *   This is the `dstCapacity` parameter in `LZ4_compress*()`.
+ *   When this size is < LZ4_COMPRESSBOUND(inputSize), then compression can fail,
+ *   in which case, the return code will be 0 (zero).
+ *   The caller must be ready for these cases to happen,
+ *   and typically design a backup scheme to send data uncompressed.
+ * The combination of both techniques can significantly reduce
+ * the amount of margin required for in-place compression.
+ *
+ * In-place compression can work in any buffer
+ * which size is >= (maxCompressedSize)
+ * with maxCompressedSize == LZ4_COMPRESSBOUND(srcSize) for guaranteed compression success.
+ * LZ4_COMPRESS_INPLACE_BUFFER_SIZE() depends on both maxCompressedSize and LZ4_DISTANCE_MAX,
+ * so it's possible to reduce memory requirements by playing with them.
+ */
+
+#define LZ4_DECOMPRESS_INPLACE_MARGIN(compressedSize)          (((compressedSize) >> 8) + 32)
+#define LZ4_DECOMPRESS_INPLACE_BUFFER_SIZE(decompressedSize)   ((decompressedSize) + LZ4_DECOMPRESS_INPLACE_MARGIN(decompressedSize))  /**< note: presumes that compressedSize < decompressedSize. note2: margin is overestimated a bit, since it could use compressedSize instead */
+
+#ifndef LZ4_DISTANCE_MAX   /* history window size; can be user-defined at compile time */
+#  define LZ4_DISTANCE_MAX 65535   /* set to maximum value by default */
+#endif
+
+#define LZ4_COMPRESS_INPLACE_MARGIN                           (LZ4_DISTANCE_MAX + 32)   /* LZ4_DISTANCE_MAX can be safely replaced by srcSize when it's smaller */
+#define LZ4_COMPRESS_INPLACE_BUFFER_SIZE(maxCompressedSize)   ((maxCompressedSize) + LZ4_COMPRESS_INPLACE_MARGIN)  /**< maxCompressedSize is generally LZ4_COMPRESSBOUND(inputSize), but can be set to any lower value, with the risk that compression can fail (return code 0(zero)) */
+
+#endif   /* LZ4_STATIC_3504398509 */
+#endif   /* LZ4_STATIC_LINKING_ONLY */
+
+
+
+#ifndef LZ4_H_98237428734687
+#define LZ4_H_98237428734687
+
+/*-************************************************************
+ *  Private Definitions
+ **************************************************************
+ * Do not use these definitions directly.
+ * They are only exposed to allow static allocation of `LZ4_stream_t` and `LZ4_streamDecode_t`.
+ * Accessing members will expose user code to API and/or ABI break in future versions of the library.
+ **************************************************************/
+#define LZ4_HASHLOG   (LZ4_MEMORY_USAGE-2)
+#define LZ4_HASHTABLESIZE (1 << LZ4_MEMORY_USAGE)
+#define LZ4_HASH_SIZE_U32 (1 << LZ4_HASHLOG)       /* required as macro for static allocation */
+
+#if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+# include <stdint.h>
+  typedef  int8_t  LZ4_i8;
+  typedef uint8_t  LZ4_byte;
+  typedef uint16_t LZ4_u16;
+  typedef uint32_t LZ4_u32;
+#else
+  typedef   signed char  LZ4_i8;
+  typedef unsigned char  LZ4_byte;
+  typedef unsigned short LZ4_u16;
+  typedef unsigned int   LZ4_u32;
+#endif
+
+/*! LZ4_stream_t :
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_stream_t object.
+**/
+
+typedef struct LZ4_stream_t_internal LZ4_stream_t_internal;
+struct LZ4_stream_t_internal {
+    LZ4_u32 hashTable[LZ4_HASH_SIZE_U32];
+    const LZ4_byte* dictionary;
+    const LZ4_stream_t_internal* dictCtx;
+    LZ4_u32 currentOffset;
+    LZ4_u32 tableType;
+    LZ4_u32 dictSize;
+    /* Implicit padding to ensure structure is aligned */
+};
+
+#define LZ4_STREAM_MINSIZE  ((1UL << (LZ4_MEMORY_USAGE)) + 32)  /* static size, for inter-version compatibility */
+union LZ4_stream_u {
+    char minStateSize[LZ4_STREAM_MINSIZE];
+    LZ4_stream_t_internal internal_donotuse;
+}; /* previously typedef'd to LZ4_stream_t */
+
+
+/*! LZ4_initStream() : v1.9.0+
+ *  An LZ4_stream_t structure must be initialized at least once.
+ *  This is automatically done when invoking LZ4_createStream(),
+ *  but it's not when the structure is simply declared on stack (for example).
+ *
+ *  Use LZ4_initStream() to properly initialize a newly declared LZ4_stream_t.
+ *  It can also initialize any arbitrary buffer of sufficient size,
+ *  and will @return a pointer of proper type upon initialization.
+ *
+ *  Note : initialization fails if size and alignment conditions are not respected.
+ *         In which case, the function will @return NULL.
+ *  Note2: An LZ4_stream_t structure guarantees correct alignment and size.
+ *  Note3: Before v1.9.0, use LZ4_resetStream() instead
+**/
+LZ4LIB_API LZ4_stream_t* LZ4_initStream (void* stateBuffer, size_t size);
+
+
+/*! LZ4_streamDecode_t :
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_streamDecode_t object.
+**/
+typedef struct {
+    const LZ4_byte* externalDict;
+    const LZ4_byte* prefixEnd;
+    size_t extDictSize;
+    size_t prefixSize;
+} LZ4_streamDecode_t_internal;
+
+#define LZ4_STREAMDECODE_MINSIZE 32
+union LZ4_streamDecode_u {
+    char minStateSize[LZ4_STREAMDECODE_MINSIZE];
+    LZ4_streamDecode_t_internal internal_donotuse;
+} ;   /* previously typedef'd to LZ4_streamDecode_t */
+
+
+
+/*-************************************
+*  Obsolete Functions
+**************************************/
+
+/*! Deprecation warnings
+ *
+ *  Deprecated functions make the compiler generate a warning when invoked.
+ *  This is meant to invite users to update their source code.
+ *  Should deprecation warnings be a problem, it is generally possible to disable them,
+ *  typically with -Wno-deprecated-declarations for gcc
+ *  or _CRT_SECURE_NO_WARNINGS in Visual.
+ *
+ *  Another method is to define LZ4_DISABLE_DEPRECATE_WARNINGS
+ *  before including the header file.
+ */
+#ifdef LZ4_DISABLE_DEPRECATE_WARNINGS
+#  define LZ4_DEPRECATED(message)   /* disable deprecation warnings */
+#else
+#  if defined (__cplusplus) && (__cplusplus >= 201402) /* C++14 or greater */
+#    define LZ4_DEPRECATED(message) [[deprecated(message)]]
+#  elif defined(_MSC_VER)
+#    define LZ4_DEPRECATED(message) __declspec(deprecated(message))
+#  elif defined(__clang__) || (defined(__GNUC__) && (__GNUC__ * 10 + __GNUC_MINOR__ >= 45))
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated(message)))
+#  elif defined(__GNUC__) && (__GNUC__ * 10 + __GNUC_MINOR__ >= 31)
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated))
+#  else
+#    pragma message("WARNING: LZ4_DEPRECATED needs custom implementation for this compiler")
+#    define LZ4_DEPRECATED(message)   /* disabled */
+#  endif
+#endif /* LZ4_DISABLE_DEPRECATE_WARNINGS */
+
+/*! Obsolete compression functions (since v1.7.3) */
+LZ4_DEPRECATED("use LZ4_compress_default() instead")       LZ4LIB_API int LZ4_compress               (const char* src, char* dest, int srcSize);
+LZ4_DEPRECATED("use LZ4_compress_default() instead")       LZ4LIB_API int LZ4_compress_limitedOutput (const char* src, char* dest, int srcSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_extState() instead") LZ4LIB_API int LZ4_compress_withState               (void* state, const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_extState() instead") LZ4LIB_API int LZ4_compress_limitedOutput_withState (void* state, const char* source, char* dest, int inputSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_continue() instead") LZ4LIB_API int LZ4_compress_continue                (LZ4_stream_t* LZ4_streamPtr, const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_continue() instead") LZ4LIB_API int LZ4_compress_limitedOutput_continue  (LZ4_stream_t* LZ4_streamPtr, const char* source, char* dest, int inputSize, int maxOutputSize);
+
+/*! Obsolete decompression functions (since v1.8.0) */
+LZ4_DEPRECATED("use LZ4_decompress_fast() instead") LZ4LIB_API int LZ4_uncompress (const char* source, char* dest, int outputSize);
+LZ4_DEPRECATED("use LZ4_decompress_safe() instead") LZ4LIB_API int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize);
+
+/* Obsolete streaming functions (since v1.7.0)
+ * degraded functionality; do not use!
+ *
+ * In order to perform streaming compression, these functions depended on data
+ * that is no longer tracked in the state. They have been preserved as well as
+ * possible: using them will still produce a correct output. However, they don't
+ * actually retain any history between compression calls. The compression ratio
+ * achieved will therefore be no better than compressing each chunk
+ * independently.
+ */
+LZ4_DEPRECATED("Use LZ4_createStream() instead") LZ4LIB_API void* LZ4_create (char* inputBuffer);
+LZ4_DEPRECATED("Use LZ4_createStream() instead") LZ4LIB_API int   LZ4_sizeofStreamState(void);
+LZ4_DEPRECATED("Use LZ4_resetStream() instead")  LZ4LIB_API int   LZ4_resetStreamState(void* state, char* inputBuffer);
+LZ4_DEPRECATED("Use LZ4_saveDict() instead")     LZ4LIB_API char* LZ4_slideInputBuffer (void* state);
+
+/*! Obsolete streaming decoding functions (since v1.7.0) */
+LZ4_DEPRECATED("use LZ4_decompress_safe_usingDict() instead") LZ4LIB_API int LZ4_decompress_safe_withPrefix64k (const char* src, char* dst, int compressedSize, int maxDstSize);
+LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") LZ4LIB_API int LZ4_decompress_fast_withPrefix64k (const char* src, char* dst, int originalSize);
+
+/*! Obsolete LZ4_decompress_fast variants (since v1.9.0) :
+ *  These functions used to be faster than LZ4_decompress_safe(),
+ *  but this is no longer the case. They are now slower.
+ *  This is because LZ4_decompress_fast() doesn't know the input size,
+ *  and therefore must progress more cautiously into the input buffer to not read beyond the end of block.
+ *  On top of that `LZ4_decompress_fast()` is not protected vs malformed or malicious inputs, making it a security liability.
+ *  As a consequence, LZ4_decompress_fast() is strongly discouraged, and deprecated.
+ *
+ *  The last remaining LZ4_decompress_fast() specificity is that
+ *  it can decompress a block without knowing its compressed size.
+ *  Such functionality can be achieved in a more secure manner
+ *  by employing LZ4_decompress_safe_partial().
+ *
+ *  Parameters:
+ *  originalSize : is the uncompressed size to regenerate.
+ *                 `dst` must be already allocated, its size must be >= 'originalSize' bytes.
+ * @return : number of bytes read from source buffer (== compressed size).
+ *           The function expects to finish at block's end exactly.
+ *           If the source stream is detected malformed, the function stops decoding and returns a negative result.
+ *  note : LZ4_decompress_fast*() requires originalSize. Thanks to this information, it never writes past the output buffer.
+ *         However, since it doesn't know its 'src' size, it may read an unknown amount of input, past input buffer bounds.
+ *         Also, since match offsets are not validated, match reads from 'src' may underflow too.
+ *         These issues never happen if input (compressed) data is correct.
+ *         But they may happen if input data is invalid (error or intentional tampering).
+ *         As a consequence, use these functions in trusted environments with trusted data **only**.
+ */
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial() instead")
+LZ4LIB_API int LZ4_decompress_fast (const char* src, char* dst, int originalSize);
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider migrating towards LZ4_decompress_safe_continue() instead. "
+               "Note that the contract will change (requires block's compressed size, instead of decompressed size)")
+LZ4LIB_API int LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int originalSize);
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial_usingDict() instead")
+LZ4LIB_API int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize, const char* dictStart, int dictSize);
+
+/*! LZ4_resetStream() :
+ *  An LZ4_stream_t structure must be initialized at least once.
+ *  This is done with LZ4_initStream(), or LZ4_resetStream().
+ *  Consider switching to LZ4_initStream(),
+ *  invoking LZ4_resetStream() will trigger deprecation warnings in the future.
+ */
+LZ4LIB_API void LZ4_resetStream (LZ4_stream_t* streamPtr);
+
+
+#endif /* LZ4_H_98237428734687 */
+
+
+#if defined (__cplusplus)
+}
+#endif

--- a/deps/lz4/lz4frame.c
+++ b/deps/lz4/lz4frame.c
@@ -1,0 +1,2136 @@
+/*
+ * LZ4 auto-framing library
+ * Copyright (C) 2011-2016, Yann Collet.
+ *
+ * BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * You can contact the author at :
+ * - LZ4 homepage : http://www.lz4.org
+ * - LZ4 source repository : https://github.com/lz4/lz4
+ */
+
+/* LZ4F is a stand-alone API to create LZ4-compressed Frames
+ * in full conformance with specification v1.6.1 .
+ * This library rely upon memory management capabilities (malloc, free)
+ * provided either by <stdlib.h>,
+ * or redirected towards another library of user's choice
+ * (see Memory Routines below).
+ */
+
+
+/*-************************************
+*  Compiler Options
+**************************************/
+#include <limits.h>
+#ifdef _MSC_VER    /* Visual Studio */
+#  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
+#endif
+
+
+/*-************************************
+*  Tuning parameters
+**************************************/
+/*
+ * LZ4F_HEAPMODE :
+ * Control how LZ4F_compressFrame allocates the Compression State,
+ * either on stack (0:default, fastest), or in memory heap (1:requires malloc()).
+ */
+#ifndef LZ4F_HEAPMODE
+#  define LZ4F_HEAPMODE 0
+#endif
+
+
+/*-************************************
+*  Library declarations
+**************************************/
+#define LZ4F_STATIC_LINKING_ONLY
+#include "lz4frame.h"
+#define LZ4_STATIC_LINKING_ONLY
+#include "lz4.h"
+#define LZ4_HC_STATIC_LINKING_ONLY
+#include "lz4hc.h"
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
+
+
+/*-************************************
+*  Memory routines
+**************************************/
+/*
+ * User may redirect invocations of
+ * malloc(), calloc() and free()
+ * towards another library or solution of their choice
+ * by modifying below section.
+**/
+
+#include <string.h>   /* memset, memcpy, memmove */
+#ifndef LZ4_SRC_INCLUDED  /* avoid redefinition when sources are coalesced */
+#  define MEM_INIT(p,v,s)   memset((p),(v),(s))
+#endif
+
+#ifndef LZ4_SRC_INCLUDED   /* avoid redefinition when sources are coalesced */
+#  include <stdlib.h>   /* malloc, calloc, free */
+#  define ALLOC(s)          malloc(s)
+#  define ALLOC_AND_ZERO(s) calloc(1,(s))
+#  define FREEMEM(p)        free(p)
+#endif
+
+static void* LZ4F_calloc(size_t s, LZ4F_CustomMem cmem)
+{
+    /* custom calloc defined : use it */
+    if (cmem.customCalloc != NULL) {
+        return cmem.customCalloc(cmem.opaqueState, s);
+    }
+    /* nothing defined : use default <stdlib.h>'s calloc() */
+    if (cmem.customAlloc == NULL) {
+        return ALLOC_AND_ZERO(s);
+    }
+    /* only custom alloc defined : use it, and combine it with memset() */
+    {   void* const p = cmem.customAlloc(cmem.opaqueState, s);
+        if (p != NULL) MEM_INIT(p, 0, s);
+        return p;
+}   }
+
+static void* LZ4F_malloc(size_t s, LZ4F_CustomMem cmem)
+{
+    /* custom malloc defined : use it */
+    if (cmem.customAlloc != NULL) {
+        return cmem.customAlloc(cmem.opaqueState, s);
+    }
+    /* nothing defined : use default <stdlib.h>'s malloc() */
+    return ALLOC(s);
+}
+
+static void LZ4F_free(void* p, LZ4F_CustomMem cmem)
+{
+    if (p == NULL) return;
+    if (cmem.customFree != NULL) {
+        /* custom allocation defined : use it */
+        cmem.customFree(cmem.opaqueState, p);
+        return;
+    }
+    /* nothing defined : use default <stdlib.h>'s free() */
+    FREEMEM(p);
+}
+
+
+/*-************************************
+*  Debug
+**************************************/
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#  include <assert.h>
+#else
+#  ifndef assert
+#    define assert(condition) ((void)0)
+#  endif
+#endif
+
+#define LZ4F_STATIC_ASSERT(c)    { enum { LZ4F_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
+
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2) && !defined(DEBUGLOG)
+#  include <stdio.h>
+static int g_debuglog_enable = 1;
+#  define DEBUGLOG(l, ...) {                                  \
+                if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
+                    fprintf(stderr, __FILE__ " (%i): ", __LINE__ );  \
+                    fprintf(stderr, __VA_ARGS__);             \
+                    fprintf(stderr, " \n");                   \
+            }   }
+#else
+#  define DEBUGLOG(l, ...)      {}    /* disabled */
+#endif
+
+
+/*-************************************
+*  Basic Types
+**************************************/
+#if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+# include <stdint.h>
+  typedef  uint8_t BYTE;
+  typedef uint16_t U16;
+  typedef uint32_t U32;
+  typedef  int32_t S32;
+  typedef uint64_t U64;
+#else
+  typedef unsigned char       BYTE;
+  typedef unsigned short      U16;
+  typedef unsigned int        U32;
+  typedef   signed int        S32;
+  typedef unsigned long long  U64;
+#endif
+
+
+/* unoptimized version; solves endianness & alignment issues */
+static U32 LZ4F_readLE32 (const void* src)
+{
+    const BYTE* const srcPtr = (const BYTE*)src;
+    U32 value32 = srcPtr[0];
+    value32 |= ((U32)srcPtr[1])<< 8;
+    value32 |= ((U32)srcPtr[2])<<16;
+    value32 |= ((U32)srcPtr[3])<<24;
+    return value32;
+}
+
+static void LZ4F_writeLE32 (void* dst, U32 value32)
+{
+    BYTE* const dstPtr = (BYTE*)dst;
+    dstPtr[0] = (BYTE)value32;
+    dstPtr[1] = (BYTE)(value32 >> 8);
+    dstPtr[2] = (BYTE)(value32 >> 16);
+    dstPtr[3] = (BYTE)(value32 >> 24);
+}
+
+static U64 LZ4F_readLE64 (const void* src)
+{
+    const BYTE* const srcPtr = (const BYTE*)src;
+    U64 value64 = srcPtr[0];
+    value64 |= ((U64)srcPtr[1]<<8);
+    value64 |= ((U64)srcPtr[2]<<16);
+    value64 |= ((U64)srcPtr[3]<<24);
+    value64 |= ((U64)srcPtr[4]<<32);
+    value64 |= ((U64)srcPtr[5]<<40);
+    value64 |= ((U64)srcPtr[6]<<48);
+    value64 |= ((U64)srcPtr[7]<<56);
+    return value64;
+}
+
+static void LZ4F_writeLE64 (void* dst, U64 value64)
+{
+    BYTE* const dstPtr = (BYTE*)dst;
+    dstPtr[0] = (BYTE)value64;
+    dstPtr[1] = (BYTE)(value64 >> 8);
+    dstPtr[2] = (BYTE)(value64 >> 16);
+    dstPtr[3] = (BYTE)(value64 >> 24);
+    dstPtr[4] = (BYTE)(value64 >> 32);
+    dstPtr[5] = (BYTE)(value64 >> 40);
+    dstPtr[6] = (BYTE)(value64 >> 48);
+    dstPtr[7] = (BYTE)(value64 >> 56);
+}
+
+
+/*-************************************
+*  Constants
+**************************************/
+#ifndef LZ4_SRC_INCLUDED   /* avoid double definition */
+#  define KB *(1<<10)
+#  define MB *(1<<20)
+#  define GB *(1<<30)
+#endif
+
+#define _1BIT  0x01
+#define _2BITS 0x03
+#define _3BITS 0x07
+#define _4BITS 0x0F
+#define _8BITS 0xFF
+
+#define LZ4F_BLOCKUNCOMPRESSED_FLAG 0x80000000U
+#define LZ4F_BLOCKSIZEID_DEFAULT LZ4F_max64KB
+
+static const size_t minFHSize = LZ4F_HEADER_SIZE_MIN;   /*  7 */
+static const size_t maxFHSize = LZ4F_HEADER_SIZE_MAX;   /* 19 */
+static const size_t BHSize = LZ4F_BLOCK_HEADER_SIZE;  /* block header : size, and compress flag */
+static const size_t BFSize = LZ4F_BLOCK_CHECKSUM_SIZE;  /* block footer : checksum (optional) */
+
+
+/*-************************************
+*  Structures and local types
+**************************************/
+
+typedef enum { LZ4B_COMPRESSED, LZ4B_UNCOMPRESSED} LZ4F_BlockCompressMode_e;
+typedef enum { ctxNone, ctxFast, ctxHC } LZ4F_CtxType_e;
+
+typedef struct LZ4F_cctx_s
+{
+    LZ4F_CustomMem cmem;
+    LZ4F_preferences_t prefs;
+    U32    version;
+    U32    cStage;     /* 0 : compression uninitialized ; 1 : initialized, can compress */
+    const LZ4F_CDict* cdict;
+    size_t maxBlockSize;
+    size_t maxBufferSize;
+    BYTE*  tmpBuff;    /* internal buffer, for streaming */
+    BYTE*  tmpIn;      /* starting position of data compress within internal buffer (>= tmpBuff) */
+    size_t tmpInSize;  /* amount of data to compress after tmpIn */
+    U64    totalInSize;
+    XXH32_state_t xxh;
+    void*  lz4CtxPtr;
+    U16    lz4CtxAlloc; /* sized for: 0 = none, 1 = lz4 ctx, 2 = lz4hc ctx */
+    U16    lz4CtxType;  /* in use as: 0 = none, 1 = lz4 ctx, 2 = lz4hc ctx */
+    LZ4F_BlockCompressMode_e  blockCompressMode;
+} LZ4F_cctx_t;
+
+
+/*-************************************
+*  Error management
+**************************************/
+#define LZ4F_GENERATE_STRING(STRING) #STRING,
+static const char* LZ4F_errorStrings[] = { LZ4F_LIST_ERRORS(LZ4F_GENERATE_STRING) };
+
+
+unsigned LZ4F_isError(LZ4F_errorCode_t code)
+{
+    return (code > (LZ4F_errorCode_t)(-LZ4F_ERROR_maxCode));
+}
+
+const char* LZ4F_getErrorName(LZ4F_errorCode_t code)
+{
+    static const char* codeError = "Unspecified error code";
+    if (LZ4F_isError(code)) return LZ4F_errorStrings[-(int)(code)];
+    return codeError;
+}
+
+LZ4F_errorCodes LZ4F_getErrorCode(size_t functionResult)
+{
+    if (!LZ4F_isError(functionResult)) return LZ4F_OK_NoError;
+    return (LZ4F_errorCodes)(-(ptrdiff_t)functionResult);
+}
+
+static LZ4F_errorCode_t LZ4F_returnErrorCode(LZ4F_errorCodes code)
+{
+    /* A compilation error here means sizeof(ptrdiff_t) is not large enough */
+    LZ4F_STATIC_ASSERT(sizeof(ptrdiff_t) >= sizeof(size_t));
+    return (LZ4F_errorCode_t)-(ptrdiff_t)code;
+}
+
+#define RETURN_ERROR(e) return LZ4F_returnErrorCode(LZ4F_ERROR_ ## e)
+
+#define RETURN_ERROR_IF(c,e) do {  \
+        if (c) {                   \
+            DEBUGLOG(3, "Error: " #c); \
+            RETURN_ERROR(e);       \
+        }                          \
+    } while (0)
+
+#define FORWARD_IF_ERROR(r) do { if (LZ4F_isError(r)) return (r); } while (0)
+
+unsigned LZ4F_getVersion(void) { return LZ4F_VERSION; }
+
+int LZ4F_compressionLevel_max(void) { return LZ4HC_CLEVEL_MAX; }
+
+size_t LZ4F_getBlockSize(LZ4F_blockSizeID_t blockSizeID)
+{
+    static const size_t blockSizes[4] = { 64 KB, 256 KB, 1 MB, 4 MB };
+
+    if (blockSizeID == 0) blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
+    if (blockSizeID < LZ4F_max64KB || blockSizeID > LZ4F_max4MB)
+        RETURN_ERROR(maxBlockSize_invalid);
+    {   int const blockSizeIdx = (int)blockSizeID - (int)LZ4F_max64KB;
+        return blockSizes[blockSizeIdx];
+}   }
+
+/*-************************************
+*  Private functions
+**************************************/
+#define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+
+static BYTE LZ4F_headerChecksum (const void* header, size_t length)
+{
+    U32 const xxh = XXH32(header, length, 0);
+    return (BYTE)(xxh >> 8);
+}
+
+
+/*-************************************
+*  Simple-pass compression functions
+**************************************/
+static LZ4F_blockSizeID_t LZ4F_optimalBSID(const LZ4F_blockSizeID_t requestedBSID,
+                                           const size_t srcSize)
+{
+    LZ4F_blockSizeID_t proposedBSID = LZ4F_max64KB;
+    size_t maxBlockSize = 64 KB;
+    while (requestedBSID > proposedBSID) {
+        if (srcSize <= maxBlockSize)
+            return proposedBSID;
+        proposedBSID = (LZ4F_blockSizeID_t)((int)proposedBSID + 1);
+        maxBlockSize <<= 2;
+    }
+    return requestedBSID;
+}
+
+/*! LZ4F_compressBound_internal() :
+ *  Provides dstCapacity given a srcSize to guarantee operation success in worst case situations.
+ *  prefsPtr is optional : if NULL is provided, preferences will be set to cover worst case scenario.
+ * @return is always the same for a srcSize and prefsPtr, so it can be relied upon to size reusable buffers.
+ *  When srcSize==0, LZ4F_compressBound() provides an upper bound for LZ4F_flush() and LZ4F_compressEnd() operations.
+ */
+static size_t LZ4F_compressBound_internal(size_t srcSize,
+                                    const LZ4F_preferences_t* preferencesPtr,
+                                          size_t alreadyBuffered)
+{
+    LZ4F_preferences_t prefsNull = LZ4F_INIT_PREFERENCES;
+    prefsNull.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled;   /* worst case */
+    prefsNull.frameInfo.blockChecksumFlag = LZ4F_blockChecksumEnabled;   /* worst case */
+    {   const LZ4F_preferences_t* const prefsPtr = (preferencesPtr==NULL) ? &prefsNull : preferencesPtr;
+        U32 const flush = prefsPtr->autoFlush | (srcSize==0);
+        LZ4F_blockSizeID_t const blockID = prefsPtr->frameInfo.blockSizeID;
+        size_t const blockSize = LZ4F_getBlockSize(blockID);
+        size_t const maxBuffered = blockSize - 1;
+        size_t const bufferedSize = MIN(alreadyBuffered, maxBuffered);
+        size_t const maxSrcSize = srcSize + bufferedSize;
+        unsigned const nbFullBlocks = (unsigned)(maxSrcSize / blockSize);
+        size_t const partialBlockSize = maxSrcSize & (blockSize-1);
+        size_t const lastBlockSize = flush ? partialBlockSize : 0;
+        unsigned const nbBlocks = nbFullBlocks + (lastBlockSize>0);
+
+        size_t const blockCRCSize = BFSize * prefsPtr->frameInfo.blockChecksumFlag;
+        size_t const frameEnd = BHSize + (prefsPtr->frameInfo.contentChecksumFlag*BFSize);
+
+        return ((BHSize + blockCRCSize) * nbBlocks) +
+               (blockSize * nbFullBlocks) + lastBlockSize + frameEnd;
+    }
+}
+
+size_t LZ4F_compressFrameBound(size_t srcSize, const LZ4F_preferences_t* preferencesPtr)
+{
+    LZ4F_preferences_t prefs;
+    size_t const headerSize = maxFHSize;      /* max header size, including optional fields */
+
+    if (preferencesPtr!=NULL) prefs = *preferencesPtr;
+    else MEM_INIT(&prefs, 0, sizeof(prefs));
+    prefs.autoFlush = 1;
+
+    return headerSize + LZ4F_compressBound_internal(srcSize, &prefs, 0);;
+}
+
+
+/*! LZ4F_compressFrame_usingCDict() :
+ *  Compress srcBuffer using a dictionary, in a single step.
+ *  cdict can be NULL, in which case, no dictionary is used.
+ *  dstBuffer MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr).
+ *  The LZ4F_preferences_t structure is optional : you may provide NULL as argument,
+ *  however, it's the only way to provide a dictID, so it's not recommended.
+ * @return : number of bytes written into dstBuffer,
+ *           or an error code if it fails (can be tested using LZ4F_isError())
+ */
+size_t LZ4F_compressFrame_usingCDict(LZ4F_cctx* cctx,
+                                     void* dstBuffer, size_t dstCapacity,
+                               const void* srcBuffer, size_t srcSize,
+                               const LZ4F_CDict* cdict,
+                               const LZ4F_preferences_t* preferencesPtr)
+{
+    LZ4F_preferences_t prefs;
+    LZ4F_compressOptions_t options;
+    BYTE* const dstStart = (BYTE*) dstBuffer;
+    BYTE* dstPtr = dstStart;
+    BYTE* const dstEnd = dstStart + dstCapacity;
+
+    DEBUGLOG(4, "LZ4F_compressFrame_usingCDict (srcSize=%u)", (unsigned)srcSize);
+    if (preferencesPtr!=NULL)
+        prefs = *preferencesPtr;
+    else
+        MEM_INIT(&prefs, 0, sizeof(prefs));
+    if (prefs.frameInfo.contentSize != 0)
+        prefs.frameInfo.contentSize = (U64)srcSize;   /* auto-correct content size if selected (!=0) */
+
+    prefs.frameInfo.blockSizeID = LZ4F_optimalBSID(prefs.frameInfo.blockSizeID, srcSize);
+    prefs.autoFlush = 1;
+    if (srcSize <= LZ4F_getBlockSize(prefs.frameInfo.blockSizeID))
+        prefs.frameInfo.blockMode = LZ4F_blockIndependent;   /* only one block => no need for inter-block link */
+
+    MEM_INIT(&options, 0, sizeof(options));
+    options.stableSrc = 1;
+
+    RETURN_ERROR_IF(dstCapacity < LZ4F_compressFrameBound(srcSize, &prefs), dstMaxSize_tooSmall);
+
+    { size_t const headerSize = LZ4F_compressBegin_usingCDict(cctx, dstBuffer, dstCapacity, cdict, &prefs);  /* write header */
+      FORWARD_IF_ERROR(headerSize);
+      dstPtr += headerSize;   /* header size */ }
+
+    assert(dstEnd >= dstPtr);
+    { size_t const cSize = LZ4F_compressUpdate(cctx, dstPtr, (size_t)(dstEnd-dstPtr), srcBuffer, srcSize, &options);
+      FORWARD_IF_ERROR(cSize);
+      dstPtr += cSize; }
+
+    assert(dstEnd >= dstPtr);
+    { size_t const tailSize = LZ4F_compressEnd(cctx, dstPtr, (size_t)(dstEnd-dstPtr), &options);   /* flush last block, and generate suffix */
+      FORWARD_IF_ERROR(tailSize);
+      dstPtr += tailSize; }
+
+    assert(dstEnd >= dstStart);
+    return (size_t)(dstPtr - dstStart);
+}
+
+
+/*! LZ4F_compressFrame() :
+ *  Compress an entire srcBuffer into a valid LZ4 frame, in a single step.
+ *  dstBuffer MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr).
+ *  The LZ4F_preferences_t structure is optional : you can provide NULL as argument. All preferences will be set to default.
+ * @return : number of bytes written into dstBuffer.
+ *           or an error code if it fails (can be tested using LZ4F_isError())
+ */
+size_t LZ4F_compressFrame(void* dstBuffer, size_t dstCapacity,
+                    const void* srcBuffer, size_t srcSize,
+                    const LZ4F_preferences_t* preferencesPtr)
+{
+    size_t result;
+#if (LZ4F_HEAPMODE)
+    LZ4F_cctx_t* cctxPtr;
+    result = LZ4F_createCompressionContext(&cctxPtr, LZ4F_VERSION);
+    FORWARD_IF_ERROR(result);
+#else
+    LZ4F_cctx_t cctx;
+    LZ4_stream_t lz4ctx;
+    LZ4F_cctx_t* const cctxPtr = &cctx;
+
+    MEM_INIT(&cctx, 0, sizeof(cctx));
+    cctx.version = LZ4F_VERSION;
+    cctx.maxBufferSize = 5 MB;   /* mess with real buffer size to prevent dynamic allocation; works only because autoflush==1 & stableSrc==1 */
+    if ( preferencesPtr == NULL
+      || preferencesPtr->compressionLevel < LZ4HC_CLEVEL_MIN ) {
+        LZ4_initStream(&lz4ctx, sizeof(lz4ctx));
+        cctxPtr->lz4CtxPtr = &lz4ctx;
+        cctxPtr->lz4CtxAlloc = 1;
+        cctxPtr->lz4CtxType = ctxFast;
+    }
+#endif
+    DEBUGLOG(4, "LZ4F_compressFrame");
+
+    result = LZ4F_compressFrame_usingCDict(cctxPtr, dstBuffer, dstCapacity,
+                                           srcBuffer, srcSize,
+                                           NULL, preferencesPtr);
+
+#if (LZ4F_HEAPMODE)
+    LZ4F_freeCompressionContext(cctxPtr);
+#else
+    if ( preferencesPtr != NULL
+      && preferencesPtr->compressionLevel >= LZ4HC_CLEVEL_MIN ) {
+        LZ4F_free(cctxPtr->lz4CtxPtr, cctxPtr->cmem);
+    }
+#endif
+    return result;
+}
+
+
+/*-***************************************************
+*   Dictionary compression
+*****************************************************/
+
+struct LZ4F_CDict_s {
+    LZ4F_CustomMem cmem;
+    void* dictContent;
+    LZ4_stream_t* fastCtx;
+    LZ4_streamHC_t* HCCtx;
+}; /* typedef'd to LZ4F_CDict within lz4frame_static.h */
+
+LZ4F_CDict*
+LZ4F_createCDict_advanced(LZ4F_CustomMem cmem, const void* dictBuffer, size_t dictSize)
+{
+    const char* dictStart = (const char*)dictBuffer;
+    LZ4F_CDict* const cdict = (LZ4F_CDict*)LZ4F_malloc(sizeof(*cdict), cmem);
+    DEBUGLOG(4, "LZ4F_createCDict_advanced");
+    if (!cdict) return NULL;
+    cdict->cmem = cmem;
+    if (dictSize > 64 KB) {
+        dictStart += dictSize - 64 KB;
+        dictSize = 64 KB;
+    }
+    cdict->dictContent = LZ4F_malloc(dictSize, cmem);
+    /* note: using @cmem to allocate => can't use default create */
+    cdict->fastCtx = (LZ4_stream_t*)LZ4F_malloc(sizeof(LZ4_stream_t), cmem);
+    cdict->HCCtx = (LZ4_streamHC_t*)LZ4F_malloc(sizeof(LZ4_streamHC_t), cmem);
+    if (!cdict->dictContent || !cdict->fastCtx || !cdict->HCCtx) {
+        LZ4F_freeCDict(cdict);
+        return NULL;
+    }
+    memcpy(cdict->dictContent, dictStart, dictSize);
+    LZ4_initStream(cdict->fastCtx, sizeof(LZ4_stream_t));
+    LZ4_loadDictSlow(cdict->fastCtx, (const char*)cdict->dictContent, (int)dictSize);
+    LZ4_initStreamHC(cdict->HCCtx, sizeof(LZ4_streamHC_t));
+    /* note: we don't know at this point which compression level is going to be used
+     * as a consequence, HCCtx is created for the more common HC mode */
+    LZ4_setCompressionLevel(cdict->HCCtx, LZ4HC_CLEVEL_DEFAULT);
+    LZ4_loadDictHC(cdict->HCCtx, (const char*)cdict->dictContent, (int)dictSize);
+    return cdict;
+}
+
+/*! LZ4F_createCDict() :
+ *  When compressing multiple messages / blocks with the same dictionary, it's recommended to load it just once.
+ *  LZ4F_createCDict() will create a digested dictionary, ready to start future compression operations without startup delay.
+ *  LZ4F_CDict can be created once and shared by multiple threads concurrently, since its usage is read-only.
+ * @dictBuffer can be released after LZ4F_CDict creation, since its content is copied within CDict
+ * @return : digested dictionary for compression, or NULL if failed */
+LZ4F_CDict* LZ4F_createCDict(const void* dictBuffer, size_t dictSize)
+{
+    DEBUGLOG(4, "LZ4F_createCDict");
+    return LZ4F_createCDict_advanced(LZ4F_defaultCMem, dictBuffer, dictSize);
+}
+
+void LZ4F_freeCDict(LZ4F_CDict* cdict)
+{
+    if (cdict==NULL) return;  /* support free on NULL */
+    LZ4F_free(cdict->dictContent, cdict->cmem);
+    LZ4F_free(cdict->fastCtx, cdict->cmem);
+    LZ4F_free(cdict->HCCtx, cdict->cmem);
+    LZ4F_free(cdict, cdict->cmem);
+}
+
+
+/*-*********************************
+*  Advanced compression functions
+***********************************/
+
+LZ4F_cctx*
+LZ4F_createCompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version)
+{
+    LZ4F_cctx* const cctxPtr =
+        (LZ4F_cctx*)LZ4F_calloc(sizeof(LZ4F_cctx), customMem);
+    if (cctxPtr==NULL) return NULL;
+
+    cctxPtr->cmem = customMem;
+    cctxPtr->version = version;
+    cctxPtr->cStage = 0;   /* Uninitialized. Next stage : init cctx */
+
+    return cctxPtr;
+}
+
+/*! LZ4F_createCompressionContext() :
+ *  The first thing to do is to create a compressionContext object, which will be used in all compression operations.
+ *  This is achieved using LZ4F_createCompressionContext(), which takes as argument a version and an LZ4F_preferences_t structure.
+ *  The version provided MUST be LZ4F_VERSION. It is intended to track potential incompatible differences between different binaries.
+ *  The function will provide a pointer to an allocated LZ4F_compressionContext_t object.
+ *  If the result LZ4F_errorCode_t is not OK_NoError, there was an error during context creation.
+ *  Object can release its memory using LZ4F_freeCompressionContext();
+**/
+LZ4F_errorCode_t
+LZ4F_createCompressionContext(LZ4F_cctx** LZ4F_compressionContextPtr, unsigned version)
+{
+    assert(LZ4F_compressionContextPtr != NULL); /* considered a violation of narrow contract */
+    /* in case it nonetheless happen in production */
+    RETURN_ERROR_IF(LZ4F_compressionContextPtr == NULL, parameter_null);
+
+    *LZ4F_compressionContextPtr = LZ4F_createCompressionContext_advanced(LZ4F_defaultCMem, version);
+    RETURN_ERROR_IF(*LZ4F_compressionContextPtr==NULL, allocation_failed);
+    return LZ4F_OK_NoError;
+}
+
+LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctxPtr)
+{
+    if (cctxPtr != NULL) {  /* support free on NULL */
+       LZ4F_free(cctxPtr->lz4CtxPtr, cctxPtr->cmem);  /* note: LZ4_streamHC_t and LZ4_stream_t are simple POD types */
+       LZ4F_free(cctxPtr->tmpBuff, cctxPtr->cmem);
+       LZ4F_free(cctxPtr, cctxPtr->cmem);
+    }
+    return LZ4F_OK_NoError;
+}
+
+
+/**
+ * This function prepares the internal LZ4(HC) stream for a new compression,
+ * resetting the context and attaching the dictionary, if there is one.
+ *
+ * It needs to be called at the beginning of each independent compression
+ * stream (i.e., at the beginning of a frame in blockLinked mode, or at the
+ * beginning of each block in blockIndependent mode).
+ */
+static void LZ4F_initStream(void* ctx,
+                            const LZ4F_CDict* cdict,
+                            int level,
+                            LZ4F_blockMode_t blockMode) {
+    if (level < LZ4HC_CLEVEL_MIN) {
+        if (cdict || blockMode == LZ4F_blockLinked) {
+            /* In these cases, we will call LZ4_compress_fast_continue(),
+             * which needs an already reset context. Otherwise, we'll call a
+             * one-shot API. The non-continued APIs internally perform their own
+             * resets at the beginning of their calls, where they know what
+             * tableType they need the context to be in. So in that case this
+             * would be misguided / wasted work. */
+            LZ4_resetStream_fast((LZ4_stream_t*)ctx);
+            if (cdict)
+                LZ4_attach_dictionary((LZ4_stream_t*)ctx, cdict->fastCtx);
+        }
+        /* In these cases, we'll call a one-shot API.
+         * The non-continued APIs internally perform their own resets
+         * at the beginning of their calls, where they know
+         * which tableType they need the context to be in.
+         * Therefore, a reset here would be wasted work. */
+    } else {
+        LZ4_resetStreamHC_fast((LZ4_streamHC_t*)ctx, level);
+        if (cdict)
+            LZ4_attach_HC_dictionary((LZ4_streamHC_t*)ctx, cdict->HCCtx);
+    }
+}
+
+static int ctxTypeID_to_size(int ctxTypeID) {
+    switch(ctxTypeID) {
+    case 1:
+        return LZ4_sizeofState();
+    case 2:
+        return LZ4_sizeofStateHC();
+    default:
+        return 0;
+    }
+}
+
+/* LZ4F_compressBegin_internal()
+ * Note: only accepts @cdict _or_ @dictBuffer as non NULL.
+ */
+size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
+                          void* dstBuffer, size_t dstCapacity,
+                          const void* dictBuffer, size_t dictSize,
+                          const LZ4F_CDict* cdict,
+                          const LZ4F_preferences_t* preferencesPtr)
+{
+    LZ4F_preferences_t const prefNull = LZ4F_INIT_PREFERENCES;
+    BYTE* const dstStart = (BYTE*)dstBuffer;
+    BYTE* dstPtr = dstStart;
+
+    RETURN_ERROR_IF(dstCapacity < maxFHSize, dstMaxSize_tooSmall);
+    if (preferencesPtr == NULL) preferencesPtr = &prefNull;
+    cctx->prefs = *preferencesPtr;
+
+    /* cctx Management */
+    {   U16 const ctxTypeID = (cctx->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) ? 1 : 2;
+        int requiredSize = ctxTypeID_to_size(ctxTypeID);
+        int allocatedSize = ctxTypeID_to_size(cctx->lz4CtxAlloc);
+        if (allocatedSize < requiredSize) {
+            /* not enough space allocated */
+            LZ4F_free(cctx->lz4CtxPtr, cctx->cmem);
+            if (cctx->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) {
+                /* must take ownership of memory allocation,
+                 * in order to respect custom allocator contract */
+                cctx->lz4CtxPtr = LZ4F_malloc(sizeof(LZ4_stream_t), cctx->cmem);
+                if (cctx->lz4CtxPtr)
+                    LZ4_initStream(cctx->lz4CtxPtr, sizeof(LZ4_stream_t));
+            } else {
+                cctx->lz4CtxPtr = LZ4F_malloc(sizeof(LZ4_streamHC_t), cctx->cmem);
+                if (cctx->lz4CtxPtr)
+                    LZ4_initStreamHC(cctx->lz4CtxPtr, sizeof(LZ4_streamHC_t));
+            }
+            RETURN_ERROR_IF(cctx->lz4CtxPtr == NULL, allocation_failed);
+            cctx->lz4CtxAlloc = ctxTypeID;
+            cctx->lz4CtxType = ctxTypeID;
+        } else if (cctx->lz4CtxType != ctxTypeID) {
+            /* otherwise, a sufficient buffer is already allocated,
+             * but we need to reset it to the correct context type */
+            if (cctx->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) {
+                LZ4_initStream((LZ4_stream_t*)cctx->lz4CtxPtr, sizeof(LZ4_stream_t));
+            } else {
+                LZ4_initStreamHC((LZ4_streamHC_t*)cctx->lz4CtxPtr, sizeof(LZ4_streamHC_t));
+                LZ4_setCompressionLevel((LZ4_streamHC_t*)cctx->lz4CtxPtr, cctx->prefs.compressionLevel);
+            }
+            cctx->lz4CtxType = ctxTypeID;
+    }   }
+
+    /* Buffer Management */
+    if (cctx->prefs.frameInfo.blockSizeID == 0)
+        cctx->prefs.frameInfo.blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
+    cctx->maxBlockSize = LZ4F_getBlockSize(cctx->prefs.frameInfo.blockSizeID);
+
+    {   size_t const requiredBuffSize = preferencesPtr->autoFlush ?
+                ((cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) ? 64 KB : 0) :  /* only needs past data up to window size */
+                cctx->maxBlockSize + ((cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) ? 128 KB : 0);
+
+        if (cctx->maxBufferSize < requiredBuffSize) {
+            cctx->maxBufferSize = 0;
+            LZ4F_free(cctx->tmpBuff, cctx->cmem);
+            cctx->tmpBuff = (BYTE*)LZ4F_malloc(requiredBuffSize, cctx->cmem);
+            RETURN_ERROR_IF(cctx->tmpBuff == NULL, allocation_failed);
+            cctx->maxBufferSize = requiredBuffSize;
+    }   }
+    cctx->tmpIn = cctx->tmpBuff;
+    cctx->tmpInSize = 0;
+    (void)XXH32_reset(&(cctx->xxh), 0);
+
+    /* context init */
+    cctx->cdict = cdict;
+    if (cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) {
+        /* frame init only for blockLinked : blockIndependent will be init at each block */
+        LZ4F_initStream(cctx->lz4CtxPtr, cdict, cctx->prefs.compressionLevel, LZ4F_blockLinked);
+    }
+    if (preferencesPtr->compressionLevel >= LZ4HC_CLEVEL_MIN) {
+        LZ4_favorDecompressionSpeed((LZ4_streamHC_t*)cctx->lz4CtxPtr, (int)preferencesPtr->favorDecSpeed);
+    }
+    if (dictBuffer) {
+        assert(cdict == NULL);
+        RETURN_ERROR_IF(dictSize > INT_MAX, parameter_invalid);
+        if (cctx->lz4CtxType == ctxFast) {
+            /* lz4 fast*/
+            LZ4_loadDict((LZ4_stream_t*)cctx->lz4CtxPtr, (const char*)dictBuffer, (int)dictSize);
+        } else {
+            /* lz4hc */
+            assert(cctx->lz4CtxType == ctxHC);
+            LZ4_loadDictHC((LZ4_streamHC_t*)cctx->lz4CtxPtr, (const char*)dictBuffer, (int)dictSize);
+        }
+    }
+
+    /* Stage 2 : Write Frame Header */
+
+    /* Magic Number */
+    LZ4F_writeLE32(dstPtr, LZ4F_MAGICNUMBER);
+    dstPtr += 4;
+    {   BYTE* const headerStart = dstPtr;
+
+        /* FLG Byte */
+        *dstPtr++ = (BYTE)(((1 & _2BITS) << 6)    /* Version('01') */
+            + ((cctx->prefs.frameInfo.blockMode & _1BIT ) << 5)
+            + ((cctx->prefs.frameInfo.blockChecksumFlag & _1BIT ) << 4)
+            + ((unsigned)(cctx->prefs.frameInfo.contentSize > 0) << 3)
+            + ((cctx->prefs.frameInfo.contentChecksumFlag & _1BIT ) << 2)
+            +  (cctx->prefs.frameInfo.dictID > 0) );
+        /* BD Byte */
+        *dstPtr++ = (BYTE)((cctx->prefs.frameInfo.blockSizeID & _3BITS) << 4);
+        /* Optional Frame content size field */
+        if (cctx->prefs.frameInfo.contentSize) {
+            LZ4F_writeLE64(dstPtr, cctx->prefs.frameInfo.contentSize);
+            dstPtr += 8;
+            cctx->totalInSize = 0;
+        }
+        /* Optional dictionary ID field */
+        if (cctx->prefs.frameInfo.dictID) {
+            LZ4F_writeLE32(dstPtr, cctx->prefs.frameInfo.dictID);
+            dstPtr += 4;
+        }
+        /* Header CRC Byte */
+        *dstPtr = LZ4F_headerChecksum(headerStart, (size_t)(dstPtr - headerStart));
+        dstPtr++;
+    }
+
+    cctx->cStage = 1;   /* header written, now request input data block */
+    return (size_t)(dstPtr - dstStart);
+}
+
+size_t LZ4F_compressBegin(LZ4F_cctx* cctx,
+                          void* dstBuffer, size_t dstCapacity,
+                          const LZ4F_preferences_t* preferencesPtr)
+{
+    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity,
+                                        NULL, 0,
+                                        NULL, preferencesPtr);
+}
+
+/* LZ4F_compressBegin_usingDictOnce:
+ * Hidden implementation,
+ * employed for multi-threaded compression
+ * when frame defines linked blocks */
+size_t LZ4F_compressBegin_usingDictOnce(LZ4F_cctx* cctx,
+                          void* dstBuffer, size_t dstCapacity,
+                          const void* dict, size_t dictSize,
+                          const LZ4F_preferences_t* preferencesPtr)
+{
+    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity,
+                                        dict, dictSize,
+                                        NULL, preferencesPtr);
+}
+
+size_t LZ4F_compressBegin_usingDict(LZ4F_cctx* cctx,
+                          void* dstBuffer, size_t dstCapacity,
+                          const void* dict, size_t dictSize,
+                          const LZ4F_preferences_t* preferencesPtr)
+{
+    /* note : incorrect implementation :
+     * this will only use the dictionary once,
+     * instead of once *per* block when frames defines independent blocks */
+    return LZ4F_compressBegin_usingDictOnce(cctx, dstBuffer, dstCapacity,
+                                        dict, dictSize,
+                                        preferencesPtr);
+}
+
+size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctx,
+                          void* dstBuffer, size_t dstCapacity,
+                          const LZ4F_CDict* cdict,
+                          const LZ4F_preferences_t* preferencesPtr)
+{
+    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity,
+                                        NULL, 0,
+                                       cdict, preferencesPtr);
+}
+
+
+/*  LZ4F_compressBound() :
+ * @return minimum capacity of dstBuffer for a given srcSize to handle worst case scenario.
+ *  LZ4F_preferences_t structure is optional : if NULL, preferences will be set to cover worst case scenario.
+ *  This function cannot fail.
+ */
+size_t LZ4F_compressBound(size_t srcSize, const LZ4F_preferences_t* preferencesPtr)
+{
+    if (preferencesPtr && preferencesPtr->autoFlush) {
+        return LZ4F_compressBound_internal(srcSize, preferencesPtr, 0);
+    }
+    return LZ4F_compressBound_internal(srcSize, preferencesPtr, (size_t)-1);
+}
+
+
+typedef int (*compressFunc_t)(void* ctx, const char* src, char* dst, int srcSize, int dstSize, int level, const LZ4F_CDict* cdict);
+
+
+/*! LZ4F_makeBlock():
+ *  compress a single block, add header and optional checksum.
+ *  assumption : dst buffer capacity is >= BHSize + srcSize + crcSize
+ */
+static size_t LZ4F_makeBlock(void* dst,
+                       const void* src, size_t srcSize,
+                             compressFunc_t compress, void* lz4ctx, int level,
+                       const LZ4F_CDict* cdict,
+                             LZ4F_blockChecksum_t crcFlag)
+{
+    BYTE* const cSizePtr = (BYTE*)dst;
+    U32 cSize;
+    assert(compress != NULL);
+    cSize = (U32)compress(lz4ctx, (const char*)src, (char*)(cSizePtr+BHSize),
+                          (int)(srcSize), (int)(srcSize-1),
+                          level, cdict);
+
+    if (cSize == 0 || cSize >= srcSize) {
+        cSize = (U32)srcSize;
+        LZ4F_writeLE32(cSizePtr, cSize | LZ4F_BLOCKUNCOMPRESSED_FLAG);
+        memcpy(cSizePtr+BHSize, src, srcSize);
+    } else {
+        LZ4F_writeLE32(cSizePtr, cSize);
+    }
+    if (crcFlag) {
+        U32 const crc32 = XXH32(cSizePtr+BHSize, cSize, 0);  /* checksum of compressed data */
+        LZ4F_writeLE32(cSizePtr+BHSize+cSize, crc32);
+    }
+    return BHSize + cSize + ((U32)crcFlag)*BFSize;
+}
+
+
+static int LZ4F_compressBlock(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+{
+    int const acceleration = (level < 0) ? -level + 1 : 1;
+    DEBUGLOG(5, "LZ4F_compressBlock (srcSize=%i)", srcSize);
+    LZ4F_initStream(ctx, cdict, level, LZ4F_blockIndependent);
+    if (cdict) {
+        return LZ4_compress_fast_continue((LZ4_stream_t*)ctx, src, dst, srcSize, dstCapacity, acceleration);
+    } else {
+        return LZ4_compress_fast_extState_fastReset(ctx, src, dst, srcSize, dstCapacity, acceleration);
+    }
+}
+
+static int LZ4F_compressBlock_continue(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+{
+    int const acceleration = (level < 0) ? -level + 1 : 1;
+    (void)cdict; /* init once at beginning of frame */
+    DEBUGLOG(5, "LZ4F_compressBlock_continue (srcSize=%i)", srcSize);
+    return LZ4_compress_fast_continue((LZ4_stream_t*)ctx, src, dst, srcSize, dstCapacity, acceleration);
+}
+
+static int LZ4F_compressBlockHC(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+{
+    LZ4F_initStream(ctx, cdict, level, LZ4F_blockIndependent);
+    if (cdict) {
+        return LZ4_compress_HC_continue((LZ4_streamHC_t*)ctx, src, dst, srcSize, dstCapacity);
+    }
+    return LZ4_compress_HC_extStateHC_fastReset(ctx, src, dst, srcSize, dstCapacity, level);
+}
+
+static int LZ4F_compressBlockHC_continue(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+{
+    (void)level; (void)cdict; /* init once at beginning of frame */
+    return LZ4_compress_HC_continue((LZ4_streamHC_t*)ctx, src, dst, srcSize, dstCapacity);
+}
+
+static int LZ4F_doNotCompressBlock(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+{
+    (void)ctx; (void)src; (void)dst; (void)srcSize; (void)dstCapacity; (void)level; (void)cdict;
+    return 0;
+}
+
+static compressFunc_t LZ4F_selectCompression(LZ4F_blockMode_t blockMode, int level, LZ4F_BlockCompressMode_e  compressMode)
+{
+    if (compressMode == LZ4B_UNCOMPRESSED)
+        return LZ4F_doNotCompressBlock;
+    if (level < LZ4HC_CLEVEL_MIN) {
+        if (blockMode == LZ4F_blockIndependent) return LZ4F_compressBlock;
+        return LZ4F_compressBlock_continue;
+    }
+    if (blockMode == LZ4F_blockIndependent) return LZ4F_compressBlockHC;
+    return LZ4F_compressBlockHC_continue;
+}
+
+/* Save history (up to 64KB) into @tmpBuff */
+static int LZ4F_localSaveDict(LZ4F_cctx_t* cctxPtr)
+{
+    if (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN)
+        return LZ4_saveDict ((LZ4_stream_t*)(cctxPtr->lz4CtxPtr), (char*)(cctxPtr->tmpBuff), 64 KB);
+    return LZ4_saveDictHC ((LZ4_streamHC_t*)(cctxPtr->lz4CtxPtr), (char*)(cctxPtr->tmpBuff), 64 KB);
+}
+
+typedef enum { notDone, fromTmpBuffer, fromSrcBuffer } LZ4F_lastBlockStatus;
+
+static const LZ4F_compressOptions_t k_cOptionsNull = { 0, { 0, 0, 0 } };
+
+
+ /*! LZ4F_compressUpdateImpl() :
+ *  LZ4F_compressUpdate() can be called repetitively to compress as much data as necessary.
+ *  When successful, the function always entirely consumes @srcBuffer.
+ *  src data is either buffered or compressed into @dstBuffer.
+ *  If the block compression does not match the compression of the previous block, the old data is flushed
+ *  and operations continue with the new compression mode.
+ * @dstCapacity MUST be >= LZ4F_compressBound(srcSize, preferencesPtr) when block compression is turned on.
+ * @compressOptionsPtr is optional : provide NULL to mean "default".
+ * @return : the number of bytes written into dstBuffer. It can be zero, meaning input data was just buffered.
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ *  After an error, the state is left in a UB state, and must be re-initialized.
+ */
+static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
+                     void* dstBuffer, size_t dstCapacity,
+                     const void* srcBuffer, size_t srcSize,
+                     const LZ4F_compressOptions_t* compressOptionsPtr,
+                     LZ4F_BlockCompressMode_e blockCompression)
+  {
+    size_t const blockSize = cctxPtr->maxBlockSize;
+    const BYTE* srcPtr = (const BYTE*)srcBuffer;
+    const BYTE* const srcEnd = srcPtr + srcSize;
+    BYTE* const dstStart = (BYTE*)dstBuffer;
+    BYTE* dstPtr = dstStart;
+    LZ4F_lastBlockStatus lastBlockCompressed = notDone;
+    compressFunc_t const compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode, cctxPtr->prefs.compressionLevel, blockCompression);
+    size_t bytesWritten;
+    DEBUGLOG(4, "LZ4F_compressUpdate (srcSize=%zu)", srcSize);
+
+    RETURN_ERROR_IF(cctxPtr->cStage != 1, compressionState_uninitialized);   /* state must be initialized and waiting for next block */
+    if (dstCapacity < LZ4F_compressBound_internal(srcSize, &(cctxPtr->prefs), cctxPtr->tmpInSize))
+        RETURN_ERROR(dstMaxSize_tooSmall);
+
+    if (blockCompression == LZ4B_UNCOMPRESSED && dstCapacity < srcSize)
+        RETURN_ERROR(dstMaxSize_tooSmall);
+
+    /* flush currently written block, to continue with new block compression */
+    if (cctxPtr->blockCompressMode != blockCompression) {
+        bytesWritten = LZ4F_flush(cctxPtr, dstBuffer, dstCapacity, compressOptionsPtr);
+        dstPtr += bytesWritten;
+        cctxPtr->blockCompressMode = blockCompression;
+    }
+
+    if (compressOptionsPtr == NULL) compressOptionsPtr = &k_cOptionsNull;
+
+    /* complete tmp buffer */
+    if (cctxPtr->tmpInSize > 0) {   /* some data already within tmp buffer */
+        size_t const sizeToCopy = blockSize - cctxPtr->tmpInSize;
+        assert(blockSize > cctxPtr->tmpInSize);
+        if (sizeToCopy > srcSize) {
+            /* add src to tmpIn buffer */
+            memcpy(cctxPtr->tmpIn + cctxPtr->tmpInSize, srcBuffer, srcSize);
+            srcPtr = srcEnd;
+            cctxPtr->tmpInSize += srcSize;
+            /* still needs some CRC */
+        } else {
+            /* complete tmpIn block and then compress it */
+            lastBlockCompressed = fromTmpBuffer;
+            memcpy(cctxPtr->tmpIn + cctxPtr->tmpInSize, srcBuffer, sizeToCopy);
+            srcPtr += sizeToCopy;
+
+            dstPtr += LZ4F_makeBlock(dstPtr,
+                                     cctxPtr->tmpIn, blockSize,
+                                     compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
+                                     cctxPtr->cdict,
+                                     cctxPtr->prefs.frameInfo.blockChecksumFlag);
+            if (cctxPtr->prefs.frameInfo.blockMode==LZ4F_blockLinked) cctxPtr->tmpIn += blockSize;
+            cctxPtr->tmpInSize = 0;
+    }   }
+
+    while ((size_t)(srcEnd - srcPtr) >= blockSize) {
+        /* compress full blocks */
+        lastBlockCompressed = fromSrcBuffer;
+        dstPtr += LZ4F_makeBlock(dstPtr,
+                                 srcPtr, blockSize,
+                                 compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
+                                 cctxPtr->cdict,
+                                 cctxPtr->prefs.frameInfo.blockChecksumFlag);
+        srcPtr += blockSize;
+    }
+
+    if ((cctxPtr->prefs.autoFlush) && (srcPtr < srcEnd)) {
+        /* autoFlush : remaining input (< blockSize) is compressed */
+        lastBlockCompressed = fromSrcBuffer;
+        dstPtr += LZ4F_makeBlock(dstPtr,
+                                 srcPtr, (size_t)(srcEnd - srcPtr),
+                                 compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
+                                 cctxPtr->cdict,
+                                 cctxPtr->prefs.frameInfo.blockChecksumFlag);
+        srcPtr = srcEnd;
+    }
+
+    /* preserve dictionary within @tmpBuff whenever necessary */
+    if ((cctxPtr->prefs.frameInfo.blockMode==LZ4F_blockLinked) && (lastBlockCompressed==fromSrcBuffer)) {
+        /* linked blocks are only supported in compressed mode, see LZ4F_uncompressedUpdate */
+        assert(blockCompression == LZ4B_COMPRESSED);
+        if (compressOptionsPtr->stableSrc) {
+            cctxPtr->tmpIn = cctxPtr->tmpBuff;  /* src is stable : dictionary remains in src across invocations */
+        } else {
+            int const realDictSize = LZ4F_localSaveDict(cctxPtr);
+            assert(0 <= realDictSize && realDictSize <= 64 KB);
+            cctxPtr->tmpIn = cctxPtr->tmpBuff + realDictSize;
+        }
+    }
+
+    /* keep tmpIn within limits */
+    if (!(cctxPtr->prefs.autoFlush)  /* no autoflush : there may be some data left within internal buffer */
+      && (cctxPtr->tmpIn + blockSize) > (cctxPtr->tmpBuff + cctxPtr->maxBufferSize) )  /* not enough room to store next block */
+    {
+        /* only preserve 64KB within internal buffer. Ensures there is enough room for next block.
+         * note: this situation necessarily implies lastBlockCompressed==fromTmpBuffer */
+        int const realDictSize = LZ4F_localSaveDict(cctxPtr);
+        cctxPtr->tmpIn = cctxPtr->tmpBuff + realDictSize;
+        assert((cctxPtr->tmpIn + blockSize) <= (cctxPtr->tmpBuff + cctxPtr->maxBufferSize));
+    }
+
+    /* some input data left, necessarily < blockSize */
+    if (srcPtr < srcEnd) {
+        /* fill tmp buffer */
+        size_t const sizeToCopy = (size_t)(srcEnd - srcPtr);
+        memcpy(cctxPtr->tmpIn, srcPtr, sizeToCopy);
+        cctxPtr->tmpInSize = sizeToCopy;
+    }
+
+    if (cctxPtr->prefs.frameInfo.contentChecksumFlag == LZ4F_contentChecksumEnabled)
+        (void)XXH32_update(&(cctxPtr->xxh), srcBuffer, srcSize);
+
+    cctxPtr->totalInSize += srcSize;
+    return (size_t)(dstPtr - dstStart);
+}
+
+/*! LZ4F_compressUpdate() :
+ *  LZ4F_compressUpdate() can be called repetitively to compress as much data as necessary.
+ *  When successful, the function always entirely consumes @srcBuffer.
+ *  src data is either buffered or compressed into @dstBuffer.
+ *  If previously an uncompressed block was written, buffered data is flushed
+ *  before appending compressed data is continued.
+ * @dstCapacity MUST be >= LZ4F_compressBound(srcSize, preferencesPtr).
+ * @compressOptionsPtr is optional : provide NULL to mean "default".
+ * @return : the number of bytes written into dstBuffer. It can be zero, meaning input data was just buffered.
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ *  After an error, the state is left in a UB state, and must be re-initialized.
+ */
+size_t LZ4F_compressUpdate(LZ4F_cctx* cctxPtr,
+                           void* dstBuffer, size_t dstCapacity,
+                     const void* srcBuffer, size_t srcSize,
+                     const LZ4F_compressOptions_t* compressOptionsPtr)
+{
+     return LZ4F_compressUpdateImpl(cctxPtr,
+                                   dstBuffer, dstCapacity,
+                                   srcBuffer, srcSize,
+                                   compressOptionsPtr, LZ4B_COMPRESSED);
+}
+
+/*! LZ4F_uncompressedUpdate() :
+ *  Same as LZ4F_compressUpdate(), but requests blocks to be sent uncompressed.
+ *  This symbol is only supported when LZ4F_blockIndependent is used
+ * @dstCapacity MUST be >= LZ4F_compressBound(srcSize, preferencesPtr).
+ * @compressOptionsPtr is optional : provide NULL to mean "default".
+ * @return : the number of bytes written into dstBuffer. It can be zero, meaning input data was just buffered.
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ *  After an error, the state is left in a UB state, and must be re-initialized.
+ */
+size_t LZ4F_uncompressedUpdate(LZ4F_cctx* cctxPtr,
+                               void* dstBuffer, size_t dstCapacity,
+                         const void* srcBuffer, size_t srcSize,
+                         const LZ4F_compressOptions_t* compressOptionsPtr)
+{
+    return LZ4F_compressUpdateImpl(cctxPtr,
+                                   dstBuffer, dstCapacity,
+                                   srcBuffer, srcSize,
+                                   compressOptionsPtr, LZ4B_UNCOMPRESSED);
+}
+
+
+/*! LZ4F_flush() :
+ *  When compressed data must be sent immediately, without waiting for a block to be filled,
+ *  invoke LZ4_flush(), which will immediately compress any remaining data stored within LZ4F_cctx.
+ *  The result of the function is the number of bytes written into dstBuffer.
+ *  It can be zero, this means there was no data left within LZ4F_cctx.
+ *  The function outputs an error code if it fails (can be tested using LZ4F_isError())
+ *  LZ4F_compressOptions_t* is optional. NULL is a valid argument.
+ */
+size_t LZ4F_flush(LZ4F_cctx* cctxPtr,
+                  void* dstBuffer, size_t dstCapacity,
+            const LZ4F_compressOptions_t* compressOptionsPtr)
+{
+    BYTE* const dstStart = (BYTE*)dstBuffer;
+    BYTE* dstPtr = dstStart;
+    compressFunc_t compress;
+
+    if (cctxPtr->tmpInSize == 0) return 0;   /* nothing to flush */
+    RETURN_ERROR_IF(cctxPtr->cStage != 1, compressionState_uninitialized);
+    RETURN_ERROR_IF(dstCapacity < (cctxPtr->tmpInSize + BHSize + BFSize), dstMaxSize_tooSmall);
+    (void)compressOptionsPtr;   /* not useful (yet) */
+
+    /* select compression function */
+    compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode, cctxPtr->prefs.compressionLevel, cctxPtr->blockCompressMode);
+
+    /* compress tmp buffer */
+    dstPtr += LZ4F_makeBlock(dstPtr,
+                             cctxPtr->tmpIn, cctxPtr->tmpInSize,
+                             compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
+                             cctxPtr->cdict,
+                             cctxPtr->prefs.frameInfo.blockChecksumFlag);
+    assert(((void)"flush overflows dstBuffer!", (size_t)(dstPtr - dstStart) <= dstCapacity));
+
+    if (cctxPtr->prefs.frameInfo.blockMode == LZ4F_blockLinked)
+        cctxPtr->tmpIn += cctxPtr->tmpInSize;
+    cctxPtr->tmpInSize = 0;
+
+    /* keep tmpIn within limits */
+    if ((cctxPtr->tmpIn + cctxPtr->maxBlockSize) > (cctxPtr->tmpBuff + cctxPtr->maxBufferSize)) {  /* necessarily LZ4F_blockLinked */
+        int const realDictSize = LZ4F_localSaveDict(cctxPtr);
+        cctxPtr->tmpIn = cctxPtr->tmpBuff + realDictSize;
+    }
+
+    return (size_t)(dstPtr - dstStart);
+}
+
+
+/*! LZ4F_compressEnd() :
+ *  When you want to properly finish the compressed frame, just call LZ4F_compressEnd().
+ *  It will flush whatever data remained within compressionContext (like LZ4_flush())
+ *  but also properly finalize the frame, with an endMark and an (optional) checksum.
+ *  LZ4F_compressOptions_t structure is optional : you can provide NULL as argument.
+ * @return: the number of bytes written into dstBuffer (necessarily >= 4 (endMark size))
+ *       or an error code if it fails (can be tested using LZ4F_isError())
+ *  The context can then be used again to compress a new frame, starting with LZ4F_compressBegin().
+ */
+size_t LZ4F_compressEnd(LZ4F_cctx* cctxPtr,
+                        void* dstBuffer, size_t dstCapacity,
+                  const LZ4F_compressOptions_t* compressOptionsPtr)
+{
+    BYTE* const dstStart = (BYTE*)dstBuffer;
+    BYTE* dstPtr = dstStart;
+
+    size_t const flushSize = LZ4F_flush(cctxPtr, dstBuffer, dstCapacity, compressOptionsPtr);
+    DEBUGLOG(5,"LZ4F_compressEnd: dstCapacity=%u", (unsigned)dstCapacity);
+    FORWARD_IF_ERROR(flushSize);
+    dstPtr += flushSize;
+
+    assert(flushSize <= dstCapacity);
+    dstCapacity -= flushSize;
+
+    RETURN_ERROR_IF(dstCapacity < 4, dstMaxSize_tooSmall);
+    LZ4F_writeLE32(dstPtr, 0);
+    dstPtr += 4;   /* endMark */
+
+    if (cctxPtr->prefs.frameInfo.contentChecksumFlag == LZ4F_contentChecksumEnabled) {
+        U32 const xxh = XXH32_digest(&(cctxPtr->xxh));
+        RETURN_ERROR_IF(dstCapacity < 8, dstMaxSize_tooSmall);
+        DEBUGLOG(5,"Writing 32-bit content checksum (0x%0X)", xxh);
+        LZ4F_writeLE32(dstPtr, xxh);
+        dstPtr+=4;   /* content Checksum */
+    }
+
+    cctxPtr->cStage = 0;   /* state is now re-usable (with identical preferences) */
+
+    if (cctxPtr->prefs.frameInfo.contentSize) {
+        if (cctxPtr->prefs.frameInfo.contentSize != cctxPtr->totalInSize)
+            RETURN_ERROR(frameSize_wrong);
+    }
+
+    return (size_t)(dstPtr - dstStart);
+}
+
+
+/*-***************************************************
+*   Frame Decompression
+*****************************************************/
+
+typedef enum {
+    dstage_getFrameHeader=0, dstage_storeFrameHeader,
+    dstage_init,
+    dstage_getBlockHeader, dstage_storeBlockHeader,
+    dstage_copyDirect, dstage_getBlockChecksum,
+    dstage_getCBlock, dstage_storeCBlock,
+    dstage_flushOut,
+    dstage_getSuffix, dstage_storeSuffix,
+    dstage_getSFrameSize, dstage_storeSFrameSize,
+    dstage_skipSkippable
+} dStage_t;
+
+struct LZ4F_dctx_s {
+    LZ4F_CustomMem cmem;
+    LZ4F_frameInfo_t frameInfo;
+    U32    version;
+    dStage_t dStage;
+    U64    frameRemainingSize;
+    size_t maxBlockSize;
+    size_t maxBufferSize;
+    BYTE*  tmpIn;
+    size_t tmpInSize;
+    size_t tmpInTarget;
+    BYTE*  tmpOutBuffer;
+    const BYTE* dict;
+    size_t dictSize;
+    BYTE*  tmpOut;
+    size_t tmpOutSize;
+    size_t tmpOutStart;
+    XXH32_state_t xxh;
+    XXH32_state_t blockChecksum;
+    int    skipChecksum;
+    BYTE   header[LZ4F_HEADER_SIZE_MAX];
+};  /* typedef'd to LZ4F_dctx in lz4frame.h */
+
+
+LZ4F_dctx* LZ4F_createDecompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version)
+{
+    LZ4F_dctx* const dctx = (LZ4F_dctx*)LZ4F_calloc(sizeof(LZ4F_dctx), customMem);
+    if (dctx == NULL) return NULL;
+
+    dctx->cmem = customMem;
+    dctx->version = version;
+    return dctx;
+}
+
+/*! LZ4F_createDecompressionContext() :
+ *  Create a decompressionContext object, which will track all decompression operations.
+ *  Provides a pointer to a fully allocated and initialized LZ4F_decompressionContext object.
+ *  Object can later be released using LZ4F_freeDecompressionContext().
+ * @return : if != 0, there was an error during context creation.
+ */
+LZ4F_errorCode_t
+LZ4F_createDecompressionContext(LZ4F_dctx** LZ4F_decompressionContextPtr, unsigned versionNumber)
+{
+    assert(LZ4F_decompressionContextPtr != NULL);  /* violation of narrow contract */
+    RETURN_ERROR_IF(LZ4F_decompressionContextPtr == NULL, parameter_null);  /* in case it nonetheless happen in production */
+
+    *LZ4F_decompressionContextPtr = LZ4F_createDecompressionContext_advanced(LZ4F_defaultCMem, versionNumber);
+    if (*LZ4F_decompressionContextPtr == NULL) {  /* failed allocation */
+        RETURN_ERROR(allocation_failed);
+    }
+    return LZ4F_OK_NoError;
+}
+
+LZ4F_errorCode_t LZ4F_freeDecompressionContext(LZ4F_dctx* dctx)
+{
+    LZ4F_errorCode_t result = LZ4F_OK_NoError;
+    if (dctx != NULL) {   /* can accept NULL input, like free() */
+      result = (LZ4F_errorCode_t)dctx->dStage;
+      LZ4F_free(dctx->tmpIn, dctx->cmem);
+      LZ4F_free(dctx->tmpOutBuffer, dctx->cmem);
+      LZ4F_free(dctx, dctx->cmem);
+    }
+    return result;
+}
+
+
+/*==---   Streaming Decompression operations   ---==*/
+void LZ4F_resetDecompressionContext(LZ4F_dctx* dctx)
+{
+    DEBUGLOG(5, "LZ4F_resetDecompressionContext");
+    dctx->dStage = dstage_getFrameHeader;
+    dctx->dict = NULL;
+    dctx->dictSize = 0;
+    dctx->skipChecksum = 0;
+    dctx->frameRemainingSize = 0;
+}
+
+
+/*! LZ4F_decodeHeader() :
+ *  input   : `src` points at the **beginning of the frame**
+ *  output  : set internal values of dctx, such as
+ *            dctx->frameInfo and dctx->dStage.
+ *            Also allocates internal buffers.
+ *  @return : nb Bytes read from src (necessarily <= srcSize)
+ *            or an error code (testable with LZ4F_isError())
+ */
+static size_t LZ4F_decodeHeader(LZ4F_dctx* dctx, const void* src, size_t srcSize)
+{
+    unsigned blockMode, blockChecksumFlag, contentSizeFlag, contentChecksumFlag, dictIDFlag, blockSizeID;
+    size_t frameHeaderSize;
+    const BYTE* srcPtr = (const BYTE*)src;
+
+    DEBUGLOG(5, "LZ4F_decodeHeader");
+    /* need to decode header to get frameInfo */
+    RETURN_ERROR_IF(srcSize < minFHSize, frameHeader_incomplete);   /* minimal frame header size */
+    MEM_INIT(&(dctx->frameInfo), 0, sizeof(dctx->frameInfo));
+
+    /* special case : skippable frames */
+    if ((LZ4F_readLE32(srcPtr) & 0xFFFFFFF0U) == LZ4F_MAGIC_SKIPPABLE_START) {
+        dctx->frameInfo.frameType = LZ4F_skippableFrame;
+        if (src == (void*)(dctx->header)) {
+            dctx->tmpInSize = srcSize;
+            dctx->tmpInTarget = 8;
+            dctx->dStage = dstage_storeSFrameSize;
+            return srcSize;
+        } else {
+            dctx->dStage = dstage_getSFrameSize;
+            return 4;
+    }   }
+
+    /* control magic number */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    if (LZ4F_readLE32(srcPtr) != LZ4F_MAGICNUMBER) {
+        DEBUGLOG(4, "frame header error : unknown magic number");
+        RETURN_ERROR(frameType_unknown);
+    }
+#endif
+    dctx->frameInfo.frameType = LZ4F_frame;
+
+    /* Flags */
+    {   U32 const FLG = srcPtr[4];
+        U32 const version = (FLG>>6) & _2BITS;
+        blockChecksumFlag = (FLG>>4) & _1BIT;
+        blockMode = (FLG>>5) & _1BIT;
+        contentSizeFlag = (FLG>>3) & _1BIT;
+        contentChecksumFlag = (FLG>>2) & _1BIT;
+        dictIDFlag = FLG & _1BIT;
+        /* validate */
+        if (((FLG>>1)&_1BIT) != 0) RETURN_ERROR(reservedFlag_set); /* Reserved bit */
+        if (version != 1) RETURN_ERROR(headerVersion_wrong);       /* Version Number, only supported value */
+    }
+    DEBUGLOG(6, "contentSizeFlag: %u", contentSizeFlag);
+
+    /* Frame Header Size */
+    frameHeaderSize = minFHSize + (contentSizeFlag?8:0) + (dictIDFlag?4:0);
+
+    if (srcSize < frameHeaderSize) {
+        /* not enough input to fully decode frame header */
+        if (srcPtr != dctx->header)
+            memcpy(dctx->header, srcPtr, srcSize);
+        dctx->tmpInSize = srcSize;
+        dctx->tmpInTarget = frameHeaderSize;
+        dctx->dStage = dstage_storeFrameHeader;
+        return srcSize;
+    }
+
+    {   U32 const BD = srcPtr[5];
+        blockSizeID = (BD>>4) & _3BITS;
+        /* validate */
+        if (((BD>>7)&_1BIT) != 0) RETURN_ERROR(reservedFlag_set);   /* Reserved bit */
+        if (blockSizeID < 4) RETURN_ERROR(maxBlockSize_invalid);    /* 4-7 only supported values for the time being */
+        if (((BD>>0)&_4BITS) != 0) RETURN_ERROR(reservedFlag_set);  /* Reserved bits */
+    }
+
+    /* check header */
+    assert(frameHeaderSize > 5);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    {   BYTE const HC = LZ4F_headerChecksum(srcPtr+4, frameHeaderSize-5);
+        RETURN_ERROR_IF(HC != srcPtr[frameHeaderSize-1], headerChecksum_invalid);
+    }
+#endif
+
+    /* save */
+    dctx->frameInfo.blockMode = (LZ4F_blockMode_t)blockMode;
+    dctx->frameInfo.blockChecksumFlag = (LZ4F_blockChecksum_t)blockChecksumFlag;
+    dctx->frameInfo.contentChecksumFlag = (LZ4F_contentChecksum_t)contentChecksumFlag;
+    dctx->frameInfo.blockSizeID = (LZ4F_blockSizeID_t)blockSizeID;
+    dctx->maxBlockSize = LZ4F_getBlockSize((LZ4F_blockSizeID_t)blockSizeID);
+    if (contentSizeFlag) {
+        dctx->frameRemainingSize = dctx->frameInfo.contentSize = LZ4F_readLE64(srcPtr+6);
+    }
+    if (dictIDFlag)
+        dctx->frameInfo.dictID = LZ4F_readLE32(srcPtr + frameHeaderSize - 5);
+
+    dctx->dStage = dstage_init;
+
+    return frameHeaderSize;
+}
+
+
+/*! LZ4F_headerSize() :
+ * @return : size of frame header
+ *           or an error code, which can be tested using LZ4F_isError()
+ */
+size_t LZ4F_headerSize(const void* src, size_t srcSize)
+{
+    RETURN_ERROR_IF(src == NULL, srcPtr_wrong);
+
+    /* minimal srcSize to determine header size */
+    if (srcSize < LZ4F_MIN_SIZE_TO_KNOW_HEADER_LENGTH)
+        RETURN_ERROR(frameHeader_incomplete);
+
+    /* special case : skippable frames */
+    if ((LZ4F_readLE32(src) & 0xFFFFFFF0U) == LZ4F_MAGIC_SKIPPABLE_START)
+        return 8;
+
+    /* control magic number */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    if (LZ4F_readLE32(src) != LZ4F_MAGICNUMBER)
+        RETURN_ERROR(frameType_unknown);
+#endif
+
+    /* Frame Header Size */
+    {   BYTE const FLG = ((const BYTE*)src)[4];
+        U32 const contentSizeFlag = (FLG>>3) & _1BIT;
+        U32 const dictIDFlag = FLG & _1BIT;
+        return minFHSize + (contentSizeFlag?8:0) + (dictIDFlag?4:0);
+    }
+}
+
+/*! LZ4F_getFrameInfo() :
+ *  This function extracts frame parameters (max blockSize, frame checksum, etc.).
+ *  Usage is optional. Objective is to provide relevant information for allocation purposes.
+ *  This function works in 2 situations :
+ *   - At the beginning of a new frame, in which case it will decode this information from `srcBuffer`, and start the decoding process.
+ *     Amount of input data provided must be large enough to successfully decode the frame header.
+ *     A header size is variable, but is guaranteed to be <= LZ4F_HEADER_SIZE_MAX bytes. It's possible to provide more input data than this minimum.
+ *   - After decoding has been started. In which case, no input is read, frame parameters are extracted from dctx.
+ *  The number of bytes consumed from srcBuffer will be updated within *srcSizePtr (necessarily <= original value).
+ *  Decompression must resume from (srcBuffer + *srcSizePtr).
+ * @return : an hint about how many srcSize bytes LZ4F_decompress() expects for next call,
+ *           or an error code which can be tested using LZ4F_isError()
+ *  note 1 : in case of error, dctx is not modified. Decoding operations can resume from where they stopped.
+ *  note 2 : frame parameters are *copied into* an already allocated LZ4F_frameInfo_t structure.
+ */
+LZ4F_errorCode_t LZ4F_getFrameInfo(LZ4F_dctx* dctx,
+                                   LZ4F_frameInfo_t* frameInfoPtr,
+                             const void* srcBuffer, size_t* srcSizePtr)
+{
+    LZ4F_STATIC_ASSERT(dstage_getFrameHeader < dstage_storeFrameHeader);
+    if (dctx->dStage > dstage_storeFrameHeader) {
+        /* frameInfo already decoded */
+        size_t o=0, i=0;
+        *srcSizePtr = 0;
+        *frameInfoPtr = dctx->frameInfo;
+        /* returns : recommended nb of bytes for LZ4F_decompress() */
+        return LZ4F_decompress(dctx, NULL, &o, NULL, &i, NULL);
+    } else {
+        if (dctx->dStage == dstage_storeFrameHeader) {
+            /* frame decoding already started, in the middle of header => automatic fail */
+            *srcSizePtr = 0;
+            RETURN_ERROR(frameDecoding_alreadyStarted);
+        } else {
+            size_t const hSize = LZ4F_headerSize(srcBuffer, *srcSizePtr);
+            if (LZ4F_isError(hSize)) { *srcSizePtr=0; return hSize; }
+            if (*srcSizePtr < hSize) {
+                *srcSizePtr=0;
+                RETURN_ERROR(frameHeader_incomplete);
+            }
+
+            {   size_t decodeResult = LZ4F_decodeHeader(dctx, srcBuffer, hSize);
+                if (LZ4F_isError(decodeResult)) {
+                    *srcSizePtr = 0;
+                } else {
+                    *srcSizePtr = decodeResult;
+                    decodeResult = BHSize;   /* block header size */
+                }
+                *frameInfoPtr = dctx->frameInfo;
+                return decodeResult;
+    }   }   }
+}
+
+
+/* LZ4F_updateDict() :
+ * only used for LZ4F_blockLinked mode
+ * Condition : @dstPtr != NULL
+ */
+static void LZ4F_updateDict(LZ4F_dctx* dctx,
+                      const BYTE* dstPtr, size_t dstSize, const BYTE* dstBufferStart,
+                      unsigned withinTmp)
+{
+    assert(dstPtr != NULL);
+    if (dctx->dictSize==0) dctx->dict = (const BYTE*)dstPtr;  /* will lead to prefix mode */
+    assert(dctx->dict != NULL);
+
+    if (dctx->dict + dctx->dictSize == dstPtr) {  /* prefix mode, everything within dstBuffer */
+        dctx->dictSize += dstSize;
+        return;
+    }
+
+    assert(dstPtr >= dstBufferStart);
+    if ((size_t)(dstPtr - dstBufferStart) + dstSize >= 64 KB) {  /* history in dstBuffer becomes large enough to become dictionary */
+        dctx->dict = (const BYTE*)dstBufferStart;
+        dctx->dictSize = (size_t)(dstPtr - dstBufferStart) + dstSize;
+        return;
+    }
+
+    assert(dstSize < 64 KB);   /* if dstSize >= 64 KB, dictionary would be set into dstBuffer directly */
+
+    /* dstBuffer does not contain whole useful history (64 KB), so it must be saved within tmpOutBuffer */
+    assert(dctx->tmpOutBuffer != NULL);
+
+    if (withinTmp && (dctx->dict == dctx->tmpOutBuffer)) {   /* continue history within tmpOutBuffer */
+        /* withinTmp expectation : content of [dstPtr,dstSize] is same as [dict+dictSize,dstSize], so we just extend it */
+        assert(dctx->dict + dctx->dictSize == dctx->tmpOut + dctx->tmpOutStart);
+        dctx->dictSize += dstSize;
+        return;
+    }
+
+    if (withinTmp) { /* copy relevant dict portion in front of tmpOut within tmpOutBuffer */
+        size_t const preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
+        size_t copySize = 64 KB - dctx->tmpOutSize;
+        const BYTE* const oldDictEnd = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
+        if (dctx->tmpOutSize > 64 KB) copySize = 0;
+        if (copySize > preserveSize) copySize = preserveSize;
+
+        memcpy(dctx->tmpOutBuffer + preserveSize - copySize, oldDictEnd - copySize, copySize);
+
+        dctx->dict = dctx->tmpOutBuffer;
+        dctx->dictSize = preserveSize + dctx->tmpOutStart + dstSize;
+        return;
+    }
+
+    if (dctx->dict == dctx->tmpOutBuffer) {    /* copy dst into tmp to complete dict */
+        if (dctx->dictSize + dstSize > dctx->maxBufferSize) {  /* tmp buffer not large enough */
+            size_t const preserveSize = 64 KB - dstSize;
+            memcpy(dctx->tmpOutBuffer, dctx->dict + dctx->dictSize - preserveSize, preserveSize);
+            dctx->dictSize = preserveSize;
+        }
+        memcpy(dctx->tmpOutBuffer + dctx->dictSize, dstPtr, dstSize);
+        dctx->dictSize += dstSize;
+        return;
+    }
+
+    /* join dict & dest into tmp */
+    {   size_t preserveSize = 64 KB - dstSize;
+        if (preserveSize > dctx->dictSize) preserveSize = dctx->dictSize;
+        memcpy(dctx->tmpOutBuffer, dctx->dict + dctx->dictSize - preserveSize, preserveSize);
+        memcpy(dctx->tmpOutBuffer + preserveSize, dstPtr, dstSize);
+        dctx->dict = dctx->tmpOutBuffer;
+        dctx->dictSize = preserveSize + dstSize;
+    }
+}
+
+
+/*! LZ4F_decompress() :
+ *  Call this function repetitively to regenerate compressed data in srcBuffer.
+ *  The function will attempt to decode up to *srcSizePtr bytes from srcBuffer
+ *  into dstBuffer of capacity *dstSizePtr.
+ *
+ *  The number of bytes regenerated into dstBuffer will be provided within *dstSizePtr (necessarily <= original value).
+ *
+ *  The number of bytes effectively read from srcBuffer will be provided within *srcSizePtr (necessarily <= original value).
+ *  If number of bytes read is < number of bytes provided, then decompression operation is not complete.
+ *  Remaining data will have to be presented again in a subsequent invocation.
+ *
+ *  The function result is an hint of the better srcSize to use for next call to LZ4F_decompress.
+ *  Schematically, it's the size of the current (or remaining) compressed block + header of next block.
+ *  Respecting the hint provides a small boost to performance, since it allows less buffer shuffling.
+ *  Note that this is just a hint, and it's always possible to any srcSize value.
+ *  When a frame is fully decoded, @return will be 0.
+ *  If decompression failed, @return is an error code which can be tested using LZ4F_isError().
+ */
+size_t LZ4F_decompress(LZ4F_dctx* dctx,
+                       void* dstBuffer, size_t* dstSizePtr,
+                       const void* srcBuffer, size_t* srcSizePtr,
+                       const LZ4F_decompressOptions_t* decompressOptionsPtr)
+{
+    LZ4F_decompressOptions_t optionsNull;
+    const BYTE* const srcStart = (const BYTE*)srcBuffer;
+    const BYTE* const srcEnd = srcStart + *srcSizePtr;
+    const BYTE* srcPtr = srcStart;
+    BYTE* const dstStart = (BYTE*)dstBuffer;
+    BYTE* const dstEnd = dstStart ? dstStart + *dstSizePtr : NULL;
+    BYTE* dstPtr = dstStart;
+    const BYTE* selectedIn = NULL;
+    unsigned doAnotherStage = 1;
+    size_t nextSrcSizeHint = 1;
+
+
+    DEBUGLOG(5, "LZ4F_decompress: src[%p](%u) => dst[%p](%u)",
+            srcBuffer, (unsigned)*srcSizePtr, dstBuffer, (unsigned)*dstSizePtr);
+    if (dstBuffer == NULL) assert(*dstSizePtr == 0);
+    MEM_INIT(&optionsNull, 0, sizeof(optionsNull));
+    if (decompressOptionsPtr==NULL) decompressOptionsPtr = &optionsNull;
+    *srcSizePtr = 0;
+    *dstSizePtr = 0;
+    assert(dctx != NULL);
+    dctx->skipChecksum |= (decompressOptionsPtr->skipChecksums != 0); /* once set, disable for the remainder of the frame */
+
+    /* behaves as a state machine */
+
+    while (doAnotherStage) {
+
+        switch(dctx->dStage)
+        {
+
+        case dstage_getFrameHeader:
+            DEBUGLOG(6, "dstage_getFrameHeader");
+            if ((size_t)(srcEnd-srcPtr) >= maxFHSize) {  /* enough to decode - shortcut */
+                size_t const hSize = LZ4F_decodeHeader(dctx, srcPtr, (size_t)(srcEnd-srcPtr));  /* will update dStage appropriately */
+                FORWARD_IF_ERROR(hSize);
+                srcPtr += hSize;
+                break;
+            }
+            dctx->tmpInSize = 0;
+            if (srcEnd-srcPtr == 0) return minFHSize;   /* 0-size input */
+            dctx->tmpInTarget = minFHSize;   /* minimum size to decode header */
+            dctx->dStage = dstage_storeFrameHeader;
+            /* fall-through */
+
+        case dstage_storeFrameHeader:
+            DEBUGLOG(6, "dstage_storeFrameHeader");
+            {   size_t const sizeToCopy = MIN(dctx->tmpInTarget - dctx->tmpInSize, (size_t)(srcEnd - srcPtr));
+                memcpy(dctx->header + dctx->tmpInSize, srcPtr, sizeToCopy);
+                dctx->tmpInSize += sizeToCopy;
+                srcPtr += sizeToCopy;
+            }
+            if (dctx->tmpInSize < dctx->tmpInTarget) {
+                nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize) + BHSize;   /* rest of header + nextBlockHeader */
+                doAnotherStage = 0;   /* not enough src data, ask for some more */
+                break;
+            }
+            FORWARD_IF_ERROR( LZ4F_decodeHeader(dctx, dctx->header, dctx->tmpInTarget) ); /* will update dStage appropriately */
+            break;
+
+        case dstage_init:
+            DEBUGLOG(6, "dstage_init");
+            if (dctx->frameInfo.contentChecksumFlag) (void)XXH32_reset(&(dctx->xxh), 0);
+            /* internal buffers allocation */
+            {   size_t const bufferNeeded = dctx->maxBlockSize
+                    + ((dctx->frameInfo.blockMode==LZ4F_blockLinked) ? 128 KB : 0);
+                if (bufferNeeded > dctx->maxBufferSize) {   /* tmp buffers too small */
+                    dctx->maxBufferSize = 0;   /* ensure allocation will be re-attempted on next entry*/
+                    LZ4F_free(dctx->tmpIn, dctx->cmem);
+                    dctx->tmpIn = (BYTE*)LZ4F_malloc(dctx->maxBlockSize + BFSize /* block checksum */, dctx->cmem);
+                    RETURN_ERROR_IF(dctx->tmpIn == NULL, allocation_failed);
+                    LZ4F_free(dctx->tmpOutBuffer, dctx->cmem);
+                    dctx->tmpOutBuffer= (BYTE*)LZ4F_malloc(bufferNeeded, dctx->cmem);
+                    RETURN_ERROR_IF(dctx->tmpOutBuffer== NULL, allocation_failed);
+                    dctx->maxBufferSize = bufferNeeded;
+            }   }
+            dctx->tmpInSize = 0;
+            dctx->tmpInTarget = 0;
+            dctx->tmpOut = dctx->tmpOutBuffer;
+            dctx->tmpOutStart = 0;
+            dctx->tmpOutSize = 0;
+
+            dctx->dStage = dstage_getBlockHeader;
+            /* fall-through */
+
+        case dstage_getBlockHeader:
+            if ((size_t)(srcEnd - srcPtr) >= BHSize) {
+                selectedIn = srcPtr;
+                srcPtr += BHSize;
+            } else {
+                /* not enough input to read cBlockSize field */
+                dctx->tmpInSize = 0;
+                dctx->dStage = dstage_storeBlockHeader;
+            }
+
+            if (dctx->dStage == dstage_storeBlockHeader)   /* can be skipped */
+        case dstage_storeBlockHeader:
+            {   size_t const remainingInput = (size_t)(srcEnd - srcPtr);
+                size_t const wantedData = BHSize - dctx->tmpInSize;
+                size_t const sizeToCopy = MIN(wantedData, remainingInput);
+                memcpy(dctx->tmpIn + dctx->tmpInSize, srcPtr, sizeToCopy);
+                srcPtr += sizeToCopy;
+                dctx->tmpInSize += sizeToCopy;
+
+                if (dctx->tmpInSize < BHSize) {   /* not enough input for cBlockSize */
+                    nextSrcSizeHint = BHSize - dctx->tmpInSize;
+                    doAnotherStage  = 0;
+                    break;
+                }
+                selectedIn = dctx->tmpIn;
+            }   /* if (dctx->dStage == dstage_storeBlockHeader) */
+
+        /* decode block header */
+            {   U32 const blockHeader = LZ4F_readLE32(selectedIn);
+                size_t const nextCBlockSize = blockHeader & 0x7FFFFFFFU;
+                size_t const crcSize = dctx->frameInfo.blockChecksumFlag * BFSize;
+                if (blockHeader==0) {  /* frameEnd signal, no more block */
+                    DEBUGLOG(5, "end of frame");
+                    dctx->dStage = dstage_getSuffix;
+                    break;
+                }
+                if (nextCBlockSize > dctx->maxBlockSize) {
+                    RETURN_ERROR(maxBlockSize_invalid);
+                }
+                if (blockHeader & LZ4F_BLOCKUNCOMPRESSED_FLAG) {
+                    /* next block is uncompressed */
+                    dctx->tmpInTarget = nextCBlockSize;
+                    DEBUGLOG(5, "next block is uncompressed (size %u)", (U32)nextCBlockSize);
+                    if (dctx->frameInfo.blockChecksumFlag) {
+                        (void)XXH32_reset(&dctx->blockChecksum, 0);
+                    }
+                    dctx->dStage = dstage_copyDirect;
+                    break;
+                }
+                /* next block is a compressed block */
+                dctx->tmpInTarget = nextCBlockSize + crcSize;
+                dctx->dStage = dstage_getCBlock;
+                if (dstPtr==dstEnd || srcPtr==srcEnd) {
+                    nextSrcSizeHint = BHSize + nextCBlockSize + crcSize;
+                    doAnotherStage = 0;
+                }
+                break;
+            }
+
+        case dstage_copyDirect:   /* uncompressed block */
+            DEBUGLOG(6, "dstage_copyDirect");
+            {   size_t sizeToCopy;
+                if (dstPtr == NULL) {
+                    sizeToCopy = 0;
+                } else {
+                    size_t const minBuffSize = MIN((size_t)(srcEnd-srcPtr), (size_t)(dstEnd-dstPtr));
+                    sizeToCopy = MIN(dctx->tmpInTarget, minBuffSize);
+                    memcpy(dstPtr, srcPtr, sizeToCopy);
+                    if (!dctx->skipChecksum) {
+                        if (dctx->frameInfo.blockChecksumFlag) {
+                            (void)XXH32_update(&dctx->blockChecksum, srcPtr, sizeToCopy);
+                        }
+                        if (dctx->frameInfo.contentChecksumFlag)
+                            (void)XXH32_update(&dctx->xxh, srcPtr, sizeToCopy);
+                    }
+                    if (dctx->frameInfo.contentSize)
+                        dctx->frameRemainingSize -= sizeToCopy;
+
+                    /* history management (linked blocks only)*/
+                    if (dctx->frameInfo.blockMode == LZ4F_blockLinked) {
+                        LZ4F_updateDict(dctx, dstPtr, sizeToCopy, dstStart, 0);
+                    }
+                    srcPtr += sizeToCopy;
+                    dstPtr += sizeToCopy;
+                }
+                if (sizeToCopy == dctx->tmpInTarget) {   /* all done */
+                    if (dctx->frameInfo.blockChecksumFlag) {
+                        dctx->tmpInSize = 0;
+                        dctx->dStage = dstage_getBlockChecksum;
+                    } else
+                        dctx->dStage = dstage_getBlockHeader;  /* new block */
+                    break;
+                }
+                dctx->tmpInTarget -= sizeToCopy;  /* need to copy more */
+            }
+            nextSrcSizeHint = dctx->tmpInTarget +
+                            +(dctx->frameInfo.blockChecksumFlag ? BFSize : 0)
+                            + BHSize /* next header size */;
+            doAnotherStage = 0;
+            break;
+
+        /* check block checksum for recently transferred uncompressed block */
+        case dstage_getBlockChecksum:
+            DEBUGLOG(6, "dstage_getBlockChecksum");
+            {   const void* crcSrc;
+                if ((srcEnd-srcPtr >= 4) && (dctx->tmpInSize==0)) {
+                    crcSrc = srcPtr;
+                    srcPtr += 4;
+                } else {
+                    size_t const stillToCopy = 4 - dctx->tmpInSize;
+                    size_t const sizeToCopy = MIN(stillToCopy, (size_t)(srcEnd-srcPtr));
+                    memcpy(dctx->header + dctx->tmpInSize, srcPtr, sizeToCopy);
+                    dctx->tmpInSize += sizeToCopy;
+                    srcPtr += sizeToCopy;
+                    if (dctx->tmpInSize < 4) {  /* all input consumed */
+                        doAnotherStage = 0;
+                        break;
+                    }
+                    crcSrc = dctx->header;
+                }
+                if (!dctx->skipChecksum) {
+                    U32 const readCRC = LZ4F_readLE32(crcSrc);
+                    U32 const calcCRC = XXH32_digest(&dctx->blockChecksum);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+                    DEBUGLOG(6, "compare block checksum");
+                    if (readCRC != calcCRC) {
+                        DEBUGLOG(4, "incorrect block checksum: %08X != %08X",
+                                readCRC, calcCRC);
+                        RETURN_ERROR(blockChecksum_invalid);
+                    }
+#else
+                    (void)readCRC;
+                    (void)calcCRC;
+#endif
+            }   }
+            dctx->dStage = dstage_getBlockHeader;  /* new block */
+            break;
+
+        case dstage_getCBlock:
+            DEBUGLOG(6, "dstage_getCBlock");
+            if ((size_t)(srcEnd-srcPtr) < dctx->tmpInTarget) {
+                dctx->tmpInSize = 0;
+                dctx->dStage = dstage_storeCBlock;
+                break;
+            }
+            /* input large enough to read full block directly */
+            selectedIn = srcPtr;
+            srcPtr += dctx->tmpInTarget;
+
+            if (0)  /* always jump over next block */
+        case dstage_storeCBlock:
+            {   size_t const wantedData = dctx->tmpInTarget - dctx->tmpInSize;
+                size_t const inputLeft = (size_t)(srcEnd-srcPtr);
+                size_t const sizeToCopy = MIN(wantedData, inputLeft);
+                memcpy(dctx->tmpIn + dctx->tmpInSize, srcPtr, sizeToCopy);
+                dctx->tmpInSize += sizeToCopy;
+                srcPtr += sizeToCopy;
+                if (dctx->tmpInSize < dctx->tmpInTarget) { /* need more input */
+                    nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize)
+                                    + (dctx->frameInfo.blockChecksumFlag ? BFSize : 0)
+                                    + BHSize /* next header size */;
+                    doAnotherStage = 0;
+                    break;
+                }
+                selectedIn = dctx->tmpIn;
+            }
+
+            /* At this stage, input is large enough to decode a block */
+
+            /* First, decode and control block checksum if it exists */
+            if (dctx->frameInfo.blockChecksumFlag) {
+                assert(dctx->tmpInTarget >= 4);
+                dctx->tmpInTarget -= 4;
+                assert(selectedIn != NULL);  /* selectedIn is defined at this stage (either srcPtr, or dctx->tmpIn) */
+                {   U32 const readBlockCrc = LZ4F_readLE32(selectedIn + dctx->tmpInTarget);
+                    U32 const calcBlockCrc = XXH32(selectedIn, dctx->tmpInTarget, 0);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+                    RETURN_ERROR_IF(readBlockCrc != calcBlockCrc, blockChecksum_invalid);
+#else
+                    (void)readBlockCrc;
+                    (void)calcBlockCrc;
+#endif
+            }   }
+
+            /* decode directly into destination buffer if there is enough room */
+            if ( ((size_t)(dstEnd-dstPtr) >= dctx->maxBlockSize)
+                 /* unless the dictionary is stored in tmpOut:
+                  * in which case it's faster to decode within tmpOut
+                  * to benefit from prefix speedup */
+              && !(dctx->dict!= NULL && (const BYTE*)dctx->dict + dctx->dictSize == dctx->tmpOut) )
+            {
+                const char* dict = (const char*)dctx->dict;
+                size_t dictSize = dctx->dictSize;
+                int decodedSize;
+                assert(dstPtr != NULL);
+                if (dict && dictSize > 1 GB) {
+                    /* overflow control : dctx->dictSize is an int, avoid truncation / sign issues */
+                    dict += dictSize - 64 KB;
+                    dictSize = 64 KB;
+                }
+                decodedSize = LZ4_decompress_safe_usingDict(
+                        (const char*)selectedIn, (char*)dstPtr,
+                        (int)dctx->tmpInTarget, (int)dctx->maxBlockSize,
+                        dict, (int)dictSize);
+                RETURN_ERROR_IF(decodedSize < 0, decompressionFailed);
+                if ((dctx->frameInfo.contentChecksumFlag) && (!dctx->skipChecksum))
+                    XXH32_update(&(dctx->xxh), dstPtr, (size_t)decodedSize);
+                if (dctx->frameInfo.contentSize)
+                    dctx->frameRemainingSize -= (size_t)decodedSize;
+
+                /* dictionary management */
+                if (dctx->frameInfo.blockMode==LZ4F_blockLinked) {
+                    LZ4F_updateDict(dctx, dstPtr, (size_t)decodedSize, dstStart, 0);
+                }
+
+                dstPtr += decodedSize;
+                dctx->dStage = dstage_getBlockHeader;  /* end of block, let's get another one */
+                break;
+            }
+
+            /* not enough place into dst : decode into tmpOut */
+
+            /* manage dictionary */
+            if (dctx->frameInfo.blockMode == LZ4F_blockLinked) {
+                if (dctx->dict == dctx->tmpOutBuffer) {
+                    /* truncate dictionary to 64 KB if too big */
+                    if (dctx->dictSize > 128 KB) {
+                        memcpy(dctx->tmpOutBuffer, dctx->dict + dctx->dictSize - 64 KB, 64 KB);
+                        dctx->dictSize = 64 KB;
+                    }
+                    dctx->tmpOut = dctx->tmpOutBuffer + dctx->dictSize;
+                } else {  /* dict not within tmpOut */
+                    size_t const reservedDictSpace = MIN(dctx->dictSize, 64 KB);
+                    dctx->tmpOut = dctx->tmpOutBuffer + reservedDictSpace;
+            }   }
+
+            /* Decode block into tmpOut */
+            {   const char* dict = (const char*)dctx->dict;
+                size_t dictSize = dctx->dictSize;
+                int decodedSize;
+                if (dict && dictSize > 1 GB) {
+                    /* the dictSize param is an int, avoid truncation / sign issues */
+                    dict += dictSize - 64 KB;
+                    dictSize = 64 KB;
+                }
+                decodedSize = LZ4_decompress_safe_usingDict(
+                        (const char*)selectedIn, (char*)dctx->tmpOut,
+                        (int)dctx->tmpInTarget, (int)dctx->maxBlockSize,
+                        dict, (int)dictSize);
+                RETURN_ERROR_IF(decodedSize < 0, decompressionFailed);
+                if (dctx->frameInfo.contentChecksumFlag && !dctx->skipChecksum)
+                    XXH32_update(&(dctx->xxh), dctx->tmpOut, (size_t)decodedSize);
+                if (dctx->frameInfo.contentSize)
+                    dctx->frameRemainingSize -= (size_t)decodedSize;
+                dctx->tmpOutSize = (size_t)decodedSize;
+                dctx->tmpOutStart = 0;
+                dctx->dStage = dstage_flushOut;
+            }
+            /* fall-through */
+
+        case dstage_flushOut:  /* flush decoded data from tmpOut to dstBuffer */
+            DEBUGLOG(6, "dstage_flushOut");
+            if (dstPtr != NULL) {
+                size_t const sizeToCopy = MIN(dctx->tmpOutSize - dctx->tmpOutStart, (size_t)(dstEnd-dstPtr));
+                memcpy(dstPtr, dctx->tmpOut + dctx->tmpOutStart, sizeToCopy);
+
+                /* dictionary management */
+                if (dctx->frameInfo.blockMode == LZ4F_blockLinked)
+                    LZ4F_updateDict(dctx, dstPtr, sizeToCopy, dstStart, 1 /*withinTmp*/);
+
+                dctx->tmpOutStart += sizeToCopy;
+                dstPtr += sizeToCopy;
+            }
+            if (dctx->tmpOutStart == dctx->tmpOutSize) { /* all flushed */
+                dctx->dStage = dstage_getBlockHeader;  /* get next block */
+                break;
+            }
+            /* could not flush everything : stop there, just request a block header */
+            doAnotherStage = 0;
+            nextSrcSizeHint = BHSize;
+            break;
+
+        case dstage_getSuffix:
+            RETURN_ERROR_IF(dctx->frameRemainingSize, frameSize_wrong);   /* incorrect frame size decoded */
+            if (!dctx->frameInfo.contentChecksumFlag) {  /* no checksum, frame is completed */
+                nextSrcSizeHint = 0;
+                LZ4F_resetDecompressionContext(dctx);
+                doAnotherStage = 0;
+                break;
+            }
+            if ((srcEnd - srcPtr) < 4) {  /* not enough size for entire CRC */
+                dctx->tmpInSize = 0;
+                dctx->dStage = dstage_storeSuffix;
+            } else {
+                selectedIn = srcPtr;
+                srcPtr += 4;
+            }
+
+            if (dctx->dStage == dstage_storeSuffix)   /* can be skipped */
+        case dstage_storeSuffix:
+            {   size_t const remainingInput = (size_t)(srcEnd - srcPtr);
+                size_t const wantedData = 4 - dctx->tmpInSize;
+                size_t const sizeToCopy = MIN(wantedData, remainingInput);
+                memcpy(dctx->tmpIn + dctx->tmpInSize, srcPtr, sizeToCopy);
+                srcPtr += sizeToCopy;
+                dctx->tmpInSize += sizeToCopy;
+                if (dctx->tmpInSize < 4) { /* not enough input to read complete suffix */
+                    nextSrcSizeHint = 4 - dctx->tmpInSize;
+                    doAnotherStage=0;
+                    break;
+                }
+                selectedIn = dctx->tmpIn;
+            }   /* if (dctx->dStage == dstage_storeSuffix) */
+
+        /* case dstage_checkSuffix: */   /* no direct entry, avoid initialization risks */
+            if (!dctx->skipChecksum) {
+                U32 const readCRC = LZ4F_readLE32(selectedIn);
+                U32 const resultCRC = XXH32_digest(&(dctx->xxh));
+                DEBUGLOG(4, "frame checksum: stored 0x%0X vs 0x%0X processed", readCRC, resultCRC);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+                RETURN_ERROR_IF(readCRC != resultCRC, contentChecksum_invalid);
+#else
+                (void)readCRC;
+                (void)resultCRC;
+#endif
+            }
+            nextSrcSizeHint = 0;
+            LZ4F_resetDecompressionContext(dctx);
+            doAnotherStage = 0;
+            break;
+
+        case dstage_getSFrameSize:
+            if ((srcEnd - srcPtr) >= 4) {
+                selectedIn = srcPtr;
+                srcPtr += 4;
+            } else {
+                /* not enough input to read cBlockSize field */
+                dctx->tmpInSize = 4;
+                dctx->tmpInTarget = 8;
+                dctx->dStage = dstage_storeSFrameSize;
+            }
+
+            if (dctx->dStage == dstage_storeSFrameSize)
+        case dstage_storeSFrameSize:
+            {   size_t const sizeToCopy = MIN(dctx->tmpInTarget - dctx->tmpInSize,
+                                             (size_t)(srcEnd - srcPtr) );
+                memcpy(dctx->header + dctx->tmpInSize, srcPtr, sizeToCopy);
+                srcPtr += sizeToCopy;
+                dctx->tmpInSize += sizeToCopy;
+                if (dctx->tmpInSize < dctx->tmpInTarget) {
+                    /* not enough input to get full sBlockSize; wait for more */
+                    nextSrcSizeHint = dctx->tmpInTarget - dctx->tmpInSize;
+                    doAnotherStage = 0;
+                    break;
+                }
+                selectedIn = dctx->header + 4;
+            }   /* if (dctx->dStage == dstage_storeSFrameSize) */
+
+        /* case dstage_decodeSFrameSize: */   /* no direct entry */
+            {   size_t const SFrameSize = LZ4F_readLE32(selectedIn);
+                dctx->frameInfo.contentSize = SFrameSize;
+                dctx->tmpInTarget = SFrameSize;
+                dctx->dStage = dstage_skipSkippable;
+                break;
+            }
+
+        case dstage_skipSkippable:
+            {   size_t const skipSize = MIN(dctx->tmpInTarget, (size_t)(srcEnd-srcPtr));
+                srcPtr += skipSize;
+                dctx->tmpInTarget -= skipSize;
+                doAnotherStage = 0;
+                nextSrcSizeHint = dctx->tmpInTarget;
+                if (nextSrcSizeHint) break;  /* still more to skip */
+                /* frame fully skipped : prepare context for a new frame */
+                LZ4F_resetDecompressionContext(dctx);
+                break;
+            }
+        }   /* switch (dctx->dStage) */
+    }   /* while (doAnotherStage) */
+
+    /* preserve history within tmpOut whenever necessary */
+    LZ4F_STATIC_ASSERT((unsigned)dstage_init == 2);
+    if ( (dctx->frameInfo.blockMode==LZ4F_blockLinked)  /* next block will use up to 64KB from previous ones */
+      && (dctx->dict != dctx->tmpOutBuffer)             /* dictionary is not already within tmp */
+      && (dctx->dict != NULL)                           /* dictionary exists */
+      && (!decompressOptionsPtr->stableDst)             /* cannot rely on dst data to remain there for next call */
+      && ((unsigned)(dctx->dStage)-2 < (unsigned)(dstage_getSuffix)-2) )  /* valid stages : [init ... getSuffix[ */
+    {
+        if (dctx->dStage == dstage_flushOut) {
+            size_t const preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
+            size_t copySize = 64 KB - dctx->tmpOutSize;
+            const BYTE* oldDictEnd = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
+            if (dctx->tmpOutSize > 64 KB) copySize = 0;
+            if (copySize > preserveSize) copySize = preserveSize;
+            assert(dctx->tmpOutBuffer != NULL);
+
+            memcpy(dctx->tmpOutBuffer + preserveSize - copySize, oldDictEnd - copySize, copySize);
+
+            dctx->dict = dctx->tmpOutBuffer;
+            dctx->dictSize = preserveSize + dctx->tmpOutStart;
+        } else {
+            const BYTE* const oldDictEnd = dctx->dict + dctx->dictSize;
+            size_t const newDictSize = MIN(dctx->dictSize, 64 KB);
+
+            memcpy(dctx->tmpOutBuffer, oldDictEnd - newDictSize, newDictSize);
+
+            dctx->dict = dctx->tmpOutBuffer;
+            dctx->dictSize = newDictSize;
+            dctx->tmpOut = dctx->tmpOutBuffer + newDictSize;
+        }
+    }
+
+    *srcSizePtr = (size_t)(srcPtr - srcStart);
+    *dstSizePtr = (size_t)(dstPtr - dstStart);
+    return nextSrcSizeHint;
+}
+
+/*! LZ4F_decompress_usingDict() :
+ *  Same as LZ4F_decompress(), using a predefined dictionary.
+ *  Dictionary is used "in place", without any preprocessing.
+ *  It must remain accessible throughout the entire frame decoding.
+ */
+size_t LZ4F_decompress_usingDict(LZ4F_dctx* dctx,
+                       void* dstBuffer, size_t* dstSizePtr,
+                       const void* srcBuffer, size_t* srcSizePtr,
+                       const void* dict, size_t dictSize,
+                       const LZ4F_decompressOptions_t* decompressOptionsPtr)
+{
+    if (dctx->dStage <= dstage_init) {
+        dctx->dict = (const BYTE*)dict;
+        dctx->dictSize = dictSize;
+    }
+    return LZ4F_decompress(dctx, dstBuffer, dstSizePtr,
+                           srcBuffer, srcSizePtr,
+                           decompressOptionsPtr);
+}

--- a/deps/lz4/lz4frame.h
+++ b/deps/lz4/lz4frame.h
@@ -1,0 +1,751 @@
+/*
+   LZ4F - LZ4-Frame library
+   Header File
+   Copyright (C) 2011-2020, Yann Collet.
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - LZ4 source repository : https://github.com/lz4/lz4
+   - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+
+/* LZ4F is a stand-alone API able to create and decode LZ4 frames
+ * conformant with specification v1.6.1 in doc/lz4_Frame_format.md .
+ * Generated frames are compatible with `lz4` CLI.
+ *
+ * LZ4F also offers streaming capabilities.
+ *
+ * lz4.h is not required when using lz4frame.h,
+ * except to extract common constants such as LZ4_VERSION_NUMBER.
+ * */
+
+#ifndef LZ4F_H_09782039843
+#define LZ4F_H_09782039843
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/* ---   Dependency   --- */
+#include <stddef.h>   /* size_t */
+
+
+/**
+ * Introduction
+ *
+ * lz4frame.h implements LZ4 frame specification: see doc/lz4_Frame_format.md .
+ * LZ4 Frames are compatible with `lz4` CLI,
+ * and designed to be interoperable with any system.
+**/
+
+/*-***************************************************************
+ *  Compiler specifics
+ *****************************************************************/
+/*  LZ4_DLL_EXPORT :
+ *  Enable exporting of functions when building a Windows DLL
+ *  LZ4FLIB_VISIBILITY :
+ *  Control library symbols visibility.
+ */
+#ifndef LZ4FLIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4FLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define LZ4FLIB_VISIBILITY
+#  endif
+#endif
+#if defined(LZ4_DLL_EXPORT) && (LZ4_DLL_EXPORT==1)
+#  define LZ4FLIB_API __declspec(dllexport) LZ4FLIB_VISIBILITY
+#elif defined(LZ4_DLL_IMPORT) && (LZ4_DLL_IMPORT==1)
+#  define LZ4FLIB_API __declspec(dllimport) LZ4FLIB_VISIBILITY
+#else
+#  define LZ4FLIB_API LZ4FLIB_VISIBILITY
+#endif
+
+#ifdef LZ4F_DISABLE_DEPRECATE_WARNINGS
+#  define LZ4F_DEPRECATE(x) x
+#else
+#  if defined(_MSC_VER)
+#    define LZ4F_DEPRECATE(x) x   /* __declspec(deprecated) x - only works with C++ */
+#  elif defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 6))
+#    define LZ4F_DEPRECATE(x) x __attribute__((deprecated))
+#  else
+#    define LZ4F_DEPRECATE(x) x   /* no deprecation warning for this compiler */
+#  endif
+#endif
+
+
+/*-************************************
+ *  Error management
+ **************************************/
+typedef size_t LZ4F_errorCode_t;
+
+LZ4FLIB_API unsigned    LZ4F_isError(LZ4F_errorCode_t code);   /**< tells when a function result is an error code */
+LZ4FLIB_API const char* LZ4F_getErrorName(LZ4F_errorCode_t code);   /**< return error code string; for debugging */
+
+
+/*-************************************
+ *  Frame compression types
+ ************************************* */
+/* #define LZ4F_ENABLE_OBSOLETE_ENUMS   // uncomment to enable obsolete enums */
+#ifdef LZ4F_ENABLE_OBSOLETE_ENUMS
+#  define LZ4F_OBSOLETE_ENUM(x) , LZ4F_DEPRECATE(x) = LZ4F_##x
+#else
+#  define LZ4F_OBSOLETE_ENUM(x)
+#endif
+
+/* The larger the block size, the (slightly) better the compression ratio,
+ * though there are diminishing returns.
+ * Larger blocks also increase memory usage on both compression and decompression sides.
+ */
+typedef enum {
+    LZ4F_default=0,
+    LZ4F_max64KB=4,
+    LZ4F_max256KB=5,
+    LZ4F_max1MB=6,
+    LZ4F_max4MB=7
+    LZ4F_OBSOLETE_ENUM(max64KB)
+    LZ4F_OBSOLETE_ENUM(max256KB)
+    LZ4F_OBSOLETE_ENUM(max1MB)
+    LZ4F_OBSOLETE_ENUM(max4MB)
+} LZ4F_blockSizeID_t;
+
+/* Linked blocks sharply reduce inefficiencies when using small blocks,
+ * they compress better.
+ * However, some LZ4 decoders are only compatible with independent blocks */
+typedef enum {
+    LZ4F_blockLinked=0,
+    LZ4F_blockIndependent
+    LZ4F_OBSOLETE_ENUM(blockLinked)
+    LZ4F_OBSOLETE_ENUM(blockIndependent)
+} LZ4F_blockMode_t;
+
+typedef enum {
+    LZ4F_noContentChecksum=0,
+    LZ4F_contentChecksumEnabled
+    LZ4F_OBSOLETE_ENUM(noContentChecksum)
+    LZ4F_OBSOLETE_ENUM(contentChecksumEnabled)
+} LZ4F_contentChecksum_t;
+
+typedef enum {
+    LZ4F_noBlockChecksum=0,
+    LZ4F_blockChecksumEnabled
+} LZ4F_blockChecksum_t;
+
+typedef enum {
+    LZ4F_frame=0,
+    LZ4F_skippableFrame
+    LZ4F_OBSOLETE_ENUM(skippableFrame)
+} LZ4F_frameType_t;
+
+#ifdef LZ4F_ENABLE_OBSOLETE_ENUMS
+typedef LZ4F_blockSizeID_t blockSizeID_t;
+typedef LZ4F_blockMode_t blockMode_t;
+typedef LZ4F_frameType_t frameType_t;
+typedef LZ4F_contentChecksum_t contentChecksum_t;
+#endif
+
+/*! LZ4F_frameInfo_t :
+ *  makes it possible to set or read frame parameters.
+ *  Structure must be first init to 0, using memset() or LZ4F_INIT_FRAMEINFO,
+ *  setting all parameters to default.
+ *  It's then possible to update selectively some parameters */
+typedef struct {
+  LZ4F_blockSizeID_t     blockSizeID;         /* max64KB, max256KB, max1MB, max4MB; 0 == default (LZ4F_max64KB) */
+  LZ4F_blockMode_t       blockMode;           /* LZ4F_blockLinked, LZ4F_blockIndependent; 0 == default (LZ4F_blockLinked) */
+  LZ4F_contentChecksum_t contentChecksumFlag; /* 1: add a 32-bit checksum of frame's decompressed data; 0 == default (disabled) */
+  LZ4F_frameType_t       frameType;           /* read-only field : LZ4F_frame or LZ4F_skippableFrame */
+  unsigned long long     contentSize;         /* Size of uncompressed content ; 0 == unknown */
+  unsigned               dictID;              /* Dictionary ID, sent by compressor to help decoder select correct dictionary; 0 == no dictID provided */
+  LZ4F_blockChecksum_t   blockChecksumFlag;   /* 1: each block followed by a checksum of block's compressed data; 0 == default (disabled) */
+} LZ4F_frameInfo_t;
+
+#define LZ4F_INIT_FRAMEINFO   { LZ4F_max64KB, LZ4F_blockLinked, LZ4F_noContentChecksum, LZ4F_frame, 0ULL, 0U, LZ4F_noBlockChecksum }    /* v1.8.3+ */
+
+/*! LZ4F_preferences_t :
+ *  makes it possible to supply advanced compression instructions to streaming interface.
+ *  Structure must be first init to 0, using memset() or LZ4F_INIT_PREFERENCES,
+ *  setting all parameters to default.
+ *  All reserved fields must be set to zero. */
+typedef struct {
+  LZ4F_frameInfo_t frameInfo;
+  int      compressionLevel;    /* 0: default (fast mode); values > LZ4HC_CLEVEL_MAX count as LZ4HC_CLEVEL_MAX; values < 0 trigger "fast acceleration" */
+  unsigned autoFlush;           /* 1: always flush; reduces usage of internal buffers */
+  unsigned favorDecSpeed;       /* 1: parser favors decompression speed vs compression ratio. Only works for high compression modes (>= LZ4HC_CLEVEL_OPT_MIN) */  /* v1.8.2+ */
+  unsigned reserved[3];         /* must be zero for forward compatibility */
+} LZ4F_preferences_t;
+
+#define LZ4F_INIT_PREFERENCES   { LZ4F_INIT_FRAMEINFO, 0, 0u, 0u, { 0u, 0u, 0u } }    /* v1.8.3+ */
+
+
+/*-*********************************
+*  Simple compression function
+***********************************/
+
+/*! LZ4F_compressFrame() :
+ *  Compress srcBuffer content into an LZ4-compressed frame.
+ *  It's a one shot operation, all input content is consumed, and all output is generated.
+ *
+ *  Note : it's a stateless operation (no LZ4F_cctx state needed).
+ *  In order to reduce load on the allocator, LZ4F_compressFrame(), by default,
+ *  uses the stack to allocate space for the compression state and some table.
+ *  If this usage of the stack is too much for your application,
+ *  consider compiling `lz4frame.c` with compile-time macro LZ4F_HEAPMODE set to 1 instead.
+ *  All state allocations will use the Heap.
+ *  It also means each invocation of LZ4F_compressFrame() will trigger several internal alloc/free invocations.
+ *
+ * @dstCapacity MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr).
+ * @preferencesPtr is optional : one can provide NULL, in which case all preferences are set to default.
+ * @return : number of bytes written into dstBuffer.
+ *           or an error code if it fails (can be tested using LZ4F_isError())
+ */
+LZ4FLIB_API size_t LZ4F_compressFrame(void* dstBuffer, size_t dstCapacity,
+                                const void* srcBuffer, size_t srcSize,
+                                const LZ4F_preferences_t* preferencesPtr);
+
+/*! LZ4F_compressFrameBound() :
+ *  Returns the maximum possible compressed size with LZ4F_compressFrame() given srcSize and preferences.
+ * `preferencesPtr` is optional. It can be replaced by NULL, in which case, the function will assume default preferences.
+ *  Note : this result is only usable with LZ4F_compressFrame().
+ *         It may also be relevant to LZ4F_compressUpdate() _only if_ no flush() operation is ever performed.
+ */
+LZ4FLIB_API size_t LZ4F_compressFrameBound(size_t srcSize, const LZ4F_preferences_t* preferencesPtr);
+
+
+/*! LZ4F_compressionLevel_max() :
+ * @return maximum allowed compression level (currently: 12)
+ */
+LZ4FLIB_API int LZ4F_compressionLevel_max(void);   /* v1.8.0+ */
+
+
+/*-***********************************
+*  Advanced compression functions
+*************************************/
+typedef struct LZ4F_cctx_s LZ4F_cctx;   /* incomplete type */
+typedef LZ4F_cctx* LZ4F_compressionContext_t;  /* for compatibility with older APIs, prefer using LZ4F_cctx */
+
+typedef struct {
+  unsigned stableSrc;    /* 1 == src content will remain present on future calls to LZ4F_compress(); skip copying src content within tmp buffer */
+  unsigned reserved[3];
+} LZ4F_compressOptions_t;
+
+/*---   Resource Management   ---*/
+
+#define LZ4F_VERSION 100    /* This number can be used to check for an incompatible API breaking change */
+LZ4FLIB_API unsigned LZ4F_getVersion(void);
+
+/*! LZ4F_createCompressionContext() :
+ *  The first thing to do is to create a compressionContext object,
+ *  which will keep track of operation state during streaming compression.
+ *  This is achieved using LZ4F_createCompressionContext(), which takes as argument a version,
+ *  and a pointer to LZ4F_cctx*, to write the resulting pointer into.
+ *  @version provided MUST be LZ4F_VERSION. It is intended to track potential version mismatch, notably when using DLL.
+ *  The function provides a pointer to a fully allocated LZ4F_cctx object.
+ *  @cctxPtr MUST be != NULL.
+ *  If @return != zero, context creation failed.
+ *  A created compression context can be employed multiple times for consecutive streaming operations.
+ *  Once all streaming compression jobs are completed,
+ *  the state object can be released using LZ4F_freeCompressionContext().
+ *  Note1 : LZ4F_freeCompressionContext() is always successful. Its return value can be ignored.
+ *  Note2 : LZ4F_freeCompressionContext() works fine with NULL input pointers (do nothing).
+**/
+LZ4FLIB_API LZ4F_errorCode_t LZ4F_createCompressionContext(LZ4F_cctx** cctxPtr, unsigned version);
+LZ4FLIB_API LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctx);
+
+
+/*----    Compression    ----*/
+
+#define LZ4F_HEADER_SIZE_MIN  7   /* LZ4 Frame header size can vary, depending on selected parameters */
+#define LZ4F_HEADER_SIZE_MAX 19
+
+/* Size in bytes of a block header in little-endian format. Highest bit indicates if block data is uncompressed */
+#define LZ4F_BLOCK_HEADER_SIZE 4
+
+/* Size in bytes of a block checksum footer in little-endian format. */
+#define LZ4F_BLOCK_CHECKSUM_SIZE 4
+
+/* Size in bytes of the content checksum. */
+#define LZ4F_CONTENT_CHECKSUM_SIZE 4
+
+/*! LZ4F_compressBegin() :
+ *  will write the frame header into dstBuffer.
+ *  dstCapacity must be >= LZ4F_HEADER_SIZE_MAX bytes.
+ * `prefsPtr` is optional : NULL can be provided to set all preferences to default.
+ * @return : number of bytes written into dstBuffer for the header
+ *           or an error code (which can be tested using LZ4F_isError())
+ */
+LZ4FLIB_API size_t LZ4F_compressBegin(LZ4F_cctx* cctx,
+                                      void* dstBuffer, size_t dstCapacity,
+                                      const LZ4F_preferences_t* prefsPtr);
+
+/*! LZ4F_compressBound() :
+ *  Provides minimum dstCapacity required to guarantee success of
+ *  LZ4F_compressUpdate(), given a srcSize and preferences, for a worst case scenario.
+ *  When srcSize==0, LZ4F_compressBound() provides an upper bound for LZ4F_flush() and LZ4F_compressEnd() instead.
+ *  Note that the result is only valid for a single invocation of LZ4F_compressUpdate().
+ *  When invoking LZ4F_compressUpdate() multiple times,
+ *  if the output buffer is gradually filled up instead of emptied and re-used from its start,
+ *  one must check if there is enough remaining capacity before each invocation, using LZ4F_compressBound().
+ * @return is always the same for a srcSize and prefsPtr.
+ *  prefsPtr is optional : when NULL is provided, preferences will be set to cover worst case scenario.
+ *  tech details :
+ * @return if automatic flushing is not enabled, includes the possibility that internal buffer might already be filled by up to (blockSize-1) bytes.
+ *  It also includes frame footer (ending + checksum), since it might be generated by LZ4F_compressEnd().
+ * @return doesn't include frame header, as it was already generated by LZ4F_compressBegin().
+ */
+LZ4FLIB_API size_t LZ4F_compressBound(size_t srcSize, const LZ4F_preferences_t* prefsPtr);
+
+/*! LZ4F_compressUpdate() :
+ *  LZ4F_compressUpdate() can be called repetitively to compress as much data as necessary.
+ *  Important rule: dstCapacity MUST be large enough to ensure operation success even in worst case situations.
+ *  This value is provided by LZ4F_compressBound().
+ *  If this condition is not respected, LZ4F_compress() will fail (result is an errorCode).
+ *  After an error, the state is left in a UB state, and must be re-initialized or freed.
+ *  If previously an uncompressed block was written, buffered data is flushed
+ *  before appending compressed data is continued.
+ * `cOptPtr` is optional : NULL can be provided, in which case all options are set to default.
+ * @return : number of bytes written into `dstBuffer` (it can be zero, meaning input data was just buffered).
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ */
+LZ4FLIB_API size_t LZ4F_compressUpdate(LZ4F_cctx* cctx,
+                                       void* dstBuffer, size_t dstCapacity,
+                                 const void* srcBuffer, size_t srcSize,
+                                 const LZ4F_compressOptions_t* cOptPtr);
+
+/*! LZ4F_flush() :
+ *  When data must be generated and sent immediately, without waiting for a block to be completely filled,
+ *  it's possible to call LZ4_flush(). It will immediately compress any data buffered within cctx.
+ * `dstCapacity` must be large enough to ensure the operation will be successful.
+ * `cOptPtr` is optional : it's possible to provide NULL, all options will be set to default.
+ * @return : nb of bytes written into dstBuffer (can be zero, when there is no data stored within cctx)
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ *  Note : LZ4F_flush() is guaranteed to be successful when dstCapacity >= LZ4F_compressBound(0, prefsPtr).
+ */
+LZ4FLIB_API size_t LZ4F_flush(LZ4F_cctx* cctx,
+                              void* dstBuffer, size_t dstCapacity,
+                        const LZ4F_compressOptions_t* cOptPtr);
+
+/*! LZ4F_compressEnd() :
+ *  To properly finish an LZ4 frame, invoke LZ4F_compressEnd().
+ *  It will flush whatever data remained within `cctx` (like LZ4_flush())
+ *  and properly finalize the frame, with an endMark and a checksum.
+ * `cOptPtr` is optional : NULL can be provided, in which case all options will be set to default.
+ * @return : nb of bytes written into dstBuffer, necessarily >= 4 (endMark),
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ *  Note : LZ4F_compressEnd() is guaranteed to be successful when dstCapacity >= LZ4F_compressBound(0, prefsPtr).
+ *  A successful call to LZ4F_compressEnd() makes `cctx` available again for another compression task.
+ */
+LZ4FLIB_API size_t LZ4F_compressEnd(LZ4F_cctx* cctx,
+                                    void* dstBuffer, size_t dstCapacity,
+                              const LZ4F_compressOptions_t* cOptPtr);
+
+
+/*-*********************************
+*  Decompression functions
+***********************************/
+typedef struct LZ4F_dctx_s LZ4F_dctx;   /* incomplete type */
+typedef LZ4F_dctx* LZ4F_decompressionContext_t;   /* compatibility with previous API versions */
+
+typedef struct {
+  unsigned stableDst;     /* pledges that last 64KB decompressed data is present right before @dstBuffer pointer.
+                           * This optimization skips internal storage operations.
+                           * Once set, this pledge must remain valid up to the end of current frame. */
+  unsigned skipChecksums; /* disable checksum calculation and verification, even when one is present in frame, to save CPU time.
+                           * Setting this option to 1 once disables all checksums for the rest of the frame. */
+  unsigned reserved1;     /* must be set to zero for forward compatibility */
+  unsigned reserved0;     /* idem */
+} LZ4F_decompressOptions_t;
+
+
+/* Resource management */
+
+/*! LZ4F_createDecompressionContext() :
+ *  Create an LZ4F_dctx object, to track all decompression operations.
+ *  @version provided MUST be LZ4F_VERSION.
+ *  @dctxPtr MUST be valid.
+ *  The function fills @dctxPtr with the value of a pointer to an allocated and initialized LZ4F_dctx object.
+ *  The @return is an errorCode, which can be tested using LZ4F_isError().
+ *  dctx memory can be released using LZ4F_freeDecompressionContext();
+ *  Result of LZ4F_freeDecompressionContext() indicates current state of decompressionContext when being released.
+ *  That is, it should be == 0 if decompression has been completed fully and correctly.
+ */
+LZ4FLIB_API LZ4F_errorCode_t LZ4F_createDecompressionContext(LZ4F_dctx** dctxPtr, unsigned version);
+LZ4FLIB_API LZ4F_errorCode_t LZ4F_freeDecompressionContext(LZ4F_dctx* dctx);
+
+
+/*-***********************************
+*  Streaming decompression functions
+*************************************/
+
+#define LZ4F_MAGICNUMBER 0x184D2204U
+#define LZ4F_MAGIC_SKIPPABLE_START 0x184D2A50U
+#define LZ4F_MIN_SIZE_TO_KNOW_HEADER_LENGTH 5
+
+/*! LZ4F_headerSize() : v1.9.0+
+ *  Provide the header size of a frame starting at `src`.
+ * `srcSize` must be >= LZ4F_MIN_SIZE_TO_KNOW_HEADER_LENGTH,
+ *  which is enough to decode the header length.
+ * @return : size of frame header
+ *           or an error code, which can be tested using LZ4F_isError()
+ *  note : Frame header size is variable, but is guaranteed to be
+ *         >= LZ4F_HEADER_SIZE_MIN bytes, and <= LZ4F_HEADER_SIZE_MAX bytes.
+ */
+LZ4FLIB_API size_t LZ4F_headerSize(const void* src, size_t srcSize);
+
+/*! LZ4F_getFrameInfo() :
+ *  This function extracts frame parameters (max blockSize, dictID, etc.).
+ *  Its usage is optional: user can also invoke LZ4F_decompress() directly.
+ *
+ *  Extracted information will fill an existing LZ4F_frameInfo_t structure.
+ *  This can be useful for allocation and dictionary identification purposes.
+ *
+ *  LZ4F_getFrameInfo() can work in the following situations :
+ *
+ *  1) At the beginning of a new frame, before any invocation of LZ4F_decompress().
+ *     It will decode header from `srcBuffer`,
+ *     consuming the header and starting the decoding process.
+ *
+ *     Input size must be large enough to contain the full frame header.
+ *     Frame header size can be known beforehand by LZ4F_headerSize().
+ *     Frame header size is variable, but is guaranteed to be >= LZ4F_HEADER_SIZE_MIN bytes,
+ *     and not more than <= LZ4F_HEADER_SIZE_MAX bytes.
+ *     Hence, blindly providing LZ4F_HEADER_SIZE_MAX bytes or more will always work.
+ *     It's allowed to provide more input data than the header size,
+ *     LZ4F_getFrameInfo() will only consume the header.
+ *
+ *     If input size is not large enough,
+ *     aka if it's smaller than header size,
+ *     function will fail and return an error code.
+ *
+ *  2) After decoding has been started,
+ *     it's possible to invoke LZ4F_getFrameInfo() anytime
+ *     to extract already decoded frame parameters stored within dctx.
+ *
+ *     Note that, if decoding has barely started,
+ *     and not yet read enough information to decode the header,
+ *     LZ4F_getFrameInfo() will fail.
+ *
+ *  The number of bytes consumed from srcBuffer will be updated in *srcSizePtr (necessarily <= original value).
+ *  LZ4F_getFrameInfo() only consumes bytes when decoding has not yet started,
+ *  and when decoding the header has been successful.
+ *  Decompression must then resume from (srcBuffer + *srcSizePtr).
+ *
+ * @return : a hint about how many srcSize bytes LZ4F_decompress() expects for next call,
+ *           or an error code which can be tested using LZ4F_isError().
+ *  note 1 : in case of error, dctx is not modified. Decoding operation can resume from beginning safely.
+ *  note 2 : frame parameters are *copied into* an already allocated LZ4F_frameInfo_t structure.
+ */
+LZ4FLIB_API size_t
+LZ4F_getFrameInfo(LZ4F_dctx* dctx,
+                  LZ4F_frameInfo_t* frameInfoPtr,
+            const void* srcBuffer, size_t* srcSizePtr);
+
+/*! LZ4F_decompress() :
+ *  Call this function repetitively to regenerate data compressed in `srcBuffer`.
+ *
+ *  The function requires a valid dctx state.
+ *  It will read up to *srcSizePtr bytes from srcBuffer,
+ *  and decompress data into dstBuffer, of capacity *dstSizePtr.
+ *
+ *  The nb of bytes consumed from srcBuffer will be written into *srcSizePtr (necessarily <= original value).
+ *  The nb of bytes decompressed into dstBuffer will be written into *dstSizePtr (necessarily <= original value).
+ *
+ *  The function does not necessarily read all input bytes, so always check value in *srcSizePtr.
+ *  Unconsumed source data must be presented again in subsequent invocations.
+ *
+ * `dstBuffer` can freely change between each consecutive function invocation.
+ * `dstBuffer` content will be overwritten.
+ *
+ *  Note: if `LZ4F_getFrameInfo()` is called before `LZ4F_decompress()`, srcBuffer must be updated to reflect
+ *  the number of bytes consumed after reading the frame header. Failure to update srcBuffer before calling
+ *  `LZ4F_decompress()` will cause decompression failure or, even worse, successful but incorrect decompression.
+ *  See the `LZ4F_getFrameInfo()` docs for details.
+ *
+ * @return : an hint of how many `srcSize` bytes LZ4F_decompress() expects for next call.
+ *  Schematically, it's the size of the current (or remaining) compressed block + header of next block.
+ *  Respecting the hint provides some small speed benefit, because it skips intermediate buffers.
+ *  This is just a hint though, it's always possible to provide any srcSize.
+ *
+ *  When a frame is fully decoded, @return will be 0 (no more data expected).
+ *  When provided with more bytes than necessary to decode a frame,
+ *  LZ4F_decompress() will stop reading exactly at end of current frame, and @return 0.
+ *
+ *  If decompression failed, @return is an error code, which can be tested using LZ4F_isError().
+ *  After a decompression error, the `dctx` context is not resumable.
+ *  Use LZ4F_resetDecompressionContext() to return to clean state.
+ *
+ *  After a frame is fully decoded, dctx can be used again to decompress another frame.
+ */
+LZ4FLIB_API size_t
+LZ4F_decompress(LZ4F_dctx* dctx,
+                void* dstBuffer, size_t* dstSizePtr,
+          const void* srcBuffer, size_t* srcSizePtr,
+          const LZ4F_decompressOptions_t* dOptPtr);
+
+
+/*! LZ4F_resetDecompressionContext() : added in v1.8.0
+ *  In case of an error, the context is left in "undefined" state.
+ *  In which case, it's necessary to reset it, before re-using it.
+ *  This method can also be used to abruptly stop any unfinished decompression,
+ *  and start a new one using same context resources. */
+LZ4FLIB_API void LZ4F_resetDecompressionContext(LZ4F_dctx* dctx);   /* always successful */
+
+
+/**********************************
+ *  Dictionary compression API
+ *********************************/
+
+/* A Dictionary is useful for the compression of small messages (KB range).
+ * It dramatically improves compression efficiency.
+ *
+ * LZ4 can ingest any input as dictionary, though only the last 64 KB are useful.
+ * Better results are generally achieved by using Zstandard's Dictionary Builder
+ * to generate a high-quality dictionary from a set of samples.
+ *
+ * The same dictionary will have to be used on the decompression side
+ * for decoding to be successful.
+ * To help identify the correct dictionary at decoding stage,
+ * the frame header allows optional embedding of a dictID field.
+ */
+
+/*! LZ4F_compressBegin_usingDict() : stable since v1.10
+ *  Inits dictionary compression streaming, and writes the frame header into dstBuffer.
+ * @dstCapacity must be >= LZ4F_HEADER_SIZE_MAX bytes.
+ * @prefsPtr is optional : one may provide NULL as argument,
+ *  however, it's the only way to provide dictID in the frame header.
+ * @dictBuffer must outlive the compression session.
+ * @return : number of bytes written into dstBuffer for the header,
+ *           or an error code (which can be tested using LZ4F_isError())
+ *  NOTE: The LZ4Frame spec allows each independent block to be compressed with the dictionary,
+ *        but this entry supports a more limited scenario, where only the first block uses the dictionary.
+ *        This is still useful for small data, which only need one block anyway.
+ *        For larger inputs, one may be more interested in LZ4F_compressFrame_usingCDict() below.
+ */
+LZ4FLIB_API size_t
+LZ4F_compressBegin_usingDict(LZ4F_cctx* cctx,
+                            void* dstBuffer, size_t dstCapacity,
+                      const void* dictBuffer, size_t dictSize,
+                      const LZ4F_preferences_t* prefsPtr);
+
+/*! LZ4F_decompress_usingDict() : stable since v1.10
+ *  Same as LZ4F_decompress(), using a predefined dictionary.
+ *  Dictionary is used "in place", without any preprocessing.
+**  It must remain accessible throughout the entire frame decoding. */
+LZ4FLIB_API size_t
+LZ4F_decompress_usingDict(LZ4F_dctx* dctxPtr,
+                          void* dstBuffer, size_t* dstSizePtr,
+                    const void* srcBuffer, size_t* srcSizePtr,
+                    const void* dict, size_t dictSize,
+                    const LZ4F_decompressOptions_t* decompressOptionsPtr);
+
+/*****************************************
+ *  Bulk processing dictionary compression
+ *****************************************/
+
+/* Loading a dictionary has a cost, since it involves construction of tables.
+ * The Bulk processing dictionary API makes it possible to share this cost
+ * over an arbitrary number of compression jobs, even concurrently,
+ * markedly improving compression latency for these cases.
+ *
+ * Note that there is no corresponding bulk API for the decompression side,
+ * because dictionary does not carry any initialization cost for decompression.
+ * Use the regular LZ4F_decompress_usingDict() there.
+ */
+typedef struct LZ4F_CDict_s LZ4F_CDict;
+
+/*! LZ4_createCDict() : stable since v1.10
+ *  When compressing multiple messages / blocks using the same dictionary, it's recommended to initialize it just once.
+ *  LZ4_createCDict() will create a digested dictionary, ready to start future compression operations without startup delay.
+ *  LZ4_CDict can be created once and shared by multiple threads concurrently, since its usage is read-only.
+ * @dictBuffer can be released after LZ4_CDict creation, since its content is copied within CDict. */
+LZ4FLIB_API LZ4F_CDict* LZ4F_createCDict(const void* dictBuffer, size_t dictSize);
+LZ4FLIB_API void        LZ4F_freeCDict(LZ4F_CDict* CDict);
+
+/*! LZ4_compressFrame_usingCDict() : stable since v1.10
+ *  Compress an entire srcBuffer into a valid LZ4 frame using a digested Dictionary.
+ * @cctx must point to a context created by LZ4F_createCompressionContext().
+ *  If @cdict==NULL, compress without a dictionary.
+ * @dstBuffer MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr).
+ *  If this condition is not respected, function will fail (@return an errorCode).
+ *  The LZ4F_preferences_t structure is optional : one may provide NULL as argument,
+ *  but it's not recommended, as it's the only way to provide @dictID in the frame header.
+ * @return : number of bytes written into dstBuffer.
+ *           or an error code if it fails (can be tested using LZ4F_isError())
+ *  Note: for larger inputs generating multiple independent blocks,
+ *        this entry point uses the dictionary for each block. */
+LZ4FLIB_API size_t
+LZ4F_compressFrame_usingCDict(LZ4F_cctx* cctx,
+                              void* dst, size_t dstCapacity,
+                        const void* src, size_t srcSize,
+                        const LZ4F_CDict* cdict,
+                        const LZ4F_preferences_t* preferencesPtr);
+
+/*! LZ4F_compressBegin_usingCDict() : stable since v1.10
+ *  Inits streaming dictionary compression, and writes the frame header into dstBuffer.
+ * @dstCapacity must be >= LZ4F_HEADER_SIZE_MAX bytes.
+ * @prefsPtr is optional : one may provide NULL as argument,
+ *  note however that it's the only way to insert a @dictID in the frame header.
+ * @cdict must outlive the compression session.
+ * @return : number of bytes written into dstBuffer for the header,
+ *           or an error code, which can be tested using LZ4F_isError(). */
+LZ4FLIB_API size_t
+LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctx,
+                              void* dstBuffer, size_t dstCapacity,
+                        const LZ4F_CDict* cdict,
+                        const LZ4F_preferences_t* prefsPtr);
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif  /* LZ4F_H_09782039843 */
+
+#if defined(LZ4F_STATIC_LINKING_ONLY) && !defined(LZ4F_H_STATIC_09782039843)
+#define LZ4F_H_STATIC_09782039843
+
+/* Note :
+ * The below declarations are not stable and may change in the future.
+ * They are therefore only safe to depend on
+ * when the caller is statically linked against the library.
+ * To access their declarations, define LZ4F_STATIC_LINKING_ONLY.
+ *
+ * By default, these symbols aren't published into shared/dynamic libraries.
+ * You can override this behavior and force them to be published
+ * by defining LZ4F_PUBLISH_STATIC_FUNCTIONS.
+ * Use at your own risk.
+ */
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#ifdef LZ4F_PUBLISH_STATIC_FUNCTIONS
+# define LZ4FLIB_STATIC_API LZ4FLIB_API
+#else
+# define LZ4FLIB_STATIC_API
+#endif
+
+
+/* ---   Error List   --- */
+#define LZ4F_LIST_ERRORS(ITEM) \
+        ITEM(OK_NoError) \
+        ITEM(ERROR_GENERIC) \
+        ITEM(ERROR_maxBlockSize_invalid) \
+        ITEM(ERROR_blockMode_invalid) \
+        ITEM(ERROR_parameter_invalid) \
+        ITEM(ERROR_compressionLevel_invalid) \
+        ITEM(ERROR_headerVersion_wrong) \
+        ITEM(ERROR_blockChecksum_invalid) \
+        ITEM(ERROR_reservedFlag_set) \
+        ITEM(ERROR_allocation_failed) \
+        ITEM(ERROR_srcSize_tooLarge) \
+        ITEM(ERROR_dstMaxSize_tooSmall) \
+        ITEM(ERROR_frameHeader_incomplete) \
+        ITEM(ERROR_frameType_unknown) \
+        ITEM(ERROR_frameSize_wrong) \
+        ITEM(ERROR_srcPtr_wrong) \
+        ITEM(ERROR_decompressionFailed) \
+        ITEM(ERROR_headerChecksum_invalid) \
+        ITEM(ERROR_contentChecksum_invalid) \
+        ITEM(ERROR_frameDecoding_alreadyStarted) \
+        ITEM(ERROR_compressionState_uninitialized) \
+        ITEM(ERROR_parameter_null) \
+        ITEM(ERROR_io_write) \
+        ITEM(ERROR_io_read) \
+        ITEM(ERROR_maxCode)
+
+#define LZ4F_GENERATE_ENUM(ENUM) LZ4F_##ENUM,
+
+/* enum list is exposed, to handle specific errors */
+typedef enum { LZ4F_LIST_ERRORS(LZ4F_GENERATE_ENUM)
+              _LZ4F_dummy_error_enum_for_c89_never_used } LZ4F_errorCodes;
+
+LZ4FLIB_STATIC_API LZ4F_errorCodes LZ4F_getErrorCode(size_t functionResult);
+
+/**********************************
+ *  Advanced compression operations
+ *********************************/
+
+/*! LZ4F_getBlockSize() :
+ * @return, in scalar format (size_t),
+ *          the maximum block size associated with @blockSizeID,
+ *          or an error code (can be tested using LZ4F_isError()) if @blockSizeID is invalid.
+**/
+LZ4FLIB_STATIC_API size_t LZ4F_getBlockSize(LZ4F_blockSizeID_t blockSizeID);
+
+/*! LZ4F_uncompressedUpdate() :
+ *  LZ4F_uncompressedUpdate() can be called repetitively to add data stored as uncompressed blocks.
+ *  Important rule: dstCapacity MUST be large enough to store the entire source buffer as
+ *  no compression is done for this operation
+ *  If this condition is not respected, LZ4F_uncompressedUpdate() will fail (result is an errorCode).
+ *  After an error, the state is left in a UB state, and must be re-initialized or freed.
+ *  If previously a compressed block was written, buffered data is flushed first,
+ *  before appending uncompressed data is continued.
+ *  This operation is only supported when LZ4F_blockIndependent is used.
+ * `cOptPtr` is optional : NULL can be provided, in which case all options are set to default.
+ * @return : number of bytes written into `dstBuffer` (it can be zero, meaning input data was just buffered).
+ *           or an error code if it fails (which can be tested using LZ4F_isError())
+ */
+LZ4FLIB_STATIC_API size_t
+LZ4F_uncompressedUpdate(LZ4F_cctx* cctx,
+                        void* dstBuffer, size_t dstCapacity,
+                  const void* srcBuffer, size_t srcSize,
+                  const LZ4F_compressOptions_t* cOptPtr);
+
+/**********************************
+ *  Custom memory allocation
+ *********************************/
+
+/*! Custom memory allocation : v1.9.4+
+ *  These prototypes make it possible to pass custom allocation/free functions.
+ *  LZ4F_customMem is provided at state creation time, using LZ4F_create*_advanced() listed below.
+ *  All allocation/free operations will be completed using these custom variants instead of regular <stdlib.h> ones.
+ */
+typedef void* (*LZ4F_AllocFunction) (void* opaqueState, size_t size);
+typedef void* (*LZ4F_CallocFunction) (void* opaqueState, size_t size);
+typedef void  (*LZ4F_FreeFunction) (void* opaqueState, void* address);
+typedef struct {
+    LZ4F_AllocFunction customAlloc;
+    LZ4F_CallocFunction customCalloc; /* optional; when not defined, uses customAlloc + memset */
+    LZ4F_FreeFunction customFree;
+    void* opaqueState;
+} LZ4F_CustomMem;
+static
+#ifdef __GNUC__
+__attribute__((__unused__))
+#endif
+LZ4F_CustomMem const LZ4F_defaultCMem = { NULL, NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
+
+LZ4FLIB_STATIC_API LZ4F_cctx* LZ4F_createCompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version);
+LZ4FLIB_STATIC_API LZ4F_dctx* LZ4F_createDecompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version);
+LZ4FLIB_STATIC_API LZ4F_CDict* LZ4F_createCDict_advanced(LZ4F_CustomMem customMem, const void* dictBuffer, size_t dictSize);
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif  /* defined(LZ4F_STATIC_LINKING_ONLY) && !defined(LZ4F_H_STATIC_09782039843) */

--- a/deps/lz4/lz4hc.c
+++ b/deps/lz4/lz4hc.c
@@ -1,0 +1,2192 @@
+/*
+    LZ4 HC - High Compression Mode of LZ4
+    Copyright (C) 2011-2020, Yann Collet.
+
+    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+    * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    You can contact the author at :
+       - LZ4 source repository : https://github.com/lz4/lz4
+       - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+/* note : lz4hc is not an independent module, it requires lz4.h/lz4.c for proper compilation */
+
+
+/* *************************************
+*  Tuning Parameter
+***************************************/
+
+/*! HEAPMODE :
+ *  Select how stateless HC compression functions like `LZ4_compress_HC()`
+ *  allocate memory for their workspace:
+ *  in stack (0:fastest), or in heap (1:default, requires malloc()).
+ *  Since workspace is rather large, heap mode is recommended.
+**/
+#ifndef LZ4HC_HEAPMODE
+#  define LZ4HC_HEAPMODE 1
+#endif
+
+
+/*===    Dependency    ===*/
+#define LZ4_HC_STATIC_LINKING_ONLY
+#include "lz4hc.h"
+#include <limits.h>
+
+
+/*===   Shared lz4.c code   ===*/
+#ifndef LZ4_SRC_INCLUDED
+# if defined(__GNUC__)
+#  pragma GCC diagnostic ignored "-Wunused-function"
+# endif
+# if defined (__clang__)
+#  pragma clang diagnostic ignored "-Wunused-function"
+# endif
+# define LZ4_COMMONDEFS_ONLY
+# include "lz4.c"   /* LZ4_count, constants, mem */
+#endif
+
+
+/*===   Enums   ===*/
+typedef enum { noDictCtx, usingDictCtxHc } dictCtx_directive;
+
+
+/*===   Constants   ===*/
+#define OPTIMAL_ML (int)((ML_MASK-1)+MINMATCH)
+#define LZ4_OPT_NUM   (1<<12)
+
+
+/*===   Macros   ===*/
+#define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+#define MAX(a,b)   ( (a) > (b) ? (a) : (b) )
+
+
+/*===   Levels definition   ===*/
+typedef enum { lz4mid, lz4hc, lz4opt } lz4hc_strat_e;
+typedef struct {
+    lz4hc_strat_e strat;
+    int nbSearches;
+    U32 targetLength;
+} cParams_t;
+static const cParams_t k_clTable[LZ4HC_CLEVEL_MAX+1] = {
+    { lz4mid,    2, 16 },  /* 0, unused */
+    { lz4mid,    2, 16 },  /* 1, unused */
+    { lz4mid,    2, 16 },  /* 2 */
+    { lz4hc,     4, 16 },  /* 3 */
+    { lz4hc,     8, 16 },  /* 4 */
+    { lz4hc,    16, 16 },  /* 5 */
+    { lz4hc,    32, 16 },  /* 6 */
+    { lz4hc,    64, 16 },  /* 7 */
+    { lz4hc,   128, 16 },  /* 8 */
+    { lz4hc,   256, 16 },  /* 9 */
+    { lz4opt,   96, 64 },  /*10==LZ4HC_CLEVEL_OPT_MIN*/
+    { lz4opt,  512,128 },  /*11 */
+    { lz4opt,16384,LZ4_OPT_NUM },  /* 12==LZ4HC_CLEVEL_MAX */
+};
+
+static cParams_t LZ4HC_getCLevelParams(int cLevel)
+{
+    /* note : clevel convention is a bit different from lz4frame,
+     * possibly something worth revisiting for consistency */
+    if (cLevel < 1)
+        cLevel = LZ4HC_CLEVEL_DEFAULT;
+    cLevel = MIN(LZ4HC_CLEVEL_MAX, cLevel);
+    return k_clTable[cLevel];
+}
+
+
+/*===   Hashing   ===*/
+#define LZ4HC_HASHSIZE 4
+#define HASH_FUNCTION(i)      (((i) * 2654435761U) >> ((MINMATCH*8)-LZ4HC_HASH_LOG))
+static U32 LZ4HC_hashPtr(const void* ptr) { return HASH_FUNCTION(LZ4_read32(ptr)); }
+
+#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
+/* lie to the compiler about data alignment; use with caution */
+static U64 LZ4_read64(const void* memPtr) { return *(const U64*) memPtr; }
+
+#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
+/* __pack instructions are safer, but compiler specific */
+LZ4_PACK(typedef struct { U64 u64; }) LZ4_unalign64;
+static U64 LZ4_read64(const void* ptr) { return ((const LZ4_unalign64*)ptr)->u64; }
+
+#else  /* safe and portable access using memcpy() */
+static U64 LZ4_read64(const void* memPtr)
+{
+    U64 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+#endif /* LZ4_FORCE_MEMORY_ACCESS */
+
+#define LZ4MID_HASHSIZE 8
+#define LZ4MID_HASHLOG (LZ4HC_HASH_LOG-1)
+#define LZ4MID_HASHTABLESIZE (1 << LZ4MID_HASHLOG)
+
+static U32 LZ4MID_hash4(U32 v) { return (v * 2654435761U) >> (32-LZ4MID_HASHLOG); }
+static U32 LZ4MID_hash4Ptr(const void* ptr) { return LZ4MID_hash4(LZ4_read32(ptr)); }
+/* note: hash7 hashes the lower 56-bits.
+ * It presumes input was read using little endian.*/
+static U32 LZ4MID_hash7(U64 v) { return (U32)(((v  << (64-56)) * 58295818150454627ULL) >> (64-LZ4MID_HASHLOG)) ; }
+static U64 LZ4_readLE64(const void* memPtr);
+static U32 LZ4MID_hash8Ptr(const void* ptr) { return LZ4MID_hash7(LZ4_readLE64(ptr)); }
+
+static U64 LZ4_readLE64(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read64(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        /* note: relies on the compiler to simplify this expression */
+        return (U64)p[0] | ((U64)p[1]<<8) | ((U64)p[2]<<16) | ((U64)p[3]<<24)
+            | ((U64)p[4]<<32) | ((U64)p[5]<<40) | ((U64)p[6]<<48) | ((U64)p[7]<<56);
+    }
+}
+
+
+/*===   Count match length   ===*/
+LZ4_FORCE_INLINE
+unsigned LZ4HC_NbCommonBytes32(U32 val)
+{
+    assert(val != 0);
+    if (LZ4_isLittleEndian()) {
+#     if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+        unsigned long r;
+        _BitScanReverse(&r, val);
+        return (unsigned)((31 - r) >> 3);
+#     elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+        return (unsigned)__builtin_clz(val) >> 3;
+#     else
+        val >>= 8;
+        val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) |
+              (val + 0x00FF0000)) >> 24;
+        return (unsigned)val ^ 3;
+#     endif
+    } else {
+#     if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+        unsigned long r;
+        _BitScanForward(&r, val);
+        return (unsigned)(r >> 3);
+#     elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+        return (unsigned)__builtin_ctz(val) >> 3;
+#     else
+        const U32 m = 0x01010101;
+        return (unsigned)((((val - 1) ^ val) & (m - 1)) * m) >> 24;
+#     endif
+    }
+}
+
+/** LZ4HC_countBack() :
+ * @return : negative value, nb of common bytes before ip/match */
+LZ4_FORCE_INLINE
+int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match,
+                    const BYTE* const iMin, const BYTE* const mMin)
+{
+    int back = 0;
+    int const min = (int)MAX(iMin - ip, mMin - match);
+    assert(min <= 0);
+    assert(ip >= iMin); assert((size_t)(ip-iMin) < (1U<<31));
+    assert(match >= mMin); assert((size_t)(match - mMin) < (1U<<31));
+
+    while ((back - min) > 3) {
+        U32 const v = LZ4_read32(ip + back - 4) ^ LZ4_read32(match + back - 4);
+        if (v) {
+            return (back - (int)LZ4HC_NbCommonBytes32(v));
+        } else back -= 4; /* 4-byte step */
+    }
+    /* check remainder if any */
+    while ( (back > min)
+         && (ip[back-1] == match[back-1]) )
+            back--;
+    return back;
+}
+
+/*===   Chain table updates   ===*/
+#define DELTANEXTU16(table, pos) table[(U16)(pos)]   /* faster */
+/* Make fields passed to, and updated by LZ4HC_encodeSequence explicit */
+#define UPDATABLE(ip, op, anchor) &ip, &op, &anchor
+
+
+/**************************************
+*  Init
+**************************************/
+static void LZ4HC_clearTables (LZ4HC_CCtx_internal* hc4)
+{
+    MEM_INIT(hc4->hashTable, 0, sizeof(hc4->hashTable));
+    MEM_INIT(hc4->chainTable, 0xFF, sizeof(hc4->chainTable));
+}
+
+static void LZ4HC_init_internal (LZ4HC_CCtx_internal* hc4, const BYTE* start)
+{
+    size_t const bufferSize = (size_t)(hc4->end - hc4->prefixStart);
+    size_t newStartingOffset = bufferSize + hc4->dictLimit;
+    DEBUGLOG(5, "LZ4HC_init_internal");
+    assert(newStartingOffset >= bufferSize);  /* check overflow */
+    if (newStartingOffset > 1 GB) {
+        LZ4HC_clearTables(hc4);
+        newStartingOffset = 0;
+    }
+    newStartingOffset += 64 KB;
+    hc4->nextToUpdate = (U32)newStartingOffset;
+    hc4->prefixStart = start;
+    hc4->end = start;
+    hc4->dictStart = start;
+    hc4->dictLimit = (U32)newStartingOffset;
+    hc4->lowLimit = (U32)newStartingOffset;
+}
+
+
+/**************************************
+*  Encode
+**************************************/
+/* LZ4HC_encodeSequence() :
+ * @return : 0 if ok,
+ *           1 if buffer issue detected */
+LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
+    const BYTE** _ip,
+    BYTE** _op,
+    const BYTE** _anchor,
+    int matchLength,
+    int offset,
+    limitedOutput_directive limit,
+    BYTE* oend)
+{
+#define ip      (*_ip)
+#define op      (*_op)
+#define anchor  (*_anchor)
+
+    size_t length;
+    BYTE* const token = op++;
+
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 6)
+    static const BYTE* start = NULL;
+    static U32 totalCost = 0;
+    U32 const pos = (start==NULL) ? 0 : (U32)(anchor - start);
+    U32 const ll = (U32)(ip - anchor);
+    U32 const llAdd = (ll>=15) ? ((ll-15) / 255) + 1 : 0;
+    U32 const mlAdd = (matchLength>=19) ? ((matchLength-19) / 255) + 1 : 0;
+    U32 const cost = 1 + llAdd + ll + 2 + mlAdd;
+    if (start==NULL) start = anchor;  /* only works for single segment */
+    /* g_debuglog_enable = (pos >= 2228) & (pos <= 2262); */
+    DEBUGLOG(6, "pos:%7u -- literals:%4u, match:%4i, offset:%5i, cost:%4u + %5u",
+                pos,
+                (U32)(ip - anchor), matchLength, offset,
+                cost, totalCost);
+    totalCost += cost;
+#endif
+
+    /* Encode Literal length */
+    length = (size_t)(ip - anchor);
+    LZ4_STATIC_ASSERT(notLimited == 0);
+    /* Check output limit */
+    if (limit && ((op + (length / 255) + length + (2 + 1 + LASTLITERALS)) > oend)) {
+        DEBUGLOG(6, "Not enough room to write %i literals (%i bytes remaining)",
+                (int)length, (int)(oend - op));
+        return 1;
+    }
+    if (length >= RUN_MASK) {
+        size_t len = length - RUN_MASK;
+        *token = (RUN_MASK << ML_BITS);
+        for(; len >= 255 ; len -= 255) *op++ = 255;
+        *op++ = (BYTE)len;
+    } else {
+        *token = (BYTE)(length << ML_BITS);
+    }
+
+    /* Copy Literals */
+    LZ4_wildCopy8(op, anchor, op + length);
+    op += length;
+
+    /* Encode Offset */
+    assert(offset <= LZ4_DISTANCE_MAX );
+    assert(offset > 0);
+    LZ4_writeLE16(op, (U16)(offset)); op += 2;
+
+    /* Encode MatchLength */
+    assert(matchLength >= MINMATCH);
+    length = (size_t)matchLength - MINMATCH;
+    if (limit && (op + (length / 255) + (1 + LASTLITERALS) > oend)) {
+        DEBUGLOG(6, "Not enough room to write match length");
+        return 1;   /* Check output limit */
+    }
+    if (length >= ML_MASK) {
+        *token += ML_MASK;
+        length -= ML_MASK;
+        for(; length >= 510 ; length -= 510) { *op++ = 255; *op++ = 255; }
+        if (length >= 255) { length -= 255; *op++ = 255; }
+        *op++ = (BYTE)length;
+    } else {
+        *token += (BYTE)(length);
+    }
+
+    /* Prepare next loop */
+    ip += matchLength;
+    anchor = ip;
+
+    return 0;
+
+#undef ip
+#undef op
+#undef anchor
+}
+
+
+typedef struct {
+    int off;
+    int len;
+    int back;  /* negative value */
+} LZ4HC_match_t;
+
+LZ4HC_match_t LZ4HC_searchExtDict(const BYTE* ip, U32 ipIndex,
+        const BYTE* const iLowLimit, const BYTE* const iHighLimit,
+        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex,
+        int currentBestML, int nbAttempts)
+{
+    size_t const lDictEndIndex = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
+    U32 lDictMatchIndex = dictCtx->hashTable[LZ4HC_hashPtr(ip)];
+    U32 matchIndex = lDictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
+    int offset = 0, sBack = 0;
+    assert(lDictEndIndex <= 1 GB);
+    if (lDictMatchIndex>0)
+        DEBUGLOG(7, "lDictEndIndex = %zu, lDictMatchIndex = %u", lDictEndIndex, lDictMatchIndex);
+    while (ipIndex - matchIndex <= LZ4_DISTANCE_MAX && nbAttempts--) {
+        const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + lDictMatchIndex;
+
+        if (LZ4_read32(matchPtr) == LZ4_read32(ip)) {
+            int mlt;
+            int back = 0;
+            const BYTE* vLimit = ip + (lDictEndIndex - lDictMatchIndex);
+            if (vLimit > iHighLimit) vLimit = iHighLimit;
+            mlt = (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, vLimit) + MINMATCH;
+            back = (ip > iLowLimit) ? LZ4HC_countBack(ip, matchPtr, iLowLimit, dictCtx->prefixStart) : 0;
+            mlt -= back;
+            if (mlt > currentBestML) {
+                currentBestML = mlt;
+                offset = (int)(ipIndex - matchIndex);
+                sBack = back;
+                DEBUGLOG(7, "found match of length %i within extDictCtx", currentBestML);
+        }   }
+
+        {   U32 const nextOffset = DELTANEXTU16(dictCtx->chainTable, lDictMatchIndex);
+            lDictMatchIndex -= nextOffset;
+            matchIndex -= nextOffset;
+    }   }
+
+    {   LZ4HC_match_t md;
+        md.len = currentBestML;
+        md.off = offset;
+        md.back = sBack;
+        return md;
+    }
+}
+
+typedef LZ4HC_match_t (*LZ4MID_searchIntoDict_f)(const BYTE* ip, U32 ipIndex,
+        const BYTE* const iHighLimit,
+        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex);
+
+static LZ4HC_match_t LZ4MID_searchHCDict(const BYTE* ip, U32 ipIndex,
+        const BYTE* const iHighLimit,
+        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex)
+{
+    return LZ4HC_searchExtDict(ip,ipIndex,
+                            ip, iHighLimit,
+                            dictCtx, gDictEndIndex,
+                            MINMATCH-1, 2);
+}
+
+static LZ4HC_match_t LZ4MID_searchExtDict(const BYTE* ip, U32 ipIndex,
+        const BYTE* const iHighLimit,
+        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex)
+{
+    size_t const lDictEndIndex = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
+    const U32* const hash4Table = dictCtx->hashTable;
+    const U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
+    DEBUGLOG(7, "LZ4MID_searchExtDict (ipIdx=%u)", ipIndex);
+
+    /* search long match first */
+    {   U32 l8DictMatchIndex = hash8Table[LZ4MID_hash8Ptr(ip)];
+        U32 m8Index = l8DictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
+        assert(lDictEndIndex <= 1 GB);
+        if (ipIndex - m8Index <= LZ4_DISTANCE_MAX) {
+            const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + l8DictMatchIndex;
+            const size_t safeLen = MIN(lDictEndIndex - l8DictMatchIndex, (size_t)(iHighLimit - ip));
+            int mlt = (int)LZ4_count(ip, matchPtr, ip + safeLen);
+            if (mlt >= MINMATCH) {
+                LZ4HC_match_t md;
+                DEBUGLOG(7, "Found long ExtDict match of len=%u", mlt);
+                md.len = mlt;
+                md.off = (int)(ipIndex - m8Index);
+                md.back = 0;
+                return md;
+            }
+        }
+    }
+
+    /* search for short match second */
+    {   U32 l4DictMatchIndex = hash4Table[LZ4MID_hash4Ptr(ip)];
+        U32 m4Index = l4DictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
+        if (ipIndex - m4Index <= LZ4_DISTANCE_MAX) {
+            const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + l4DictMatchIndex;
+            const size_t safeLen = MIN(lDictEndIndex - l4DictMatchIndex, (size_t)(iHighLimit - ip));
+            int mlt = (int)LZ4_count(ip, matchPtr, ip + safeLen);
+            if (mlt >= MINMATCH) {
+                LZ4HC_match_t md;
+                DEBUGLOG(7, "Found short ExtDict match of len=%u", mlt);
+                md.len = mlt;
+                md.off = (int)(ipIndex - m4Index);
+                md.back = 0;
+                return md;
+            }
+        }
+    }
+
+    /* nothing found */
+    {   LZ4HC_match_t const md = {0, 0, 0 };
+        return md;
+    }
+}
+
+/**************************************
+*  Mid Compression (level 2)
+**************************************/
+
+LZ4_FORCE_INLINE void
+LZ4MID_addPosition(U32* hTable, U32 hValue, U32 index)
+{
+    hTable[hValue] = index;
+}
+
+#define ADDPOS8(_p, _idx) LZ4MID_addPosition(hash8Table, LZ4MID_hash8Ptr(_p), _idx)
+#define ADDPOS4(_p, _idx) LZ4MID_addPosition(hash4Table, LZ4MID_hash4Ptr(_p), _idx)
+
+/* Fill hash tables with references into dictionary.
+ * The resulting table is only exploitable by LZ4MID (level 2) */
+static void
+LZ4MID_fillHTable (LZ4HC_CCtx_internal* cctx, const void* dict, size_t size)
+{
+    U32* const hash4Table = cctx->hashTable;
+    U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
+    const BYTE* const prefixPtr = (const BYTE*)dict;
+    U32 const prefixIdx = cctx->dictLimit;
+    U32 const target = prefixIdx + (U32)size - LZ4MID_HASHSIZE;
+    U32 idx = cctx->nextToUpdate;
+    assert(dict == cctx->prefixStart);
+    DEBUGLOG(4, "LZ4MID_fillHTable (size:%zu)", size);
+    if (size <= LZ4MID_HASHSIZE)
+        return;
+
+    for (; idx < target; idx += 3) {
+        ADDPOS4(prefixPtr+idx-prefixIdx, idx);
+        ADDPOS8(prefixPtr+idx+1-prefixIdx, idx+1);
+    }
+
+    idx = (size > 32 KB + LZ4MID_HASHSIZE) ? target - 32 KB : cctx->nextToUpdate;
+    for (; idx < target; idx += 1) {
+        ADDPOS8(prefixPtr+idx-prefixIdx, idx);
+    }
+
+    cctx->nextToUpdate = target;
+}
+
+static LZ4MID_searchIntoDict_f select_searchDict_function(const LZ4HC_CCtx_internal* dictCtx)
+{
+    if (dictCtx == NULL) return NULL;
+    if (LZ4HC_getCLevelParams(dictCtx->compressionLevel).strat == lz4mid)
+        return LZ4MID_searchExtDict;
+    return LZ4MID_searchHCDict;
+}
+
+static int LZ4MID_compress (
+    LZ4HC_CCtx_internal* const ctx,
+    const char* const src,
+    char* const dst,
+    int* srcSizePtr,
+    int const maxOutputSize,
+    const limitedOutput_directive limit,
+    const dictCtx_directive dict
+    )
+{
+    U32* const hash4Table = ctx->hashTable;
+    U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
+    const BYTE* ip = (const BYTE*)src;
+    const BYTE* anchor = ip;
+    const BYTE* const iend = ip + *srcSizePtr;
+    const BYTE* const mflimit = iend - MFLIMIT;
+    const BYTE* const matchlimit = (iend - LASTLITERALS);
+    const BYTE* const ilimit = (iend - LZ4MID_HASHSIZE);
+    BYTE* op = (BYTE*)dst;
+    BYTE* oend = op + maxOutputSize;
+
+    const BYTE* const prefixPtr = ctx->prefixStart;
+    const U32 prefixIdx = ctx->dictLimit;
+    const U32 ilimitIdx = (U32)(ilimit - prefixPtr) + prefixIdx;
+    const BYTE* const dictStart = ctx->dictStart;
+    const U32 dictIdx = ctx->lowLimit;
+    const U32 gDictEndIndex = ctx->lowLimit;
+    const LZ4MID_searchIntoDict_f searchIntoDict = (dict == usingDictCtxHc) ? select_searchDict_function(ctx->dictCtx) : NULL;
+    unsigned matchLength;
+    unsigned matchDistance;
+
+    /* input sanitization */
+    DEBUGLOG(5, "LZ4MID_compress (%i bytes)", *srcSizePtr);
+    if (dict == usingDictCtxHc) DEBUGLOG(5, "usingDictCtxHc");
+    assert(*srcSizePtr >= 0);
+    if (*srcSizePtr) assert(src != NULL);
+    if (maxOutputSize) assert(dst != NULL);
+    if (*srcSizePtr < 0) return 0;  /* invalid */
+    if (maxOutputSize < 0) return 0; /* invalid */
+    if (*srcSizePtr > LZ4_MAX_INPUT_SIZE) {
+        /* forbidden: no input is allowed to be that large */
+        return 0;
+    }
+    if (limit == fillOutput) oend -= LASTLITERALS;  /* Hack for support LZ4 format restriction */
+    if (*srcSizePtr < LZ4_minLength)
+        goto _lz4mid_last_literals;  /* Input too small, no compression (all literals) */
+
+    /* main loop */
+    while (ip <= mflimit) {
+        const U32 ipIndex = (U32)(ip - prefixPtr) + prefixIdx;
+        /* search long match */
+        {   U32 const h8 = LZ4MID_hash8Ptr(ip);
+            U32 const pos8 = hash8Table[h8];
+            assert(h8 < LZ4MID_HASHTABLESIZE);
+            assert(pos8 < ipIndex);
+            LZ4MID_addPosition(hash8Table, h8, ipIndex);
+            if (ipIndex - pos8 <= LZ4_DISTANCE_MAX) {
+                /* match candidate found */
+                if (pos8 >= prefixIdx) {
+                    const BYTE* const matchPtr = prefixPtr + pos8 - prefixIdx;
+                    assert(matchPtr < ip);
+                    matchLength = LZ4_count(ip, matchPtr, matchlimit);
+                    if (matchLength >= MINMATCH) {
+                        DEBUGLOG(7, "found long match at pos %u (len=%u)", pos8, matchLength);
+                        matchDistance = ipIndex - pos8;
+                        goto _lz4mid_encode_sequence;
+                    }
+                } else {
+                    if (pos8 >= dictIdx) {
+                        /* extDict match candidate */
+                        const BYTE* const matchPtr = dictStart + (pos8 - dictIdx);
+                        const size_t safeLen = MIN(prefixIdx - pos8, (size_t)(matchlimit - ip));
+                        matchLength = LZ4_count(ip, matchPtr, ip + safeLen);
+                        if (matchLength >= MINMATCH) {
+                            DEBUGLOG(7, "found long match at ExtDict pos %u (len=%u)", pos8, matchLength);
+                            matchDistance = ipIndex - pos8;
+                            goto _lz4mid_encode_sequence;
+                        }
+                    }
+                }
+        }   }
+        /* search short match */
+        {   U32 const h4 = LZ4MID_hash4Ptr(ip);
+            U32 const pos4 = hash4Table[h4];
+            assert(h4 < LZ4MID_HASHTABLESIZE);
+            assert(pos4 < ipIndex);
+            LZ4MID_addPosition(hash4Table, h4, ipIndex);
+            if (ipIndex - pos4 <= LZ4_DISTANCE_MAX) {
+                /* match candidate found */
+                if (pos4 >= prefixIdx) {
+                /* only search within prefix */
+                    const BYTE* const matchPtr = prefixPtr + (pos4 - prefixIdx);
+                    assert(matchPtr < ip);
+                    assert(matchPtr >= prefixPtr);
+                    matchLength = LZ4_count(ip, matchPtr, matchlimit);
+                    if (matchLength >= MINMATCH) {
+                        /* short match found, let's just check ip+1 for longer */
+                        U32 const h8 = LZ4MID_hash8Ptr(ip+1);
+                        U32 const pos8 = hash8Table[h8];
+                        U32 const m2Distance = ipIndex + 1 - pos8;
+                        matchDistance = ipIndex - pos4;
+                        if ( m2Distance <= LZ4_DISTANCE_MAX
+                        && pos8 >= prefixIdx /* only search within prefix */
+                        && likely(ip < mflimit)
+                        ) {
+                            const BYTE* const m2Ptr = prefixPtr + (pos8 - prefixIdx);
+                            unsigned ml2 = LZ4_count(ip+1, m2Ptr, matchlimit);
+                            if (ml2 > matchLength) {
+                                LZ4MID_addPosition(hash8Table, h8, ipIndex+1);
+                                ip++;
+                                matchLength = ml2;
+                                matchDistance = m2Distance;
+                        }   }
+                        goto _lz4mid_encode_sequence;
+                    }
+                } else {
+                    if (pos4 >= dictIdx) {
+                        /* extDict match candidate */
+                        const BYTE* const matchPtr = dictStart + (pos4 - dictIdx);
+                        const size_t safeLen = MIN(prefixIdx - pos4, (size_t)(matchlimit - ip));
+                        matchLength = LZ4_count(ip, matchPtr, ip + safeLen);
+                        if (matchLength >= MINMATCH) {
+                            DEBUGLOG(7, "found match at ExtDict pos %u (len=%u)", pos4, matchLength);
+                            matchDistance = ipIndex - pos4;
+                            goto _lz4mid_encode_sequence;
+                        }
+                    }
+                }
+        }   }
+        /* no match found in prefix */
+        if ( (dict == usingDictCtxHc)
+          && (ipIndex - gDictEndIndex < LZ4_DISTANCE_MAX - 8) ) {
+            /* search a match into external dictionary */
+            LZ4HC_match_t dMatch = searchIntoDict(ip, ipIndex,
+                    matchlimit,
+                    ctx->dictCtx, gDictEndIndex);
+            if (dMatch.len >= MINMATCH) {
+                DEBUGLOG(7, "found Dictionary match (offset=%i)", dMatch.off);
+                assert(dMatch.back == 0);
+                matchLength = (unsigned)dMatch.len;
+                matchDistance = (unsigned)dMatch.off;
+                goto _lz4mid_encode_sequence;
+            }
+        }
+        /* no match found */
+        ip += 1 + ((ip-anchor) >> 9);  /* skip faster over incompressible data */
+        continue;
+
+_lz4mid_encode_sequence:
+        /* catch back */
+        while (((ip > anchor) & ((U32)(ip-prefixPtr) > matchDistance)) && (unlikely(ip[-1] == ip[-(int)matchDistance-1]))) {
+            ip--;  matchLength++;
+        };
+
+        /* fill table with beginning of match */
+        ADDPOS8(ip+1, ipIndex+1);
+        ADDPOS8(ip+2, ipIndex+2);
+        ADDPOS4(ip+1, ipIndex+1);
+
+        /* encode */
+        {   BYTE* const saved_op = op;
+            /* LZ4HC_encodeSequence always updates @op; on success, it updates @ip and @anchor */
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                    (int)matchLength, (int)matchDistance,
+                    limit, oend) ) {
+                op = saved_op;  /* restore @op value before failed LZ4HC_encodeSequence */
+                goto _lz4mid_dest_overflow;
+            }
+        }
+
+        /* fill table with end of match */
+        {   U32 endMatchIdx = (U32)(ip-prefixPtr) + prefixIdx;
+            U32 pos_m2 = endMatchIdx - 2;
+            if (pos_m2 < ilimitIdx) {
+                if (likely(ip - prefixPtr > 5)) {
+                    ADDPOS8(ip-5, endMatchIdx - 5);
+                }
+                ADDPOS8(ip-3, endMatchIdx - 3);
+                ADDPOS8(ip-2, endMatchIdx - 2);
+                ADDPOS4(ip-2, endMatchIdx - 2);
+                ADDPOS4(ip-1, endMatchIdx - 1);
+            }
+        }
+    }
+
+_lz4mid_last_literals:
+    /* Encode Last Literals */
+    {   size_t lastRunSize = (size_t)(iend - anchor);  /* literals */
+        size_t llAdd = (lastRunSize + 255 - RUN_MASK) / 255;
+        size_t const totalSize = 1 + llAdd + lastRunSize;
+        if (limit == fillOutput) oend += LASTLITERALS;  /* restore correct value */
+        if (limit && (op + totalSize > oend)) {
+            if (limit == limitedOutput) return 0;  /* not enough space in @dst */
+            /* adapt lastRunSize to fill 'dest' */
+            lastRunSize  = (size_t)(oend - op) - 1 /*token*/;
+            llAdd = (lastRunSize + 256 - RUN_MASK) / 256;
+            lastRunSize -= llAdd;
+        }
+        DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
+        ip = anchor + lastRunSize;  /* can be != iend if limit==fillOutput */
+
+        if (lastRunSize >= RUN_MASK) {
+            size_t accumulator = lastRunSize - RUN_MASK;
+            *op++ = (RUN_MASK << ML_BITS);
+            for(; accumulator >= 255 ; accumulator -= 255)
+                *op++ = 255;
+            *op++ = (BYTE) accumulator;
+        } else {
+            *op++ = (BYTE)(lastRunSize << ML_BITS);
+        }
+        assert(lastRunSize <= (size_t)(oend - op));
+        LZ4_memcpy(op, anchor, lastRunSize);
+        op += lastRunSize;
+    }
+
+    /* End */
+    DEBUGLOG(5, "compressed %i bytes into %i bytes", *srcSizePtr, (int)((char*)op - dst));
+    assert(ip >= (const BYTE*)src);
+    assert(ip <= iend);
+    *srcSizePtr = (int)(ip - (const BYTE*)src);
+    assert((char*)op >= dst);
+    assert(op <= oend);
+    assert((char*)op - dst < INT_MAX);
+    return (int)((char*)op - dst);
+
+_lz4mid_dest_overflow:
+    if (limit == fillOutput) {
+        /* Assumption : @ip, @anchor, @optr and @matchLength must be set correctly */
+        size_t const ll = (size_t)(ip - anchor);
+        size_t const ll_addbytes = (ll + 240) / 255;
+        size_t const ll_totalCost = 1 + ll_addbytes + ll;
+        BYTE* const maxLitPos = oend - 3; /* 2 for offset, 1 for token */
+        DEBUGLOG(6, "Last sequence is overflowing : %u literals, %u remaining space",
+                (unsigned)ll, (unsigned)(oend-op));
+        if (op + ll_totalCost <= maxLitPos) {
+            /* ll validated; now adjust match length */
+            size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
+            size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
+            assert(maxMlSize < INT_MAX);
+            if ((size_t)matchLength > maxMlSize) matchLength= (unsigned)maxMlSize;
+            if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + matchLength >= MFLIMIT) {
+            DEBUGLOG(6, "Let's encode a last sequence (ll=%u, ml=%u)", (unsigned)ll, matchLength);
+                LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                        (int)matchLength, (int)matchDistance,
+                        notLimited, oend);
+        }   }
+        DEBUGLOG(6, "Let's finish with a run of literals (%u bytes left)", (unsigned)(oend-op));
+        goto _lz4mid_last_literals;
+    }
+    /* compression failed */
+    return 0;
+}
+
+
+/**************************************
+*  HC Compression - Search
+**************************************/
+
+/* Update chains up to ip (excluded) */
+LZ4_FORCE_INLINE void LZ4HC_Insert (LZ4HC_CCtx_internal* hc4, const BYTE* ip)
+{
+    U16* const chainTable = hc4->chainTable;
+    U32* const hashTable  = hc4->hashTable;
+    const BYTE* const prefixPtr = hc4->prefixStart;
+    U32 const prefixIdx = hc4->dictLimit;
+    U32 const target = (U32)(ip - prefixPtr) + prefixIdx;
+    U32 idx = hc4->nextToUpdate;
+    assert(ip >= prefixPtr);
+    assert(target >= prefixIdx);
+
+    while (idx < target) {
+        U32 const h = LZ4HC_hashPtr(prefixPtr+idx-prefixIdx);
+        size_t delta = idx - hashTable[h];
+        if (delta>LZ4_DISTANCE_MAX) delta = LZ4_DISTANCE_MAX;
+        DELTANEXTU16(chainTable, idx) = (U16)delta;
+        hashTable[h] = idx;
+        idx++;
+    }
+
+    hc4->nextToUpdate = target;
+}
+
+#if defined(_MSC_VER)
+#  define LZ4HC_rotl32(x,r) _rotl(x,r)
+#else
+#  define LZ4HC_rotl32(x,r) ((x << r) | (x >> (32 - r)))
+#endif
+
+
+static U32 LZ4HC_rotatePattern(size_t const rotate, U32 const pattern)
+{
+    size_t const bitsToRotate = (rotate & (sizeof(pattern) - 1)) << 3;
+    if (bitsToRotate == 0) return pattern;
+    return LZ4HC_rotl32(pattern, (int)bitsToRotate);
+}
+
+/* LZ4HC_countPattern() :
+ * pattern32 must be a sample of repetitive pattern of length 1, 2 or 4 (but not 3!) */
+static unsigned
+LZ4HC_countPattern(const BYTE* ip, const BYTE* const iEnd, U32 const pattern32)
+{
+    const BYTE* const iStart = ip;
+    reg_t const pattern = (sizeof(pattern)==8) ?
+        (reg_t)pattern32 + (((reg_t)pattern32) << (sizeof(pattern)*4)) : pattern32;
+
+    while (likely(ip < iEnd-(sizeof(pattern)-1))) {
+        reg_t const diff = LZ4_read_ARCH(ip) ^ pattern;
+        if (!diff) { ip+=sizeof(pattern); continue; }
+        ip += LZ4_NbCommonBytes(diff);
+        return (unsigned)(ip - iStart);
+    }
+
+    if (LZ4_isLittleEndian()) {
+        reg_t patternByte = pattern;
+        while ((ip<iEnd) && (*ip == (BYTE)patternByte)) {
+            ip++; patternByte >>= 8;
+        }
+    } else {  /* big endian */
+        U32 bitOffset = (sizeof(pattern)*8) - 8;
+        while (ip < iEnd) {
+            BYTE const byte = (BYTE)(pattern >> bitOffset);
+            if (*ip != byte) break;
+            ip ++; bitOffset -= 8;
+    }   }
+
+    return (unsigned)(ip - iStart);
+}
+
+/* LZ4HC_reverseCountPattern() :
+ * pattern must be a sample of repetitive pattern of length 1, 2 or 4 (but not 3!)
+ * read using natural platform endianness */
+static unsigned
+LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow, U32 pattern)
+{
+    const BYTE* const iStart = ip;
+
+    while (likely(ip >= iLow+4)) {
+        if (LZ4_read32(ip-4) != pattern) break;
+        ip -= 4;
+    }
+    {   const BYTE* bytePtr = (const BYTE*)(&pattern) + 3; /* works for any endianness */
+        while (likely(ip>iLow)) {
+            if (ip[-1] != *bytePtr) break;
+            ip--; bytePtr--;
+    }   }
+    return (unsigned)(iStart - ip);
+}
+
+/* LZ4HC_protectDictEnd() :
+ * Checks if the match is in the last 3 bytes of the dictionary, so reading the
+ * 4 byte MINMATCH would overflow.
+ * @returns true if the match index is okay.
+ */
+static int LZ4HC_protectDictEnd(U32 const dictLimit, U32 const matchIndex)
+{
+    return ((U32)((dictLimit - 1) - matchIndex) >= 3);
+}
+
+typedef enum { rep_untested, rep_not, rep_confirmed } repeat_state_e;
+typedef enum { favorCompressionRatio=0, favorDecompressionSpeed } HCfavor_e;
+
+
+LZ4_FORCE_INLINE LZ4HC_match_t
+LZ4HC_InsertAndGetWiderMatch (
+        LZ4HC_CCtx_internal* const hc4,
+        const BYTE* const ip,
+        const BYTE* const iLowLimit, const BYTE* const iHighLimit,
+        int longest,
+        const int maxNbAttempts,
+        const int patternAnalysis, const int chainSwap,
+        const dictCtx_directive dict,
+        const HCfavor_e favorDecSpeed)
+{
+    U16* const chainTable = hc4->chainTable;
+    U32* const hashTable = hc4->hashTable;
+    const LZ4HC_CCtx_internal* const dictCtx = hc4->dictCtx;
+    const BYTE* const prefixPtr = hc4->prefixStart;
+    const U32 prefixIdx = hc4->dictLimit;
+    const U32 ipIndex = (U32)(ip - prefixPtr) + prefixIdx;
+    const int withinStartDistance = (hc4->lowLimit + (LZ4_DISTANCE_MAX + 1) > ipIndex);
+    const U32 lowestMatchIndex = (withinStartDistance) ? hc4->lowLimit : ipIndex - LZ4_DISTANCE_MAX;
+    const BYTE* const dictStart = hc4->dictStart;
+    const U32 dictIdx = hc4->lowLimit;
+    const BYTE* const dictEnd = dictStart + prefixIdx - dictIdx;
+    int const lookBackLength = (int)(ip-iLowLimit);
+    int nbAttempts = maxNbAttempts;
+    U32 matchChainPos = 0;
+    U32 const pattern = LZ4_read32(ip);
+    U32 matchIndex;
+    repeat_state_e repeat = rep_untested;
+    size_t srcPatternLength = 0;
+    int offset = 0, sBack = 0;
+
+    DEBUGLOG(7, "LZ4HC_InsertAndGetWiderMatch");
+    /* First Match */
+    LZ4HC_Insert(hc4, ip);  /* insert all prior positions up to ip (excluded) */
+    matchIndex = hashTable[LZ4HC_hashPtr(ip)];
+    DEBUGLOG(7, "First candidate match for pos %u found at index %u / %u (lowestMatchIndex)",
+                ipIndex, matchIndex, lowestMatchIndex);
+
+    while ((matchIndex>=lowestMatchIndex) && (nbAttempts>0)) {
+        int matchLength=0;
+        nbAttempts--;
+        assert(matchIndex < ipIndex);
+        if (favorDecSpeed && (ipIndex - matchIndex < 8)) {
+            /* do nothing:
+             * favorDecSpeed intentionally skips matches with offset < 8 */
+        } else if (matchIndex >= prefixIdx) {   /* within current Prefix */
+            const BYTE* const matchPtr = prefixPtr + (matchIndex - prefixIdx);
+            assert(matchPtr < ip);
+            assert(longest >= 1);
+            if (LZ4_read16(iLowLimit + longest - 1) == LZ4_read16(matchPtr - lookBackLength + longest - 1)) {
+                if (LZ4_read32(matchPtr) == pattern) {
+                    int const back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, prefixPtr) : 0;
+                    matchLength = MINMATCH + (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, iHighLimit);
+                    matchLength -= back;
+                    if (matchLength > longest) {
+                        longest = matchLength;
+                        offset = (int)(ipIndex - matchIndex);
+                        sBack = back;
+                        DEBUGLOG(7, "Found match of len=%i within prefix, offset=%i, back=%i", longest, offset, -back);
+            }   }   }
+        } else {   /* lowestMatchIndex <= matchIndex < dictLimit : within Ext Dict */
+            const BYTE* const matchPtr = dictStart + (matchIndex - dictIdx);
+            assert(matchIndex >= dictIdx);
+            if ( likely(matchIndex <= prefixIdx - 4)
+              && (LZ4_read32(matchPtr) == pattern) ) {
+                int back = 0;
+                const BYTE* vLimit = ip + (prefixIdx - matchIndex);
+                if (vLimit > iHighLimit) vLimit = iHighLimit;
+                matchLength = (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, vLimit) + MINMATCH;
+                if ((ip+matchLength == vLimit) && (vLimit < iHighLimit))
+                    matchLength += LZ4_count(ip+matchLength, prefixPtr, iHighLimit);
+                back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, dictStart) : 0;
+                matchLength -= back;
+                if (matchLength > longest) {
+                    longest = matchLength;
+                    offset = (int)(ipIndex - matchIndex);
+                    sBack = back;
+                    DEBUGLOG(7, "Found match of len=%i within dict, offset=%i, back=%i", longest, offset, -back);
+        }   }   }
+
+        if (chainSwap && matchLength==longest) {   /* better match => select a better chain */
+            assert(lookBackLength==0);   /* search forward only */
+            if (matchIndex + (U32)longest <= ipIndex) {
+                int const kTrigger = 4;
+                U32 distanceToNextMatch = 1;
+                int const end = longest - MINMATCH + 1;
+                int step = 1;
+                int accel = 1 << kTrigger;
+                int pos;
+                for (pos = 0; pos < end; pos += step) {
+                    U32 const candidateDist = DELTANEXTU16(chainTable, matchIndex + (U32)pos);
+                    step = (accel++ >> kTrigger);
+                    if (candidateDist > distanceToNextMatch) {
+                        distanceToNextMatch = candidateDist;
+                        matchChainPos = (U32)pos;
+                        accel = 1 << kTrigger;
+                }   }
+                if (distanceToNextMatch > 1) {
+                    if (distanceToNextMatch > matchIndex) break;   /* avoid overflow */
+                    matchIndex -= distanceToNextMatch;
+                    continue;
+        }   }   }
+
+        {   U32 const distNextMatch = DELTANEXTU16(chainTable, matchIndex);
+            if (patternAnalysis && distNextMatch==1 && matchChainPos==0) {
+                U32 const matchCandidateIdx = matchIndex-1;
+                /* may be a repeated pattern */
+                if (repeat == rep_untested) {
+                    if ( ((pattern & 0xFFFF) == (pattern >> 16))
+                      &  ((pattern & 0xFF)   == (pattern >> 24)) ) {
+                        DEBUGLOG(7, "Repeat pattern detected, char %02X", pattern >> 24);
+                        repeat = rep_confirmed;
+                        srcPatternLength = LZ4HC_countPattern(ip+sizeof(pattern), iHighLimit, pattern) + sizeof(pattern);
+                    } else {
+                        repeat = rep_not;
+                }   }
+                if ( (repeat == rep_confirmed) && (matchCandidateIdx >= lowestMatchIndex)
+                  && LZ4HC_protectDictEnd(prefixIdx, matchCandidateIdx) ) {
+                    const int extDict = matchCandidateIdx < prefixIdx;
+                    const BYTE* const matchPtr = extDict ? dictStart + (matchCandidateIdx - dictIdx) : prefixPtr + (matchCandidateIdx - prefixIdx);
+                    if (LZ4_read32(matchPtr) == pattern) {  /* good candidate */
+                        const BYTE* const iLimit = extDict ? dictEnd : iHighLimit;
+                        size_t forwardPatternLength = LZ4HC_countPattern(matchPtr+sizeof(pattern), iLimit, pattern) + sizeof(pattern);
+                        if (extDict && matchPtr + forwardPatternLength == iLimit) {
+                            U32 const rotatedPattern = LZ4HC_rotatePattern(forwardPatternLength, pattern);
+                            forwardPatternLength += LZ4HC_countPattern(prefixPtr, iHighLimit, rotatedPattern);
+                        }
+                        {   const BYTE* const lowestMatchPtr = extDict ? dictStart : prefixPtr;
+                            size_t backLength = LZ4HC_reverseCountPattern(matchPtr, lowestMatchPtr, pattern);
+                            size_t currentSegmentLength;
+                            if (!extDict
+                              && matchPtr - backLength == prefixPtr
+                              && dictIdx < prefixIdx) {
+                                U32 const rotatedPattern = LZ4HC_rotatePattern((U32)(-(int)backLength), pattern);
+                                backLength += LZ4HC_reverseCountPattern(dictEnd, dictStart, rotatedPattern);
+                            }
+                            /* Limit backLength not go further than lowestMatchIndex */
+                            backLength = matchCandidateIdx - MAX(matchCandidateIdx - (U32)backLength, lowestMatchIndex);
+                            assert(matchCandidateIdx - backLength >= lowestMatchIndex);
+                            currentSegmentLength = backLength + forwardPatternLength;
+                            /* Adjust to end of pattern if the source pattern fits, otherwise the beginning of the pattern */
+                            if ( (currentSegmentLength >= srcPatternLength)   /* current pattern segment large enough to contain full srcPatternLength */
+                              && (forwardPatternLength <= srcPatternLength) ) { /* haven't reached this position yet */
+                                U32 const newMatchIndex = matchCandidateIdx + (U32)forwardPatternLength - (U32)srcPatternLength;  /* best position, full pattern, might be followed by more match */
+                                if (LZ4HC_protectDictEnd(prefixIdx, newMatchIndex))
+                                    matchIndex = newMatchIndex;
+                                else {
+                                    /* Can only happen if started in the prefix */
+                                    assert(newMatchIndex >= prefixIdx - 3 && newMatchIndex < prefixIdx && !extDict);
+                                    matchIndex = prefixIdx;
+                                }
+                            } else {
+                                U32 const newMatchIndex = matchCandidateIdx - (U32)backLength;   /* farthest position in current segment, will find a match of length currentSegmentLength + maybe some back */
+                                if (!LZ4HC_protectDictEnd(prefixIdx, newMatchIndex)) {
+                                    assert(newMatchIndex >= prefixIdx - 3 && newMatchIndex < prefixIdx && !extDict);
+                                    matchIndex = prefixIdx;
+                                } else {
+                                    matchIndex = newMatchIndex;
+                                    if (lookBackLength==0) {  /* no back possible */
+                                        size_t const maxML = MIN(currentSegmentLength, srcPatternLength);
+                                        if ((size_t)longest < maxML) {
+                                            assert(prefixPtr - prefixIdx + matchIndex != ip);
+                                            if ((size_t)(ip - prefixPtr) + prefixIdx - matchIndex > LZ4_DISTANCE_MAX) break;
+                                            assert(maxML < 2 GB);
+                                            longest = (int)maxML;
+                                            offset = (int)(ipIndex - matchIndex);
+                                            assert(sBack == 0);
+                                            DEBUGLOG(7, "Found repeat pattern match of len=%i, offset=%i", longest, offset);
+                                        }
+                                        {   U32 const distToNextPattern = DELTANEXTU16(chainTable, matchIndex);
+                                            if (distToNextPattern > matchIndex) break;  /* avoid overflow */
+                                            matchIndex -= distToNextPattern;
+                        }   }   }   }   }
+                        continue;
+                }   }
+        }   }   /* PA optimization */
+
+        /* follow current chain */
+        matchIndex -= DELTANEXTU16(chainTable, matchIndex + matchChainPos);
+
+    }  /* while ((matchIndex>=lowestMatchIndex) && (nbAttempts)) */
+
+    if ( dict == usingDictCtxHc
+      && nbAttempts > 0
+      && withinStartDistance) {
+        size_t const dictEndOffset = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
+        U32 dictMatchIndex = dictCtx->hashTable[LZ4HC_hashPtr(ip)];
+        assert(dictEndOffset <= 1 GB);
+        matchIndex = dictMatchIndex + lowestMatchIndex - (U32)dictEndOffset;
+        if (dictMatchIndex>0) DEBUGLOG(7, "dictEndOffset = %zu, dictMatchIndex = %u => relative matchIndex = %i", dictEndOffset, dictMatchIndex, (int)dictMatchIndex - (int)dictEndOffset);
+        while (ipIndex - matchIndex <= LZ4_DISTANCE_MAX && nbAttempts--) {
+            const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + dictMatchIndex;
+
+            if (LZ4_read32(matchPtr) == pattern) {
+                int mlt;
+                int back = 0;
+                const BYTE* vLimit = ip + (dictEndOffset - dictMatchIndex);
+                if (vLimit > iHighLimit) vLimit = iHighLimit;
+                mlt = (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, vLimit) + MINMATCH;
+                back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, dictCtx->prefixStart) : 0;
+                mlt -= back;
+                if (mlt > longest) {
+                    longest = mlt;
+                    offset = (int)(ipIndex - matchIndex);
+                    sBack = back;
+                    DEBUGLOG(7, "found match of length %i within extDictCtx", longest);
+            }   }
+
+            {   U32 const nextOffset = DELTANEXTU16(dictCtx->chainTable, dictMatchIndex);
+                dictMatchIndex -= nextOffset;
+                matchIndex -= nextOffset;
+    }   }   }
+
+    {   LZ4HC_match_t md;
+        assert(longest >= 0);
+        md.len = longest;
+        md.off = offset;
+        md.back = sBack;
+        return md;
+    }
+}
+
+LZ4_FORCE_INLINE LZ4HC_match_t
+LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index table will be updated */
+                       const BYTE* const ip, const BYTE* const iLimit,
+                       const int maxNbAttempts,
+                       const int patternAnalysis,
+                       const dictCtx_directive dict)
+{
+    DEBUGLOG(7, "LZ4HC_InsertAndFindBestMatch");
+    /* note : LZ4HC_InsertAndGetWiderMatch() is able to modify the starting position of a match (*startpos),
+     * but this won't be the case here, as we define iLowLimit==ip,
+     * so LZ4HC_InsertAndGetWiderMatch() won't be allowed to search past ip */
+    return LZ4HC_InsertAndGetWiderMatch(hc4, ip, ip, iLimit, MINMATCH-1, maxNbAttempts, patternAnalysis, 0 /*chainSwap*/, dict, favorCompressionRatio);
+}
+
+
+LZ4_FORCE_INLINE int LZ4HC_compress_hashChain (
+    LZ4HC_CCtx_internal* const ctx,
+    const char* const source,
+    char* const dest,
+    int* srcSizePtr,
+    int const maxOutputSize,
+    int maxNbAttempts,
+    const limitedOutput_directive limit,
+    const dictCtx_directive dict
+    )
+{
+    const int inputSize = *srcSizePtr;
+    const int patternAnalysis = (maxNbAttempts > 128);   /* levels 9+ */
+
+    const BYTE* ip = (const BYTE*) source;
+    const BYTE* anchor = ip;
+    const BYTE* const iend = ip + inputSize;
+    const BYTE* const mflimit = iend - MFLIMIT;
+    const BYTE* const matchlimit = (iend - LASTLITERALS);
+
+    BYTE* optr = (BYTE*) dest;
+    BYTE* op = (BYTE*) dest;
+    BYTE* oend = op + maxOutputSize;
+
+    const BYTE* start0;
+    const BYTE* start2 = NULL;
+    const BYTE* start3 = NULL;
+    LZ4HC_match_t m0, m1, m2, m3;
+    const LZ4HC_match_t nomatch = {0, 0, 0};
+
+    /* init */
+    DEBUGLOG(5, "LZ4HC_compress_hashChain (dict?=>%i)", dict);
+    *srcSizePtr = 0;
+    if (limit == fillOutput) oend -= LASTLITERALS;                  /* Hack for support LZ4 format restriction */
+    if (inputSize < LZ4_minLength) goto _last_literals;             /* Input too small, no compression (all literals) */
+
+    /* Main Loop */
+    while (ip <= mflimit) {
+        m1 = LZ4HC_InsertAndFindBestMatch(ctx, ip, matchlimit, maxNbAttempts, patternAnalysis, dict);
+        if (m1.len<MINMATCH) { ip++; continue; }
+
+        /* saved, in case we would skip too much */
+        start0 = ip; m0 = m1;
+
+_Search2:
+        DEBUGLOG(7, "_Search2 (currently found match of size %i)", m1.len);
+        if (ip+m1.len <= mflimit) {
+            start2 = ip + m1.len - 2;
+            m2 = LZ4HC_InsertAndGetWiderMatch(ctx,
+                            start2, ip + 0, matchlimit, m1.len,
+                            maxNbAttempts, patternAnalysis, 0, dict, favorCompressionRatio);
+            start2 += m2.back;
+        } else {
+            m2 = nomatch;  /* do not search further */
+        }
+
+        if (m2.len <= m1.len) { /* No better match => encode ML1 immediately */
+            optr = op;
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                    m1.len, m1.off,
+                    limit, oend) )
+                goto _dest_overflow;
+            continue;
+        }
+
+        if (start0 < ip) {   /* first match was skipped at least once */
+            if (start2 < ip + m0.len) {  /* squeezing ML1 between ML0(original ML1) and ML2 */
+                ip = start0; m1 = m0;  /* restore initial Match1 */
+        }   }
+
+        /* Here, start0==ip */
+        if ((start2 - ip) < 3) {  /* First Match too small : removed */
+            ip = start2;
+            m1 = m2;
+            goto _Search2;
+        }
+
+_Search3:
+        if ((start2 - ip) < OPTIMAL_ML) {
+            int correction;
+            int new_ml = m1.len;
+            if (new_ml > OPTIMAL_ML) new_ml = OPTIMAL_ML;
+            if (ip+new_ml > start2 + m2.len - MINMATCH)
+                new_ml = (int)(start2 - ip) + m2.len - MINMATCH;
+            correction = new_ml - (int)(start2 - ip);
+            if (correction > 0) {
+                start2 += correction;
+                m2.len -= correction;
+            }
+        }
+
+        if (start2 + m2.len <= mflimit) {
+            start3 = start2 + m2.len - 3;
+            m3 = LZ4HC_InsertAndGetWiderMatch(ctx,
+                            start3, start2, matchlimit, m2.len,
+                            maxNbAttempts, patternAnalysis, 0, dict, favorCompressionRatio);
+            start3 += m3.back;
+        } else {
+            m3 = nomatch;  /* do not search further */
+        }
+
+        if (m3.len <= m2.len) {  /* No better match => encode ML1 and ML2 */
+            /* ip & ref are known; Now for ml */
+            if (start2 < ip+m1.len) m1.len = (int)(start2 - ip);
+            /* Now, encode 2 sequences */
+            optr = op;
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                    m1.len, m1.off,
+                    limit, oend) )
+                goto _dest_overflow;
+            ip = start2;
+            optr = op;
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                    m2.len, m2.off,
+                    limit, oend) ) {
+                m1 = m2;
+                goto _dest_overflow;
+            }
+            continue;
+        }
+
+        if (start3 < ip+m1.len+3) {  /* Not enough space for match 2 : remove it */
+            if (start3 >= (ip+m1.len)) {  /* can write Seq1 immediately ==> Seq2 is removed, so Seq3 becomes Seq1 */
+                if (start2 < ip+m1.len) {
+                    int correction = (int)(ip+m1.len - start2);
+                    start2 += correction;
+                    m2.len -= correction;
+                    if (m2.len < MINMATCH) {
+                        start2 = start3;
+                        m2 = m3;
+                    }
+                }
+
+                optr = op;
+                if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                        m1.len, m1.off,
+                        limit, oend) )
+                    goto _dest_overflow;
+                ip  = start3;
+                m1 = m3;
+
+                start0 = start2;
+                m0 = m2;
+                goto _Search2;
+            }
+
+            start2 = start3;
+            m2 = m3;
+            goto _Search3;
+        }
+
+        /*
+        * OK, now we have 3 ascending matches;
+        * let's write the first one ML1.
+        * ip & ref are known; Now decide ml.
+        */
+        if (start2 < ip+m1.len) {
+            if ((start2 - ip) < OPTIMAL_ML) {
+                int correction;
+                if (m1.len > OPTIMAL_ML) m1.len = OPTIMAL_ML;
+                if (ip + m1.len > start2 + m2.len - MINMATCH)
+                    m1.len = (int)(start2 - ip) + m2.len - MINMATCH;
+                correction = m1.len - (int)(start2 - ip);
+                if (correction > 0) {
+                    start2 += correction;
+                    m2.len -= correction;
+                }
+            } else {
+                m1.len = (int)(start2 - ip);
+            }
+        }
+        optr = op;
+        if ( LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
+                m1.len, m1.off,
+                limit, oend) )
+            goto _dest_overflow;
+
+        /* ML2 becomes ML1 */
+        ip = start2; m1 = m2;
+
+        /* ML3 becomes ML2 */
+        start2 = start3; m2 = m3;
+
+        /* let's find a new ML3 */
+        goto _Search3;
+    }
+
+_last_literals:
+    /* Encode Last Literals */
+    {   size_t lastRunSize = (size_t)(iend - anchor);  /* literals */
+        size_t llAdd = (lastRunSize + 255 - RUN_MASK) / 255;
+        size_t const totalSize = 1 + llAdd + lastRunSize;
+        if (limit == fillOutput) oend += LASTLITERALS;  /* restore correct value */
+        if (limit && (op + totalSize > oend)) {
+            if (limit == limitedOutput) return 0;
+            /* adapt lastRunSize to fill 'dest' */
+            lastRunSize  = (size_t)(oend - op) - 1 /*token*/;
+            llAdd = (lastRunSize + 256 - RUN_MASK) / 256;
+            lastRunSize -= llAdd;
+        }
+        DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
+        ip = anchor + lastRunSize;  /* can be != iend if limit==fillOutput */
+
+        if (lastRunSize >= RUN_MASK) {
+            size_t accumulator = lastRunSize - RUN_MASK;
+            *op++ = (RUN_MASK << ML_BITS);
+            for(; accumulator >= 255 ; accumulator -= 255) *op++ = 255;
+            *op++ = (BYTE) accumulator;
+        } else {
+            *op++ = (BYTE)(lastRunSize << ML_BITS);
+        }
+        LZ4_memcpy(op, anchor, lastRunSize);
+        op += lastRunSize;
+    }
+
+    /* End */
+    *srcSizePtr = (int) (((const char*)ip) - source);
+    return (int) (((char*)op)-dest);
+
+_dest_overflow:
+    if (limit == fillOutput) {
+        /* Assumption : @ip, @anchor, @optr and @m1 must be set correctly */
+        size_t const ll = (size_t)(ip - anchor);
+        size_t const ll_addbytes = (ll + 240) / 255;
+        size_t const ll_totalCost = 1 + ll_addbytes + ll;
+        BYTE* const maxLitPos = oend - 3; /* 2 for offset, 1 for token */
+        DEBUGLOG(6, "Last sequence overflowing");
+        op = optr;  /* restore correct out pointer */
+        if (op + ll_totalCost <= maxLitPos) {
+            /* ll validated; now adjust match length */
+            size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
+            size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
+            assert(maxMlSize < INT_MAX); assert(m1.len >= 0);
+            if ((size_t)m1.len > maxMlSize) m1.len = (int)maxMlSize;
+            if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + m1.len >= MFLIMIT) {
+                LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m1.len, m1.off, notLimited, oend);
+        }   }
+        goto _last_literals;
+    }
+    /* compression failed */
+    return 0;
+}
+
+
+static int LZ4HC_compress_optimal( LZ4HC_CCtx_internal* ctx,
+    const char* const source, char* dst,
+    int* srcSizePtr, int dstCapacity,
+    int const nbSearches, size_t sufficient_len,
+    const limitedOutput_directive limit, int const fullUpdate,
+    const dictCtx_directive dict,
+    const HCfavor_e favorDecSpeed);
+
+LZ4_FORCE_INLINE int
+LZ4HC_compress_generic_internal (
+            LZ4HC_CCtx_internal* const ctx,
+            const char* const src,
+            char* const dst,
+            int* const srcSizePtr,
+            int const dstCapacity,
+            int cLevel,
+            const limitedOutput_directive limit,
+            const dictCtx_directive dict
+            )
+{
+    DEBUGLOG(5, "LZ4HC_compress_generic_internal(src=%p, srcSize=%d)",
+                src, *srcSizePtr);
+
+    if (limit == fillOutput && dstCapacity < 1) return 0;   /* Impossible to store anything */
+    if ((U32)*srcSizePtr > (U32)LZ4_MAX_INPUT_SIZE) return 0;  /* Unsupported input size (too large or negative) */
+
+    ctx->end += *srcSizePtr;
+    {   cParams_t const cParam = LZ4HC_getCLevelParams(cLevel);
+        HCfavor_e const favor = ctx->favorDecSpeed ? favorDecompressionSpeed : favorCompressionRatio;
+        int result;
+
+        if (cParam.strat == lz4mid) {
+            result = LZ4MID_compress(ctx,
+                                src, dst, srcSizePtr, dstCapacity,
+                                limit, dict);
+        } else if (cParam.strat == lz4hc) {
+            result = LZ4HC_compress_hashChain(ctx,
+                                src, dst, srcSizePtr, dstCapacity,
+                                cParam.nbSearches, limit, dict);
+        } else {
+            assert(cParam.strat == lz4opt);
+            result = LZ4HC_compress_optimal(ctx,
+                                src, dst, srcSizePtr, dstCapacity,
+                                cParam.nbSearches, cParam.targetLength, limit,
+                                cLevel >= LZ4HC_CLEVEL_MAX,   /* ultra mode */
+                                dict, favor);
+        }
+        if (result <= 0) ctx->dirty = 1;
+        return result;
+    }
+}
+
+static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBlock);
+
+static int
+LZ4HC_compress_generic_noDictCtx (
+        LZ4HC_CCtx_internal* const ctx,
+        const char* const src,
+        char* const dst,
+        int* const srcSizePtr,
+        int const dstCapacity,
+        int cLevel,
+        limitedOutput_directive limit
+        )
+{
+    assert(ctx->dictCtx == NULL);
+    return LZ4HC_compress_generic_internal(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit, noDictCtx);
+}
+
+static int isStateCompatible(const LZ4HC_CCtx_internal* ctx1, const LZ4HC_CCtx_internal* ctx2)
+{
+    int const isMid1 = LZ4HC_getCLevelParams(ctx1->compressionLevel).strat == lz4mid;
+    int const isMid2 = LZ4HC_getCLevelParams(ctx2->compressionLevel).strat == lz4mid;
+    return !(isMid1 ^ isMid2);
+}
+
+static int
+LZ4HC_compress_generic_dictCtx (
+        LZ4HC_CCtx_internal* const ctx,
+        const char* const src,
+        char* const dst,
+        int* const srcSizePtr,
+        int const dstCapacity,
+        int cLevel,
+        limitedOutput_directive limit
+        )
+{
+    const size_t position = (size_t)(ctx->end - ctx->prefixStart) + (ctx->dictLimit - ctx->lowLimit);
+    assert(ctx->dictCtx != NULL);
+    if (position >= 64 KB) {
+        ctx->dictCtx = NULL;
+        return LZ4HC_compress_generic_noDictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
+    } else if (position == 0 && *srcSizePtr > 4 KB && isStateCompatible(ctx, ctx->dictCtx)) {
+        LZ4_memcpy(ctx, ctx->dictCtx, sizeof(LZ4HC_CCtx_internal));
+        LZ4HC_setExternalDict(ctx, (const BYTE *)src);
+        ctx->compressionLevel = (short)cLevel;
+        return LZ4HC_compress_generic_noDictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
+    } else {
+        return LZ4HC_compress_generic_internal(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit, usingDictCtxHc);
+    }
+}
+
+static int
+LZ4HC_compress_generic (
+        LZ4HC_CCtx_internal* const ctx,
+        const char* const src,
+        char* const dst,
+        int* const srcSizePtr,
+        int const dstCapacity,
+        int cLevel,
+        limitedOutput_directive limit
+        )
+{
+    if (ctx->dictCtx == NULL) {
+        return LZ4HC_compress_generic_noDictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
+    } else {
+        return LZ4HC_compress_generic_dictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
+    }
+}
+
+
+int LZ4_sizeofStateHC(void) { return (int)sizeof(LZ4_streamHC_t); }
+
+static size_t LZ4_streamHC_t_alignment(void)
+{
+#if LZ4_ALIGN_TEST
+    typedef struct { char c; LZ4_streamHC_t t; } t_a;
+    return sizeof(t_a) - sizeof(LZ4_streamHC_t);
+#else
+    return 1;  /* effectively disabled */
+#endif
+}
+
+/* state is presumed correctly initialized,
+ * in which case its size and alignment have already been validate */
+int LZ4_compress_HC_extStateHC_fastReset (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel)
+{
+    LZ4HC_CCtx_internal* const ctx = &((LZ4_streamHC_t*)state)->internal_donotuse;
+    if (!LZ4_isAligned(state, LZ4_streamHC_t_alignment())) return 0;
+    LZ4_resetStreamHC_fast((LZ4_streamHC_t*)state, compressionLevel);
+    LZ4HC_init_internal (ctx, (const BYTE*)src);
+    if (dstCapacity < LZ4_compressBound(srcSize))
+        return LZ4HC_compress_generic (ctx, src, dst, &srcSize, dstCapacity, compressionLevel, limitedOutput);
+    else
+        return LZ4HC_compress_generic (ctx, src, dst, &srcSize, dstCapacity, compressionLevel, notLimited);
+}
+
+int LZ4_compress_HC_extStateHC (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel)
+{
+    LZ4_streamHC_t* const ctx = LZ4_initStreamHC(state, sizeof(*ctx));
+    if (ctx==NULL) return 0;   /* init failure */
+    return LZ4_compress_HC_extStateHC_fastReset(state, src, dst, srcSize, dstCapacity, compressionLevel);
+}
+
+int LZ4_compress_HC(const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel)
+{
+    int cSize;
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+    LZ4_streamHC_t* const statePtr = (LZ4_streamHC_t*)ALLOC(sizeof(LZ4_streamHC_t));
+    if (statePtr==NULL) return 0;
+#else
+    LZ4_streamHC_t state;
+    LZ4_streamHC_t* const statePtr = &state;
+#endif
+    DEBUGLOG(5, "LZ4_compress_HC")
+    cSize = LZ4_compress_HC_extStateHC(statePtr, src, dst, srcSize, dstCapacity, compressionLevel);
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+    FREEMEM(statePtr);
+#endif
+    return cSize;
+}
+
+/* state is presumed sized correctly (>= sizeof(LZ4_streamHC_t)) */
+int LZ4_compress_HC_destSize(void* state, const char* source, char* dest, int* sourceSizePtr, int targetDestSize, int cLevel)
+{
+    LZ4_streamHC_t* const ctx = LZ4_initStreamHC(state, sizeof(*ctx));
+    if (ctx==NULL) return 0;   /* init failure */
+    LZ4HC_init_internal(&ctx->internal_donotuse, (const BYTE*) source);
+    LZ4_setCompressionLevel(ctx, cLevel);
+    return LZ4HC_compress_generic(&ctx->internal_donotuse, source, dest, sourceSizePtr, targetDestSize, cLevel, fillOutput);
+}
+
+
+
+/**************************************
+*  Streaming Functions
+**************************************/
+/* allocation */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_streamHC_t* LZ4_createStreamHC(void)
+{
+    LZ4_streamHC_t* const state =
+        (LZ4_streamHC_t*)ALLOC_AND_ZERO(sizeof(LZ4_streamHC_t));
+    if (state == NULL) return NULL;
+    LZ4_setCompressionLevel(state, LZ4HC_CLEVEL_DEFAULT);
+    return state;
+}
+
+int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
+{
+    DEBUGLOG(4, "LZ4_freeStreamHC(%p)", LZ4_streamHCPtr);
+    if (!LZ4_streamHCPtr) return 0;  /* support free on NULL */
+    FREEMEM(LZ4_streamHCPtr);
+    return 0;
+}
+#endif
+
+
+LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size)
+{
+    LZ4_streamHC_t* const LZ4_streamHCPtr = (LZ4_streamHC_t*)buffer;
+    DEBUGLOG(4, "LZ4_initStreamHC(%p, %u)", buffer, (unsigned)size);
+    /* check conditions */
+    if (buffer == NULL) return NULL;
+    if (size < sizeof(LZ4_streamHC_t)) return NULL;
+    if (!LZ4_isAligned(buffer, LZ4_streamHC_t_alignment())) return NULL;
+    /* init */
+    { LZ4HC_CCtx_internal* const hcstate = &(LZ4_streamHCPtr->internal_donotuse);
+      MEM_INIT(hcstate, 0, sizeof(*hcstate)); }
+    LZ4_setCompressionLevel(LZ4_streamHCPtr, LZ4HC_CLEVEL_DEFAULT);
+    return LZ4_streamHCPtr;
+}
+
+/* just a stub */
+void LZ4_resetStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
+{
+    LZ4_initStreamHC(LZ4_streamHCPtr, sizeof(*LZ4_streamHCPtr));
+    LZ4_setCompressionLevel(LZ4_streamHCPtr, compressionLevel);
+}
+
+void LZ4_resetStreamHC_fast (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
+{
+    LZ4HC_CCtx_internal* const s = &LZ4_streamHCPtr->internal_donotuse;
+    DEBUGLOG(5, "LZ4_resetStreamHC_fast(%p, %d)", LZ4_streamHCPtr, compressionLevel);
+    if (s->dirty) {
+        LZ4_initStreamHC(LZ4_streamHCPtr, sizeof(*LZ4_streamHCPtr));
+    } else {
+        assert(s->end >= s->prefixStart);
+        s->dictLimit += (U32)(s->end - s->prefixStart);
+        s->prefixStart = NULL;
+        s->end = NULL;
+        s->dictCtx = NULL;
+    }
+    LZ4_setCompressionLevel(LZ4_streamHCPtr, compressionLevel);
+}
+
+void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
+{
+    DEBUGLOG(5, "LZ4_setCompressionLevel(%p, %d)", LZ4_streamHCPtr, compressionLevel);
+    if (compressionLevel < 1) compressionLevel = LZ4HC_CLEVEL_DEFAULT;
+    if (compressionLevel > LZ4HC_CLEVEL_MAX) compressionLevel = LZ4HC_CLEVEL_MAX;
+    LZ4_streamHCPtr->internal_donotuse.compressionLevel = (short)compressionLevel;
+}
+
+void LZ4_favorDecompressionSpeed(LZ4_streamHC_t* LZ4_streamHCPtr, int favor)
+{
+    LZ4_streamHCPtr->internal_donotuse.favorDecSpeed = (favor!=0);
+}
+
+/* LZ4_loadDictHC() :
+ * LZ4_streamHCPtr is presumed properly initialized */
+int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr,
+              const char* dictionary, int dictSize)
+{
+    LZ4HC_CCtx_internal* const ctxPtr = &LZ4_streamHCPtr->internal_donotuse;
+    cParams_t cp;
+    DEBUGLOG(4, "LZ4_loadDictHC(ctx:%p, dict:%p, dictSize:%d, clevel=%d)", LZ4_streamHCPtr, dictionary, dictSize, ctxPtr->compressionLevel);
+    assert(dictSize >= 0);
+    assert(LZ4_streamHCPtr != NULL);
+    if (dictSize > 64 KB) {
+        dictionary += (size_t)dictSize - 64 KB;
+        dictSize = 64 KB;
+    }
+    /* need a full initialization, there are bad side-effects when using resetFast() */
+    {   int const cLevel = ctxPtr->compressionLevel;
+        LZ4_initStreamHC(LZ4_streamHCPtr, sizeof(*LZ4_streamHCPtr));
+        LZ4_setCompressionLevel(LZ4_streamHCPtr, cLevel);
+        cp = LZ4HC_getCLevelParams(cLevel);
+    }
+    LZ4HC_init_internal (ctxPtr, (const BYTE*)dictionary);
+    ctxPtr->end = (const BYTE*)dictionary + dictSize;
+    if (cp.strat == lz4mid) {
+        LZ4MID_fillHTable (ctxPtr, dictionary, (size_t)dictSize);
+    } else {
+        if (dictSize >= LZ4HC_HASHSIZE) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);
+    }
+    return dictSize;
+}
+
+void LZ4_attach_HC_dictionary(LZ4_streamHC_t *working_stream, const LZ4_streamHC_t *dictionary_stream) {
+    working_stream->internal_donotuse.dictCtx = dictionary_stream != NULL ? &(dictionary_stream->internal_donotuse) : NULL;
+}
+
+/* compression */
+
+static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBlock)
+{
+    DEBUGLOG(4, "LZ4HC_setExternalDict(%p, %p)", ctxPtr, newBlock);
+    if ( (ctxPtr->end >= ctxPtr->prefixStart + 4)
+      && (LZ4HC_getCLevelParams(ctxPtr->compressionLevel).strat != lz4mid) ) {
+        LZ4HC_Insert (ctxPtr, ctxPtr->end-3);  /* Referencing remaining dictionary content */
+    }
+
+    /* Only one memory segment for extDict, so any previous extDict is lost at this stage */
+    ctxPtr->lowLimit  = ctxPtr->dictLimit;
+    ctxPtr->dictStart  = ctxPtr->prefixStart;
+    ctxPtr->dictLimit += (U32)(ctxPtr->end - ctxPtr->prefixStart);
+    ctxPtr->prefixStart = newBlock;
+    ctxPtr->end  = newBlock;
+    ctxPtr->nextToUpdate = ctxPtr->dictLimit;   /* match referencing will resume from there */
+
+    /* cannot reference an extDict and a dictCtx at the same time */
+    ctxPtr->dictCtx = NULL;
+}
+
+static int
+LZ4_compressHC_continue_generic (LZ4_streamHC_t* LZ4_streamHCPtr,
+                                 const char* src, char* dst,
+                                 int* srcSizePtr, int dstCapacity,
+                                 limitedOutput_directive limit)
+{
+    LZ4HC_CCtx_internal* const ctxPtr = &LZ4_streamHCPtr->internal_donotuse;
+    DEBUGLOG(5, "LZ4_compressHC_continue_generic(ctx=%p, src=%p, srcSize=%d, limit=%d)",
+                LZ4_streamHCPtr, src, *srcSizePtr, limit);
+    assert(ctxPtr != NULL);
+    /* auto-init if forgotten */
+    if (ctxPtr->prefixStart == NULL)
+        LZ4HC_init_internal (ctxPtr, (const BYTE*) src);
+
+    /* Check overflow */
+    if ((size_t)(ctxPtr->end - ctxPtr->prefixStart) + ctxPtr->dictLimit > 2 GB) {
+        size_t dictSize = (size_t)(ctxPtr->end - ctxPtr->prefixStart);
+        if (dictSize > 64 KB) dictSize = 64 KB;
+        LZ4_loadDictHC(LZ4_streamHCPtr, (const char*)(ctxPtr->end) - dictSize, (int)dictSize);
+    }
+
+    /* Check if blocks follow each other */
+    if ((const BYTE*)src != ctxPtr->end)
+        LZ4HC_setExternalDict(ctxPtr, (const BYTE*)src);
+
+    /* Check overlapping input/dictionary space */
+    {   const BYTE* sourceEnd = (const BYTE*) src + *srcSizePtr;
+        const BYTE* const dictBegin = ctxPtr->dictStart;
+        const BYTE* const dictEnd   = ctxPtr->dictStart + (ctxPtr->dictLimit - ctxPtr->lowLimit);
+        if ((sourceEnd > dictBegin) && ((const BYTE*)src < dictEnd)) {
+            if (sourceEnd > dictEnd) sourceEnd = dictEnd;
+            ctxPtr->lowLimit += (U32)(sourceEnd - ctxPtr->dictStart);
+            ctxPtr->dictStart += (U32)(sourceEnd - ctxPtr->dictStart);
+            /* invalidate dictionary is it's too small */
+            if (ctxPtr->dictLimit - ctxPtr->lowLimit < LZ4HC_HASHSIZE) {
+                ctxPtr->lowLimit = ctxPtr->dictLimit;
+                ctxPtr->dictStart = ctxPtr->prefixStart;
+    }   }   }
+
+    return LZ4HC_compress_generic (ctxPtr, src, dst, srcSizePtr, dstCapacity, ctxPtr->compressionLevel, limit);
+}
+
+int LZ4_compress_HC_continue (LZ4_streamHC_t* LZ4_streamHCPtr, const char* src, char* dst, int srcSize, int dstCapacity)
+{
+    DEBUGLOG(5, "LZ4_compress_HC_continue");
+    if (dstCapacity < LZ4_compressBound(srcSize))
+        return LZ4_compressHC_continue_generic (LZ4_streamHCPtr, src, dst, &srcSize, dstCapacity, limitedOutput);
+    else
+        return LZ4_compressHC_continue_generic (LZ4_streamHCPtr, src, dst, &srcSize, dstCapacity, notLimited);
+}
+
+int LZ4_compress_HC_continue_destSize (LZ4_streamHC_t* LZ4_streamHCPtr, const char* src, char* dst, int* srcSizePtr, int targetDestSize)
+{
+    return LZ4_compressHC_continue_generic(LZ4_streamHCPtr, src, dst, srcSizePtr, targetDestSize, fillOutput);
+}
+
+
+/* LZ4_saveDictHC :
+ * save history content
+ * into a user-provided buffer
+ * which is then used to continue compression
+ */
+int LZ4_saveDictHC (LZ4_streamHC_t* LZ4_streamHCPtr, char* safeBuffer, int dictSize)
+{
+    LZ4HC_CCtx_internal* const streamPtr = &LZ4_streamHCPtr->internal_donotuse;
+    int const prefixSize = (int)(streamPtr->end - streamPtr->prefixStart);
+    DEBUGLOG(5, "LZ4_saveDictHC(%p, %p, %d)", LZ4_streamHCPtr, safeBuffer, dictSize);
+    assert(prefixSize >= 0);
+    if (dictSize > 64 KB) dictSize = 64 KB;
+    if (dictSize < 4) dictSize = 0;
+    if (dictSize > prefixSize) dictSize = prefixSize;
+    if (safeBuffer == NULL) assert(dictSize == 0);
+    if (dictSize > 0)
+        LZ4_memmove(safeBuffer, streamPtr->end - dictSize, (size_t)dictSize);
+    {   U32 const endIndex = (U32)(streamPtr->end - streamPtr->prefixStart) + streamPtr->dictLimit;
+        streamPtr->end = (safeBuffer == NULL) ? NULL : (const BYTE*)safeBuffer + dictSize;
+        streamPtr->prefixStart = (const BYTE*)safeBuffer;
+        streamPtr->dictLimit = endIndex - (U32)dictSize;
+        streamPtr->lowLimit = endIndex - (U32)dictSize;
+        streamPtr->dictStart = streamPtr->prefixStart;
+        if (streamPtr->nextToUpdate < streamPtr->dictLimit)
+            streamPtr->nextToUpdate = streamPtr->dictLimit;
+    }
+    return dictSize;
+}
+
+
+/* ================================================
+ *  LZ4 Optimal parser (levels [LZ4HC_CLEVEL_OPT_MIN - LZ4HC_CLEVEL_MAX])
+ * ===============================================*/
+typedef struct {
+    int price;
+    int off;
+    int mlen;
+    int litlen;
+} LZ4HC_optimal_t;
+
+/* price in bytes */
+LZ4_FORCE_INLINE int LZ4HC_literalsPrice(int const litlen)
+{
+    int price = litlen;
+    assert(litlen >= 0);
+    if (litlen >= (int)RUN_MASK)
+        price += 1 + ((litlen-(int)RUN_MASK) / 255);
+    return price;
+}
+
+/* requires mlen >= MINMATCH */
+LZ4_FORCE_INLINE int LZ4HC_sequencePrice(int litlen, int mlen)
+{
+    int price = 1 + 2 ; /* token + 16-bit offset */
+    assert(litlen >= 0);
+    assert(mlen >= MINMATCH);
+
+    price += LZ4HC_literalsPrice(litlen);
+
+    if (mlen >= (int)(ML_MASK+MINMATCH))
+        price += 1 + ((mlen-(int)(ML_MASK+MINMATCH)) / 255);
+
+    return price;
+}
+
+LZ4_FORCE_INLINE LZ4HC_match_t
+LZ4HC_FindLongerMatch(LZ4HC_CCtx_internal* const ctx,
+                      const BYTE* ip, const BYTE* const iHighLimit,
+                      int minLen, int nbSearches,
+                      const dictCtx_directive dict,
+                      const HCfavor_e favorDecSpeed)
+{
+    LZ4HC_match_t const match0 = { 0 , 0, 0 };
+    /* note : LZ4HC_InsertAndGetWiderMatch() is able to modify the starting position of a match (*startpos),
+     * but this won't be the case here, as we define iLowLimit==ip,
+    ** so LZ4HC_InsertAndGetWiderMatch() won't be allowed to search past ip */
+    LZ4HC_match_t md = LZ4HC_InsertAndGetWiderMatch(ctx, ip, ip, iHighLimit, minLen, nbSearches, 1 /*patternAnalysis*/, 1 /*chainSwap*/, dict, favorDecSpeed);
+    assert(md.back == 0);
+    if (md.len <= minLen) return match0;
+    if (favorDecSpeed) {
+        if ((md.len>18) & (md.len<=36)) md.len=18;   /* favor dec.speed (shortcut) */
+    }
+    return md;
+}
+
+
+static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
+                                    const char* const source,
+                                    char* dst,
+                                    int* srcSizePtr,
+                                    int dstCapacity,
+                                    int const nbSearches,
+                                    size_t sufficient_len,
+                                    const limitedOutput_directive limit,
+                                    int const fullUpdate,
+                                    const dictCtx_directive dict,
+                                    const HCfavor_e favorDecSpeed)
+{
+    int retval = 0;
+#define TRAILING_LITERALS 3
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+    LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)ALLOC(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
+#else
+    LZ4HC_optimal_t opt[LZ4_OPT_NUM + TRAILING_LITERALS];   /* ~64 KB, which is a bit large for stack... */
+#endif
+
+    const BYTE* ip = (const BYTE*) source;
+    const BYTE* anchor = ip;
+    const BYTE* const iend = ip + *srcSizePtr;
+    const BYTE* const mflimit = iend - MFLIMIT;
+    const BYTE* const matchlimit = iend - LASTLITERALS;
+    BYTE* op = (BYTE*) dst;
+    BYTE* opSaved = (BYTE*) dst;
+    BYTE* oend = op + dstCapacity;
+    int ovml = MINMATCH;  /* overflow - last sequence */
+    int ovoff = 0;
+
+    /* init */
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+    if (opt == NULL) goto _return_label;
+#endif
+    DEBUGLOG(5, "LZ4HC_compress_optimal(dst=%p, dstCapa=%u)", dst, (unsigned)dstCapacity);
+    *srcSizePtr = 0;
+    if (limit == fillOutput) oend -= LASTLITERALS;   /* Hack for support LZ4 format restriction */
+    if (sufficient_len >= LZ4_OPT_NUM) sufficient_len = LZ4_OPT_NUM-1;
+
+    /* Main Loop */
+    while (ip <= mflimit) {
+         int const llen = (int)(ip - anchor);
+         int best_mlen, best_off;
+         int cur, last_match_pos = 0;
+
+         LZ4HC_match_t const firstMatch = LZ4HC_FindLongerMatch(ctx, ip, matchlimit, MINMATCH-1, nbSearches, dict, favorDecSpeed);
+         if (firstMatch.len==0) { ip++; continue; }
+
+         if ((size_t)firstMatch.len > sufficient_len) {
+             /* good enough solution : immediate encoding */
+             int const firstML = firstMatch.len;
+             opSaved = op;
+             if ( LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), firstML, firstMatch.off, limit, oend) ) {  /* updates ip, op and anchor */
+                 ovml = firstML;
+                 ovoff = firstMatch.off;
+                 goto _dest_overflow;
+             }
+             continue;
+         }
+
+         /* set prices for first positions (literals) */
+         {   int rPos;
+             for (rPos = 0 ; rPos < MINMATCH ; rPos++) {
+                 int const cost = LZ4HC_literalsPrice(llen + rPos);
+                 opt[rPos].mlen = 1;
+                 opt[rPos].off = 0;
+                 opt[rPos].litlen = llen + rPos;
+                 opt[rPos].price = cost;
+                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
+                             rPos, cost, opt[rPos].litlen);
+         }   }
+         /* set prices using initial match */
+         {   int const matchML = firstMatch.len;   /* necessarily < sufficient_len < LZ4_OPT_NUM */
+             int const offset = firstMatch.off;
+             int mlen;
+             assert(matchML < LZ4_OPT_NUM);
+             for (mlen = MINMATCH ; mlen <= matchML ; mlen++) {
+                 int const cost = LZ4HC_sequencePrice(llen, mlen);
+                 opt[mlen].mlen = mlen;
+                 opt[mlen].off = offset;
+                 opt[mlen].litlen = llen;
+                 opt[mlen].price = cost;
+                 DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i) -- initial setup",
+                             mlen, cost, mlen);
+         }   }
+         last_match_pos = firstMatch.len;
+         {   int addLit;
+             for (addLit = 1; addLit <= TRAILING_LITERALS; addLit ++) {
+                 opt[last_match_pos+addLit].mlen = 1; /* literal */
+                 opt[last_match_pos+addLit].off = 0;
+                 opt[last_match_pos+addLit].litlen = addLit;
+                 opt[last_match_pos+addLit].price = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
+                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
+                             last_match_pos+addLit, opt[last_match_pos+addLit].price, addLit);
+         }   }
+
+         /* check further positions */
+         for (cur = 1; cur < last_match_pos; cur++) {
+             const BYTE* const curPtr = ip + cur;
+             LZ4HC_match_t newMatch;
+
+             if (curPtr > mflimit) break;
+             DEBUGLOG(7, "rPos:%u[%u] vs [%u]%u",
+                     cur, opt[cur].price, opt[cur+1].price, cur+1);
+             if (fullUpdate) {
+                 /* not useful to search here if next position has same (or lower) cost */
+                 if ( (opt[cur+1].price <= opt[cur].price)
+                   /* in some cases, next position has same cost, but cost rises sharply after, so a small match would still be beneficial */
+                   && (opt[cur+MINMATCH].price < opt[cur].price + 3/*min seq price*/) )
+                     continue;
+             } else {
+                 /* not useful to search here if next position has same (or lower) cost */
+                 if (opt[cur+1].price <= opt[cur].price) continue;
+             }
+
+             DEBUGLOG(7, "search at rPos:%u", cur);
+             if (fullUpdate)
+                 newMatch = LZ4HC_FindLongerMatch(ctx, curPtr, matchlimit, MINMATCH-1, nbSearches, dict, favorDecSpeed);
+             else
+                 /* only test matches of minimum length; slightly faster, but misses a few bytes */
+                 newMatch = LZ4HC_FindLongerMatch(ctx, curPtr, matchlimit, last_match_pos - cur, nbSearches, dict, favorDecSpeed);
+             if (!newMatch.len) continue;
+
+             if ( ((size_t)newMatch.len > sufficient_len)
+               || (newMatch.len + cur >= LZ4_OPT_NUM) ) {
+                 /* immediate encoding */
+                 best_mlen = newMatch.len;
+                 best_off = newMatch.off;
+                 last_match_pos = cur + 1;
+                 goto encode;
+             }
+
+             /* before match : set price with literals at beginning */
+             {   int const baseLitlen = opt[cur].litlen;
+                 int litlen;
+                 for (litlen = 1; litlen < MINMATCH; litlen++) {
+                     int const price = opt[cur].price - LZ4HC_literalsPrice(baseLitlen) + LZ4HC_literalsPrice(baseLitlen+litlen);
+                     int const pos = cur + litlen;
+                     if (price < opt[pos].price) {
+                         opt[pos].mlen = 1; /* literal */
+                         opt[pos].off = 0;
+                         opt[pos].litlen = baseLitlen+litlen;
+                         opt[pos].price = price;
+                         DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)",
+                                     pos, price, opt[pos].litlen);
+             }   }   }
+
+             /* set prices using match at position = cur */
+             {   int const matchML = newMatch.len;
+                 int ml = MINMATCH;
+
+                 assert(cur + newMatch.len < LZ4_OPT_NUM);
+                 for ( ; ml <= matchML ; ml++) {
+                     int const pos = cur + ml;
+                     int const offset = newMatch.off;
+                     int price;
+                     int ll;
+                     DEBUGLOG(7, "testing price rPos %i (last_match_pos=%i)",
+                                 pos, last_match_pos);
+                     if (opt[cur].mlen == 1) {
+                         ll = opt[cur].litlen;
+                         price = ((cur > ll) ? opt[cur - ll].price : 0)
+                               + LZ4HC_sequencePrice(ll, ml);
+                     } else {
+                         ll = 0;
+                         price = opt[cur].price + LZ4HC_sequencePrice(0, ml);
+                     }
+
+                    assert((U32)favorDecSpeed <= 1);
+                     if (pos > last_match_pos+TRAILING_LITERALS
+                      || price <= opt[pos].price - (int)favorDecSpeed) {
+                         DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i)",
+                                     pos, price, ml);
+                         assert(pos < LZ4_OPT_NUM);
+                         if ( (ml == matchML)  /* last pos of last match */
+                           && (last_match_pos < pos) )
+                             last_match_pos = pos;
+                         opt[pos].mlen = ml;
+                         opt[pos].off = offset;
+                         opt[pos].litlen = ll;
+                         opt[pos].price = price;
+             }   }   }
+             /* complete following positions with literals */
+             {   int addLit;
+                 for (addLit = 1; addLit <= TRAILING_LITERALS; addLit ++) {
+                     opt[last_match_pos+addLit].mlen = 1; /* literal */
+                     opt[last_match_pos+addLit].off = 0;
+                     opt[last_match_pos+addLit].litlen = addLit;
+                     opt[last_match_pos+addLit].price = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
+                     DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)", last_match_pos+addLit, opt[last_match_pos+addLit].price, addLit);
+             }   }
+         }  /* for (cur = 1; cur <= last_match_pos; cur++) */
+
+         assert(last_match_pos < LZ4_OPT_NUM + TRAILING_LITERALS);
+         best_mlen = opt[last_match_pos].mlen;
+         best_off = opt[last_match_pos].off;
+         cur = last_match_pos - best_mlen;
+
+encode: /* cur, last_match_pos, best_mlen, best_off must be set */
+         assert(cur < LZ4_OPT_NUM);
+         assert(last_match_pos >= 1);  /* == 1 when only one candidate */
+         DEBUGLOG(6, "reverse traversal, looking for shortest path (last_match_pos=%i)", last_match_pos);
+         {   int candidate_pos = cur;
+             int selected_matchLength = best_mlen;
+             int selected_offset = best_off;
+             while (1) {  /* from end to beginning */
+                 int const next_matchLength = opt[candidate_pos].mlen;  /* can be 1, means literal */
+                 int const next_offset = opt[candidate_pos].off;
+                 DEBUGLOG(7, "pos %i: sequence length %i", candidate_pos, selected_matchLength);
+                 opt[candidate_pos].mlen = selected_matchLength;
+                 opt[candidate_pos].off = selected_offset;
+                 selected_matchLength = next_matchLength;
+                 selected_offset = next_offset;
+                 if (next_matchLength > candidate_pos) break; /* last match elected, first match to encode */
+                 assert(next_matchLength > 0);  /* can be 1, means literal */
+                 candidate_pos -= next_matchLength;
+         }   }
+
+         /* encode all recorded sequences in order */
+         {   int rPos = 0;  /* relative position (to ip) */
+             while (rPos < last_match_pos) {
+                 int const ml = opt[rPos].mlen;
+                 int const offset = opt[rPos].off;
+                 if (ml == 1) { ip++; rPos++; continue; }  /* literal; note: can end up with several literals, in which case, skip them */
+                 rPos += ml;
+                 assert(ml >= MINMATCH);
+                 assert((offset >= 1) && (offset <= LZ4_DISTANCE_MAX));
+                 opSaved = op;
+                 if ( LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), ml, offset, limit, oend) ) {  /* updates ip, op and anchor */
+                     ovml = ml;
+                     ovoff = offset;
+                     goto _dest_overflow;
+         }   }   }
+     }  /* while (ip <= mflimit) */
+
+_last_literals:
+     /* Encode Last Literals */
+     {   size_t lastRunSize = (size_t)(iend - anchor);  /* literals */
+         size_t llAdd = (lastRunSize + 255 - RUN_MASK) / 255;
+         size_t const totalSize = 1 + llAdd + lastRunSize;
+         if (limit == fillOutput) oend += LASTLITERALS;  /* restore correct value */
+         if (limit && (op + totalSize > oend)) {
+             if (limit == limitedOutput) { /* Check output limit */
+                retval = 0;
+                goto _return_label;
+             }
+             /* adapt lastRunSize to fill 'dst' */
+             lastRunSize  = (size_t)(oend - op) - 1 /*token*/;
+             llAdd = (lastRunSize + 256 - RUN_MASK) / 256;
+             lastRunSize -= llAdd;
+         }
+         DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
+         ip = anchor + lastRunSize; /* can be != iend if limit==fillOutput */
+
+         if (lastRunSize >= RUN_MASK) {
+             size_t accumulator = lastRunSize - RUN_MASK;
+             *op++ = (RUN_MASK << ML_BITS);
+             for(; accumulator >= 255 ; accumulator -= 255) *op++ = 255;
+             *op++ = (BYTE) accumulator;
+         } else {
+             *op++ = (BYTE)(lastRunSize << ML_BITS);
+         }
+         LZ4_memcpy(op, anchor, lastRunSize);
+         op += lastRunSize;
+     }
+
+     /* End */
+     *srcSizePtr = (int) (((const char*)ip) - source);
+     retval = (int) ((char*)op-dst);
+     goto _return_label;
+
+_dest_overflow:
+if (limit == fillOutput) {
+     /* Assumption : ip, anchor, ovml and ovref must be set correctly */
+     size_t const ll = (size_t)(ip - anchor);
+     size_t const ll_addbytes = (ll + 240) / 255;
+     size_t const ll_totalCost = 1 + ll_addbytes + ll;
+     BYTE* const maxLitPos = oend - 3; /* 2 for offset, 1 for token */
+     DEBUGLOG(6, "Last sequence overflowing (only %i bytes remaining)", (int)(oend-1-opSaved));
+     op = opSaved;  /* restore correct out pointer */
+     if (op + ll_totalCost <= maxLitPos) {
+         /* ll validated; now adjust match length */
+         size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
+         size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
+         assert(maxMlSize < INT_MAX); assert(ovml >= 0);
+         if ((size_t)ovml > maxMlSize) ovml = (int)maxMlSize;
+         if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + ovml >= MFLIMIT) {
+             DEBUGLOG(6, "Space to end : %i + ml (%i)", (int)((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1), ovml);
+             DEBUGLOG(6, "Before : ip = %p, anchor = %p", ip, anchor);
+             LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), ovml, ovoff, notLimited, oend);
+             DEBUGLOG(6, "After : ip = %p, anchor = %p", ip, anchor);
+     }   }
+     goto _last_literals;
+}
+_return_label:
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+     if (opt) FREEMEM(opt);
+#endif
+     return retval;
+}
+
+
+/***************************************************
+*  Deprecated Functions
+***************************************************/
+
+/* These functions currently generate deprecation warnings */
+
+/* Wrappers for deprecated compression functions */
+int LZ4_compressHC(const char* src, char* dst, int srcSize) { return LZ4_compress_HC (src, dst, srcSize, LZ4_compressBound(srcSize), 0); }
+int LZ4_compressHC_limitedOutput(const char* src, char* dst, int srcSize, int maxDstSize) { return LZ4_compress_HC(src, dst, srcSize, maxDstSize, 0); }
+int LZ4_compressHC2(const char* src, char* dst, int srcSize, int cLevel) { return LZ4_compress_HC (src, dst, srcSize, LZ4_compressBound(srcSize), cLevel); }
+int LZ4_compressHC2_limitedOutput(const char* src, char* dst, int srcSize, int maxDstSize, int cLevel) { return LZ4_compress_HC(src, dst, srcSize, maxDstSize, cLevel); }
+int LZ4_compressHC_withStateHC (void* state, const char* src, char* dst, int srcSize) { return LZ4_compress_HC_extStateHC (state, src, dst, srcSize, LZ4_compressBound(srcSize), 0); }
+int LZ4_compressHC_limitedOutput_withStateHC (void* state, const char* src, char* dst, int srcSize, int maxDstSize) { return LZ4_compress_HC_extStateHC (state, src, dst, srcSize, maxDstSize, 0); }
+int LZ4_compressHC2_withStateHC (void* state, const char* src, char* dst, int srcSize, int cLevel) { return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, LZ4_compressBound(srcSize), cLevel); }
+int LZ4_compressHC2_limitedOutput_withStateHC (void* state, const char* src, char* dst, int srcSize, int maxDstSize, int cLevel) { return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, maxDstSize, cLevel); }
+int LZ4_compressHC_continue (LZ4_streamHC_t* ctx, const char* src, char* dst, int srcSize) { return LZ4_compress_HC_continue (ctx, src, dst, srcSize, LZ4_compressBound(srcSize)); }
+int LZ4_compressHC_limitedOutput_continue (LZ4_streamHC_t* ctx, const char* src, char* dst, int srcSize, int maxDstSize) { return LZ4_compress_HC_continue (ctx, src, dst, srcSize, maxDstSize); }
+
+
+/* Deprecated streaming functions */
+int LZ4_sizeofStreamStateHC(void) { return sizeof(LZ4_streamHC_t); }
+
+/* state is presumed correctly sized, aka >= sizeof(LZ4_streamHC_t)
+ * @return : 0 on success, !=0 if error */
+int LZ4_resetStreamStateHC(void* state, char* inputBuffer)
+{
+    LZ4_streamHC_t* const hc4 = LZ4_initStreamHC(state, sizeof(*hc4));
+    if (hc4 == NULL) return 1;   /* init failed */
+    LZ4HC_init_internal (&hc4->internal_donotuse, (const BYTE*)inputBuffer);
+    return 0;
+}
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+void* LZ4_createHC (const char* inputBuffer)
+{
+    LZ4_streamHC_t* const hc4 = LZ4_createStreamHC();
+    if (hc4 == NULL) return NULL;   /* not enough memory */
+    LZ4HC_init_internal (&hc4->internal_donotuse, (const BYTE*)inputBuffer);
+    return hc4;
+}
+
+int LZ4_freeHC (void* LZ4HC_Data)
+{
+    if (!LZ4HC_Data) return 0;  /* support free on NULL */
+    FREEMEM(LZ4HC_Data);
+    return 0;
+}
+#endif
+
+int LZ4_compressHC2_continue (void* LZ4HC_Data, const char* src, char* dst, int srcSize, int cLevel)
+{
+    return LZ4HC_compress_generic (&((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse, src, dst, &srcSize, 0, cLevel, notLimited);
+}
+
+int LZ4_compressHC2_limitedOutput_continue (void* LZ4HC_Data, const char* src, char* dst, int srcSize, int dstCapacity, int cLevel)
+{
+    return LZ4HC_compress_generic (&((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse, src, dst, &srcSize, dstCapacity, cLevel, limitedOutput);
+}
+
+char* LZ4_slideInputBufferHC(void* LZ4HC_Data)
+{
+    LZ4HC_CCtx_internal* const s = &((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse;
+    const BYTE* const bufferStart = s->prefixStart - s->dictLimit + s->lowLimit;
+    LZ4_resetStreamHC_fast((LZ4_streamHC_t*)LZ4HC_Data, s->compressionLevel);
+    /* ugly conversion trick, required to evade (const char*) -> (char*) cast-qual warning :( */
+    return (char*)(uptrval)bufferStart;
+}

--- a/deps/lz4/lz4hc.h
+++ b/deps/lz4/lz4hc.h
@@ -1,0 +1,414 @@
+/*
+   LZ4 HC - High Compression Mode of LZ4
+   Header File
+   Copyright (C) 2011-2020, Yann Collet.
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - LZ4 source repository : https://github.com/lz4/lz4
+   - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+#ifndef LZ4_HC_H_19834876238432
+#define LZ4_HC_H_19834876238432
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/* --- Dependency --- */
+/* note : lz4hc requires lz4.h/lz4.c for compilation */
+#include "lz4.h"   /* stddef, LZ4LIB_API, LZ4_DEPRECATED */
+
+
+/* --- Useful constants --- */
+#define LZ4HC_CLEVEL_MIN         2
+#define LZ4HC_CLEVEL_DEFAULT     9
+#define LZ4HC_CLEVEL_OPT_MIN    10
+#define LZ4HC_CLEVEL_MAX        12
+
+
+/*-************************************
+ *  Block Compression
+ **************************************/
+/*! LZ4_compress_HC() :
+ *  Compress data from `src` into `dst`, using the powerful but slower "HC" algorithm.
+ * `dst` must be already allocated.
+ *  Compression is guaranteed to succeed if `dstCapacity >= LZ4_compressBound(srcSize)` (see "lz4.h")
+ *  Max supported `srcSize` value is LZ4_MAX_INPUT_SIZE (see "lz4.h")
+ * `compressionLevel` : any value between 1 and LZ4HC_CLEVEL_MAX will work.
+ *                      Values > LZ4HC_CLEVEL_MAX behave the same as LZ4HC_CLEVEL_MAX.
+ * @return : the number of bytes written into 'dst'
+ *           or 0 if compression fails.
+ */
+LZ4LIB_API int LZ4_compress_HC (const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel);
+
+
+/* Note :
+ *   Decompression functions are provided within "lz4.h" (BSD license)
+ */
+
+
+/*! LZ4_compress_HC_extStateHC() :
+ *  Same as LZ4_compress_HC(), but using an externally allocated memory segment for `state`.
+ * `state` size is provided by LZ4_sizeofStateHC().
+ *  Memory segment must be aligned on 8-bytes boundaries (which a normal malloc() should do properly).
+ */
+LZ4LIB_API int LZ4_sizeofStateHC(void);
+LZ4LIB_API int LZ4_compress_HC_extStateHC(void* stateHC, const char* src, char* dst, int srcSize, int maxDstSize, int compressionLevel);
+
+
+/*! LZ4_compress_HC_destSize() : v1.9.0+
+ *  Will compress as much data as possible from `src`
+ *  to fit into `targetDstSize` budget.
+ *  Result is provided in 2 parts :
+ * @return : the number of bytes written into 'dst' (necessarily <= targetDstSize)
+ *           or 0 if compression fails.
+ * `srcSizePtr` : on success, *srcSizePtr is updated to indicate how much bytes were read from `src`
+ */
+LZ4LIB_API int LZ4_compress_HC_destSize(void* stateHC,
+                                  const char* src, char* dst,
+                                        int* srcSizePtr, int targetDstSize,
+                                        int compressionLevel);
+
+
+/*-************************************
+ *  Streaming Compression
+ *  Bufferless synchronous API
+ **************************************/
+ typedef union LZ4_streamHC_u LZ4_streamHC_t;   /* incomplete type (defined later) */
+
+/*! LZ4_createStreamHC() and LZ4_freeStreamHC() :
+ *  These functions create and release memory for LZ4 HC streaming state.
+ *  Newly created states are automatically initialized.
+ *  A same state can be used multiple times consecutively,
+ *  starting with LZ4_resetStreamHC_fast() to start a new stream of blocks.
+ */
+LZ4LIB_API LZ4_streamHC_t* LZ4_createStreamHC(void);
+LZ4LIB_API int             LZ4_freeStreamHC (LZ4_streamHC_t* streamHCPtr);
+
+/*
+  These functions compress data in successive blocks of any size,
+  using previous blocks as dictionary, to improve compression ratio.
+  One key assumption is that previous blocks (up to 64 KB) remain read-accessible while compressing next blocks.
+  There is an exception for ring buffers, which can be smaller than 64 KB.
+  Ring-buffer scenario is automatically detected and handled within LZ4_compress_HC_continue().
+
+  Before starting compression, state must be allocated and properly initialized.
+  LZ4_createStreamHC() does both, though compression level is set to LZ4HC_CLEVEL_DEFAULT.
+
+  Selecting the compression level can be done with LZ4_resetStreamHC_fast() (starts a new stream)
+  or LZ4_setCompressionLevel() (anytime, between blocks in the same stream) (experimental).
+  LZ4_resetStreamHC_fast() only works on states which have been properly initialized at least once,
+  which is automatically the case when state is created using LZ4_createStreamHC().
+
+  After reset, a first "fictional block" can be designated as initial dictionary,
+  using LZ4_loadDictHC() (Optional).
+  Note: In order for LZ4_loadDictHC() to create the correct data structure,
+  it is essential to set the compression level _before_ loading the dictionary.
+
+  Invoke LZ4_compress_HC_continue() to compress each successive block.
+  The number of blocks is unlimited.
+  Previous input blocks, including initial dictionary when present,
+  must remain accessible and unmodified during compression.
+
+  It's allowed to update compression level anytime between blocks,
+  using LZ4_setCompressionLevel() (experimental).
+
+ @dst buffer should be sized to handle worst case scenarios
+  (see LZ4_compressBound(), it ensures compression success).
+  In case of failure, the API does not guarantee recovery,
+  so the state _must_ be reset.
+  To ensure compression success
+  whenever @dst buffer size cannot be made >= LZ4_compressBound(),
+  consider using LZ4_compress_HC_continue_destSize().
+
+  Whenever previous input blocks can't be preserved unmodified in-place during compression of next blocks,
+  it's possible to copy the last blocks into a more stable memory space, using LZ4_saveDictHC().
+  Return value of LZ4_saveDictHC() is the size of dictionary effectively saved into 'safeBuffer' (<= 64 KB)
+
+  After completing a streaming compression,
+  it's possible to start a new stream of blocks, using the same LZ4_streamHC_t state,
+  just by resetting it, using LZ4_resetStreamHC_fast().
+*/
+
+LZ4LIB_API void LZ4_resetStreamHC_fast(LZ4_streamHC_t* streamHCPtr, int compressionLevel);   /* v1.9.0+ */
+LZ4LIB_API int  LZ4_loadDictHC (LZ4_streamHC_t* streamHCPtr, const char* dictionary, int dictSize);
+
+LZ4LIB_API int LZ4_compress_HC_continue (LZ4_streamHC_t* streamHCPtr,
+                                   const char* src, char* dst,
+                                         int srcSize, int maxDstSize);
+
+/*! LZ4_compress_HC_continue_destSize() : v1.9.0+
+ *  Similar to LZ4_compress_HC_continue(),
+ *  but will read as much data as possible from `src`
+ *  to fit into `targetDstSize` budget.
+ *  Result is provided into 2 parts :
+ * @return : the number of bytes written into 'dst' (necessarily <= targetDstSize)
+ *           or 0 if compression fails.
+ * `srcSizePtr` : on success, *srcSizePtr will be updated to indicate how much bytes were read from `src`.
+ *           Note that this function may not consume the entire input.
+ */
+LZ4LIB_API int LZ4_compress_HC_continue_destSize(LZ4_streamHC_t* LZ4_streamHCPtr,
+                                           const char* src, char* dst,
+                                                 int* srcSizePtr, int targetDstSize);
+
+LZ4LIB_API int LZ4_saveDictHC (LZ4_streamHC_t* streamHCPtr, char* safeBuffer, int maxDictSize);
+
+
+/*! LZ4_attach_HC_dictionary() : stable since v1.10.0
+ *  This API allows for the efficient re-use of a static dictionary many times.
+ *
+ *  Rather than re-loading the dictionary buffer into a working context before
+ *  each compression, or copying a pre-loaded dictionary's LZ4_streamHC_t into a
+ *  working LZ4_streamHC_t, this function introduces a no-copy setup mechanism,
+ *  in which the working stream references the dictionary stream in-place.
+ *
+ *  Several assumptions are made about the state of the dictionary stream.
+ *  Currently, only streams which have been prepared by LZ4_loadDictHC() should
+ *  be expected to work.
+ *
+ *  Alternatively, the provided dictionary stream pointer may be NULL, in which
+ *  case any existing dictionary stream is unset.
+ *
+ *  A dictionary should only be attached to a stream without any history (i.e.,
+ *  a stream that has just been reset).
+ *
+ *  The dictionary will remain attached to the working stream only for the
+ *  current stream session. Calls to LZ4_resetStreamHC(_fast) will remove the
+ *  dictionary context association from the working stream. The dictionary
+ *  stream (and source buffer) must remain in-place / accessible / unchanged
+ *  through the lifetime of the stream session.
+ */
+LZ4LIB_API void
+LZ4_attach_HC_dictionary(LZ4_streamHC_t* working_stream,
+                   const LZ4_streamHC_t* dictionary_stream);
+
+
+/*^**********************************************
+ * !!!!!!   STATIC LINKING ONLY   !!!!!!
+ ***********************************************/
+
+/*-******************************************************************
+ * PRIVATE DEFINITIONS :
+ * Do not use these definitions directly.
+ * They are merely exposed to allow static allocation of `LZ4_streamHC_t`.
+ * Declare an `LZ4_streamHC_t` directly, rather than any type below.
+ * Even then, only do so in the context of static linking, as definitions may change between versions.
+ ********************************************************************/
+
+#define LZ4HC_DICTIONARY_LOGSIZE 16
+#define LZ4HC_MAXD (1<<LZ4HC_DICTIONARY_LOGSIZE)
+#define LZ4HC_MAXD_MASK (LZ4HC_MAXD - 1)
+
+#define LZ4HC_HASH_LOG 15
+#define LZ4HC_HASHTABLESIZE (1 << LZ4HC_HASH_LOG)
+#define LZ4HC_HASH_MASK (LZ4HC_HASHTABLESIZE - 1)
+
+
+/* Never ever use these definitions directly !
+ * Declare or allocate an LZ4_streamHC_t instead.
+**/
+typedef struct LZ4HC_CCtx_internal LZ4HC_CCtx_internal;
+struct LZ4HC_CCtx_internal
+{
+    LZ4_u32 hashTable[LZ4HC_HASHTABLESIZE];
+    LZ4_u16 chainTable[LZ4HC_MAXD];
+    const LZ4_byte* end;     /* next block here to continue on current prefix */
+    const LZ4_byte* prefixStart;  /* Indexes relative to this position */
+    const LZ4_byte* dictStart; /* alternate reference for extDict */
+    LZ4_u32 dictLimit;       /* below that point, need extDict */
+    LZ4_u32 lowLimit;        /* below that point, no more history */
+    LZ4_u32 nextToUpdate;    /* index from which to continue dictionary update */
+    short   compressionLevel;
+    LZ4_i8  favorDecSpeed;   /* favor decompression speed if this flag set,
+                                otherwise, favor compression ratio */
+    LZ4_i8  dirty;           /* stream has to be fully reset if this flag is set */
+    const LZ4HC_CCtx_internal* dictCtx;
+};
+
+#define LZ4_STREAMHC_MINSIZE  262200  /* static size, for inter-version compatibility */
+union LZ4_streamHC_u {
+    char minStateSize[LZ4_STREAMHC_MINSIZE];
+    LZ4HC_CCtx_internal internal_donotuse;
+}; /* previously typedef'd to LZ4_streamHC_t */
+
+/* LZ4_streamHC_t :
+ * This structure allows static allocation of LZ4 HC streaming state.
+ * This can be used to allocate statically on stack, or as part of a larger structure.
+ *
+ * Such state **must** be initialized using LZ4_initStreamHC() before first use.
+ *
+ * Note that invoking LZ4_initStreamHC() is not required when
+ * the state was created using LZ4_createStreamHC() (which is recommended).
+ * Using the normal builder, a newly created state is automatically initialized.
+ *
+ * Static allocation shall only be used in combination with static linking.
+ */
+
+/* LZ4_initStreamHC() : v1.9.0+
+ * Required before first use of a statically allocated LZ4_streamHC_t.
+ * Before v1.9.0 : use LZ4_resetStreamHC() instead
+ */
+LZ4LIB_API LZ4_streamHC_t* LZ4_initStreamHC(void* buffer, size_t size);
+
+
+/*-************************************
+*  Deprecated Functions
+**************************************/
+/* see lz4.h LZ4_DISABLE_DEPRECATE_WARNINGS to turn off deprecation warnings */
+
+/* deprecated compression functions */
+LZ4_DEPRECATED("use LZ4_compress_HC() instead") LZ4LIB_API int LZ4_compressHC               (const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_HC() instead") LZ4LIB_API int LZ4_compressHC_limitedOutput (const char* source, char* dest, int inputSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_compress_HC() instead") LZ4LIB_API int LZ4_compressHC2              (const char* source, char* dest, int inputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_compress_HC() instead") LZ4LIB_API int LZ4_compressHC2_limitedOutput(const char* source, char* dest, int inputSize, int maxOutputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_compress_HC_extStateHC() instead") LZ4LIB_API int LZ4_compressHC_withStateHC               (void* state, const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_HC_extStateHC() instead") LZ4LIB_API int LZ4_compressHC_limitedOutput_withStateHC (void* state, const char* source, char* dest, int inputSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_compress_HC_extStateHC() instead") LZ4LIB_API int LZ4_compressHC2_withStateHC              (void* state, const char* source, char* dest, int inputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_compress_HC_extStateHC() instead") LZ4LIB_API int LZ4_compressHC2_limitedOutput_withStateHC(void* state, const char* source, char* dest, int inputSize, int maxOutputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_compress_HC_continue() instead") LZ4LIB_API int LZ4_compressHC_continue               (LZ4_streamHC_t* LZ4_streamHCPtr, const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_HC_continue() instead") LZ4LIB_API int LZ4_compressHC_limitedOutput_continue (LZ4_streamHC_t* LZ4_streamHCPtr, const char* source, char* dest, int inputSize, int maxOutputSize);
+
+/* Obsolete streaming functions; degraded functionality; do not use!
+ *
+ * In order to perform streaming compression, these functions depended on data
+ * that is no longer tracked in the state. They have been preserved as well as
+ * possible: using them will still produce a correct output. However, use of
+ * LZ4_slideInputBufferHC() will truncate the history of the stream, rather
+ * than preserve a window-sized chunk of history.
+ */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_DEPRECATED("use LZ4_createStreamHC() instead") LZ4LIB_API void* LZ4_createHC (const char* inputBuffer);
+LZ4_DEPRECATED("use LZ4_freeStreamHC() instead") LZ4LIB_API   int   LZ4_freeHC (void* LZ4HC_Data);
+#endif
+LZ4_DEPRECATED("use LZ4_saveDictHC() instead") LZ4LIB_API     char* LZ4_slideInputBufferHC (void* LZ4HC_Data);
+LZ4_DEPRECATED("use LZ4_compress_HC_continue() instead") LZ4LIB_API int LZ4_compressHC2_continue               (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_compress_HC_continue() instead") LZ4LIB_API int LZ4_compressHC2_limitedOutput_continue (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int maxOutputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_createStreamHC() instead") LZ4LIB_API int   LZ4_sizeofStreamStateHC(void);
+LZ4_DEPRECATED("use LZ4_initStreamHC() instead") LZ4LIB_API  int   LZ4_resetStreamStateHC(void* state, char* inputBuffer);
+
+
+/* LZ4_resetStreamHC() is now replaced by LZ4_initStreamHC().
+ * The intention is to emphasize the difference with LZ4_resetStreamHC_fast(),
+ * which is now the recommended function to start a new stream of blocks,
+ * but cannot be used to initialize a memory segment containing arbitrary garbage data.
+ *
+ * It is recommended to switch to LZ4_initStreamHC().
+ * LZ4_resetStreamHC() will generate deprecation warnings in a future version.
+ */
+LZ4LIB_API void LZ4_resetStreamHC (LZ4_streamHC_t* streamHCPtr, int compressionLevel);
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* LZ4_HC_H_19834876238432 */
+
+
+/*-**************************************************
+ * !!!!!     STATIC LINKING ONLY     !!!!!
+ * Following definitions are considered experimental.
+ * They should not be linked from DLL,
+ * as there is no guarantee of API stability yet.
+ * Prototypes will be promoted to "stable" status
+ * after successful usage in real-life scenarios.
+ ***************************************************/
+#ifdef LZ4_HC_STATIC_LINKING_ONLY   /* protection macro */
+#ifndef LZ4_HC_SLO_098092834
+#define LZ4_HC_SLO_098092834
+
+#define LZ4_STATIC_LINKING_ONLY   /* LZ4LIB_STATIC_API */
+#include "lz4.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/*! LZ4_setCompressionLevel() : v1.8.0+ (experimental)
+ *  It's possible to change compression level
+ *  between successive invocations of LZ4_compress_HC_continue*()
+ *  for dynamic adaptation.
+ */
+LZ4LIB_STATIC_API void LZ4_setCompressionLevel(
+    LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel);
+
+/*! LZ4_favorDecompressionSpeed() : v1.8.2+ (experimental)
+ *  Opt. Parser will favor decompression speed over compression ratio.
+ *  Only applicable to levels >= LZ4HC_CLEVEL_OPT_MIN.
+ */
+LZ4LIB_STATIC_API void LZ4_favorDecompressionSpeed(
+    LZ4_streamHC_t* LZ4_streamHCPtr, int favor);
+
+/*! LZ4_resetStreamHC_fast() : v1.9.0+
+ *  When an LZ4_streamHC_t is known to be in a internally coherent state,
+ *  it can often be prepared for a new compression with almost no work, only
+ *  sometimes falling back to the full, expensive reset that is always required
+ *  when the stream is in an indeterminate state (i.e., the reset performed by
+ *  LZ4_resetStreamHC()).
+ *
+ *  LZ4_streamHCs are guaranteed to be in a valid state when:
+ *  - returned from LZ4_createStreamHC()
+ *  - reset by LZ4_resetStreamHC()
+ *  - memset(stream, 0, sizeof(LZ4_streamHC_t))
+ *  - the stream was in a valid state and was reset by LZ4_resetStreamHC_fast()
+ *  - the stream was in a valid state and was then used in any compression call
+ *    that returned success
+ *  - the stream was in an indeterminate state and was used in a compression
+ *    call that fully reset the state (LZ4_compress_HC_extStateHC()) and that
+ *    returned success
+ *
+ *  Note:
+ *  A stream that was last used in a compression call that returned an error
+ *  may be passed to this function. However, it will be fully reset, which will
+ *  clear any existing history and settings from the context.
+ */
+LZ4LIB_STATIC_API void LZ4_resetStreamHC_fast(
+    LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel);
+
+/*! LZ4_compress_HC_extStateHC_fastReset() :
+ *  A variant of LZ4_compress_HC_extStateHC().
+ *
+ *  Using this variant avoids an expensive initialization step. It is only safe
+ *  to call if the state buffer is known to be correctly initialized already
+ *  (see above comment on LZ4_resetStreamHC_fast() for a definition of
+ *  "correctly initialized"). From a high level, the difference is that this
+ *  function initializes the provided state with a call to
+ *  LZ4_resetStreamHC_fast() while LZ4_compress_HC_extStateHC() starts with a
+ *  call to LZ4_resetStreamHC().
+ */
+LZ4LIB_STATIC_API int LZ4_compress_HC_extStateHC_fastReset (
+    void* state,
+    const char* src, char* dst,
+    int srcSize, int dstCapacity,
+    int compressionLevel);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif   /* LZ4_HC_SLO_098092834 */
+#endif   /* LZ4_HC_STATIC_LINKING_ONLY */

--- a/deps/lz4/xxhash.c
+++ b/deps/lz4/xxhash.c
@@ -1,0 +1,1032 @@
+/*
+*  xxHash - Fast Hash algorithm
+*  Copyright (C) 2012-2016, Yann Collet
+*
+*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are
+*  met:
+*
+*  * Redistributions of source code must retain the above copyright
+*  notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*  copyright notice, this list of conditions and the following disclaimer
+*  in the documentation and/or other materials provided with the
+*  distribution.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*  You can contact the author at :
+*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+
+/* *************************************
+*  Tuning parameters
+***************************************/
+/*!XXH_FORCE_MEMORY_ACCESS :
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is safe and portable.
+ * Unfortunately, on some target/compiler combinations, the generated assembly is sub-optimal.
+ * The below switch allow to select different access method for improved performance.
+ * Method 0 (default) : use `memcpy()`. Safe and portable.
+ * Method 1 : `__packed` statement. It depends on compiler extension (ie, not portable).
+ *            This method is safe if your compiler supports it, and *generally* as fast or faster than `memcpy`.
+ * Method 2 : direct access. This method doesn't depend on compiler but violate C standard.
+ *            It can generate buggy code on targets which do not support unaligned memory accesses.
+ *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
+ * See http://stackoverflow.com/a/32095106/646947 for details.
+ * Prefer these methods in priority order (0 > 1 > 2)
+ */
+#ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
+#  if defined(__GNUC__) && ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
+                        || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) \
+                        || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+#    define XXH_FORCE_MEMORY_ACCESS 2
+#  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
+  (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
+                    || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
+                    || defined(__ARM_ARCH_7S__) || defined(__aarch64__) ))
+#    define XXH_FORCE_MEMORY_ACCESS 1
+#  endif
+#endif
+
+/*!XXH_ACCEPT_NULL_INPUT_POINTER :
+ * If input pointer is NULL, xxHash default behavior is to dereference it, triggering a segfault.
+ * When this macro is enabled, xxHash actively checks input for null pointer.
+ * It it is, result for null input pointers is the same as a null-length input.
+ */
+#ifndef XXH_ACCEPT_NULL_INPUT_POINTER   /* can be defined externally */
+#  define XXH_ACCEPT_NULL_INPUT_POINTER 0
+#endif
+
+/*!XXH_FORCE_NATIVE_FORMAT :
+ * By default, xxHash library provides endian-independent Hash values, based on little-endian convention.
+ * Results are therefore identical for little-endian and big-endian CPU.
+ * This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
+ * Should endian-independence be of no importance for your application, you may set the #define below to 1,
+ * to improve speed for Big-endian CPU.
+ * This option has no impact on Little_Endian CPU.
+ */
+#ifndef XXH_FORCE_NATIVE_FORMAT   /* can be defined externally */
+#  define XXH_FORCE_NATIVE_FORMAT 0
+#endif
+
+/*!XXH_FORCE_ALIGN_CHECK :
+ * This is a minor performance trick, only useful with lots of very small keys.
+ * It means : check for aligned/unaligned input.
+ * The check costs one initial branch per hash;
+ * set it to 0 when the input is guaranteed to be aligned,
+ * or when alignment doesn't matter for performance.
+ */
+#ifndef XXH_FORCE_ALIGN_CHECK /* can be defined externally */
+#  if defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#    define XXH_FORCE_ALIGN_CHECK 0
+#  elif defined(__aarch64__)
+#    define XXH_FORCE_ALIGN_CHECK 0
+#  else
+#    define XXH_FORCE_ALIGN_CHECK 1
+#  endif
+#endif
+
+
+/* *************************************
+*  Includes & Memory related functions
+***************************************/
+/*! Modify the local functions below should you wish to use some other memory routines
+*   for malloc(), free() */
+#include <stdlib.h>
+static void* XXH_malloc(size_t s) { return malloc(s); }
+static void  XXH_free  (void* p)  { free(p); }
+/*! and for memcpy() */
+#include <string.h>
+static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcpy(dest,src,size); }
+
+#include <assert.h>   /* assert */
+
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
+
+
+/* *************************************
+*  Compiler Specific Options
+***************************************/
+#if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
+#  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
+#  define FORCE_INLINE static __forceinline
+#else
+#  if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#    if defined (__GNUC__) || defined (__clang__)
+#      define FORCE_INLINE static inline __attribute__((always_inline))
+#    else
+#      define FORCE_INLINE static inline
+#    endif
+#  else
+#    define FORCE_INLINE static
+#  endif /* __STDC_VERSION__ */
+#endif
+
+
+/* *************************************
+*  Basic Types
+***************************************/
+#ifndef MEM_MODULE
+# if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint8_t  BYTE;
+    typedef uint16_t U16;
+    typedef uint32_t U32;
+# else
+    typedef unsigned char      BYTE;
+    typedef unsigned short     U16;
+    typedef unsigned int       U32;
+# endif
+#endif
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static U32 XXH_read32(const void* memPtr) { return *(const U32*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+typedef union { U32 u32; } __attribute__((packed)) unalign;
+static U32 XXH_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+static U32 XXH_read32(const void* memPtr)
+{
+    U32 val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+
+/* ****************************************
+*  Compiler-specific Functions and Macros
+******************************************/
+#define XXH_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+
+/* Note : although _rotl exists for minGW (GCC under windows), performance seems poor */
+#if defined(_MSC_VER)
+#  define XXH_rotl32(x,r) _rotl(x,r)
+#  define XXH_rotl64(x,r) _rotl64(x,r)
+#else
+#  define XXH_rotl32(x,r) ((x << r) | (x >> (32 - r)))
+#  define XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
+#endif
+
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap32 _byteswap_ulong
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap32 __builtin_bswap32
+#else
+static U32 XXH_swap32 (U32 x)
+{
+    return  ((x << 24) & 0xff000000 ) |
+            ((x <<  8) & 0x00ff0000 ) |
+            ((x >>  8) & 0x0000ff00 ) |
+            ((x >> 24) & 0x000000ff );
+}
+#endif
+
+
+/* *************************************
+*  Architecture Macros
+***************************************/
+typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianness;
+
+/* XXH_CPU_LITTLE_ENDIAN can be defined externally, for example on the compiler command line */
+#ifndef XXH_CPU_LITTLE_ENDIAN
+static int XXH_isLittleEndian(void)
+{
+    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental  */
+    return one.c[0];
+}
+#   define XXH_CPU_LITTLE_ENDIAN   XXH_isLittleEndian()
+#endif
+
+
+/* ***************************
+*  Memory reads
+*****************************/
+typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
+
+FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_endianness endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+    else
+        return endian==XXH_littleEndian ? *(const U32*)ptr : XXH_swap32(*(const U32*)ptr);
+}
+
+FORCE_INLINE U32 XXH_readLE32(const void* ptr, XXH_endianness endian)
+{
+    return XXH_readLE32_align(ptr, endian, XXH_unaligned);
+}
+
+static U32 XXH_readBE32(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+}
+
+
+/* *************************************
+*  Macros
+***************************************/
+#define XXH_STATIC_ASSERT(c)  { enum { XXH_sa = 1/(int)(!!(c)) }; }  /* use after variable declarations */
+XXH_PUBLIC_API unsigned XXH_versionNumber (void) { return XXH_VERSION_NUMBER; }
+
+
+/* *******************************************************************
+*  32-bit hash functions
+*********************************************************************/
+static const U32 PRIME32_1 = 2654435761U;
+static const U32 PRIME32_2 = 2246822519U;
+static const U32 PRIME32_3 = 3266489917U;
+static const U32 PRIME32_4 =  668265263U;
+static const U32 PRIME32_5 =  374761393U;
+
+static U32 XXH32_round(U32 seed, U32 input)
+{
+    seed += input * PRIME32_2;
+    seed  = XXH_rotl32(seed, 13);
+    seed *= PRIME32_1;
+    return seed;
+}
+
+/* mix all bits */
+static U32 XXH32_avalanche(U32 h32)
+{
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+    return(h32);
+}
+
+#define XXH_get32bits(p) XXH_readLE32_align(p, endian, align)
+
+static U32
+XXH32_finalize(U32 h32, const void* ptr, size_t len,
+                XXH_endianness endian, XXH_alignment align)
+
+{
+    const BYTE* p = (const BYTE*)ptr;
+
+#define PROCESS1               \
+    h32 += (*p++) * PRIME32_5; \
+    h32 = XXH_rotl32(h32, 11) * PRIME32_1 ;
+
+#define PROCESS4                         \
+    h32 += XXH_get32bits(p) * PRIME32_3; \
+    p+=4;                                \
+    h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
+
+    switch(len&15)  /* or switch(bEnd - p) */
+    {
+      case 12:      PROCESS4;
+                    /* fallthrough */
+      case 8:       PROCESS4;
+                    /* fallthrough */
+      case 4:       PROCESS4;
+                    return XXH32_avalanche(h32);
+
+      case 13:      PROCESS4;
+                    /* fallthrough */
+      case 9:       PROCESS4;
+                    /* fallthrough */
+      case 5:       PROCESS4;
+                    PROCESS1;
+                    return XXH32_avalanche(h32);
+
+      case 14:      PROCESS4;
+                    /* fallthrough */
+      case 10:      PROCESS4;
+                    /* fallthrough */
+      case 6:       PROCESS4;
+                    PROCESS1;
+                    PROCESS1;
+                    return XXH32_avalanche(h32);
+
+      case 15:      PROCESS4;
+                    /* fallthrough */
+      case 11:      PROCESS4;
+                    /* fallthrough */
+      case 7:       PROCESS4;
+                    /* fallthrough */
+      case 3:       PROCESS1;
+                    /* fallthrough */
+      case 2:       PROCESS1;
+                    /* fallthrough */
+      case 1:       PROCESS1;
+                    /* fallthrough */
+      case 0:       return XXH32_avalanche(h32);
+    }
+    assert(0);
+    return h32;   /* reaching this point is deemed impossible */
+}
+
+
+FORCE_INLINE U32
+XXH32_endian_align(const void* input, size_t len, U32 seed,
+                    XXH_endianness endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U32 h32;
+
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+    if (p==NULL) {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)16;
+    }
+#endif
+
+    if (len>=16) {
+        const BYTE* const limit = bEnd - 15;
+        U32 v1 = seed + PRIME32_1 + PRIME32_2;
+        U32 v2 = seed + PRIME32_2;
+        U32 v3 = seed + 0;
+        U32 v4 = seed - PRIME32_1;
+
+        do {
+            v1 = XXH32_round(v1, XXH_get32bits(p)); p+=4;
+            v2 = XXH32_round(v2, XXH_get32bits(p)); p+=4;
+            v3 = XXH32_round(v3, XXH_get32bits(p)); p+=4;
+            v4 = XXH32_round(v4, XXH_get32bits(p)); p+=4;
+        } while (p < limit);
+
+        h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
+            + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    } else {
+        h32  = seed + PRIME32_5;
+    }
+
+    h32 += (U32)len;
+
+    return XXH32_finalize(h32, p, len&15, endian, align);
+}
+
+
+XXH_PUBLIC_API unsigned int XXH32 (const void* input, size_t len, unsigned int seed)
+{
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH32_state_t state;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, input, len);
+    return XXH32_digest(&state);
+#else
+    XXH_endianness endian_detected = (XXH_endianness)XXH_CPU_LITTLE_ENDIAN;
+
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
+            if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+                return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+            else
+                return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }   }
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+
+
+/*======   Hash streaming   ======*/
+
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void)
+{
+    return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t* srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int seed)
+{
+    XXH32_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
+    memset(&state, 0, sizeof(state));
+    state.v1 = seed + PRIME32_1 + PRIME32_2;
+    state.v2 = seed + PRIME32_2;
+    state.v3 = seed + 0;
+    state.v4 = seed - PRIME32_1;
+    /* do not write into reserved, planned to be removed in a future version */
+    memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
+    return XXH_OK;
+}
+
+
+FORCE_INLINE XXH_errorcode
+XXH32_update_endian(XXH32_state_t* state, const void* input, size_t len, XXH_endianness endian)
+{
+    if (input==NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+        return XXH_OK;
+#else
+        return XXH_ERROR;
+#endif
+
+    {   const BYTE* p = (const BYTE*)input;
+        const BYTE* const bEnd = p + len;
+
+        state->total_len_32 += (unsigned)len;
+        state->large_len |= (len>=16) | (state->total_len_32>=16);
+
+        if (state->memsize + len < 16)  {   /* fill in tmp buffer */
+            XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
+            state->memsize += (unsigned)len;
+            return XXH_OK;
+        }
+
+        if (state->memsize) {   /* some data left from previous update */
+            XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16-state->memsize);
+            {   const U32* p32 = state->mem32;
+                state->v1 = XXH32_round(state->v1, XXH_readLE32(p32, endian)); p32++;
+                state->v2 = XXH32_round(state->v2, XXH_readLE32(p32, endian)); p32++;
+                state->v3 = XXH32_round(state->v3, XXH_readLE32(p32, endian)); p32++;
+                state->v4 = XXH32_round(state->v4, XXH_readLE32(p32, endian));
+            }
+            p += 16-state->memsize;
+            state->memsize = 0;
+        }
+
+        if (p <= bEnd-16) {
+            const BYTE* const limit = bEnd - 16;
+            U32 v1 = state->v1;
+            U32 v2 = state->v2;
+            U32 v3 = state->v3;
+            U32 v4 = state->v4;
+
+            do {
+                v1 = XXH32_round(v1, XXH_readLE32(p, endian)); p+=4;
+                v2 = XXH32_round(v2, XXH_readLE32(p, endian)); p+=4;
+                v3 = XXH32_round(v3, XXH_readLE32(p, endian)); p+=4;
+                v4 = XXH32_round(v4, XXH_readLE32(p, endian)); p+=4;
+            } while (p<=limit);
+
+            state->v1 = v1;
+            state->v2 = v2;
+            state->v3 = v3;
+            state->v4 = v4;
+        }
+
+        if (p < bEnd) {
+            XXH_memcpy(state->mem32, p, (size_t)(bEnd-p));
+            state->memsize = (unsigned)(bEnd-p);
+        }
+    }
+
+    return XXH_OK;
+}
+
+
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianness endian_detected = (XXH_endianness)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH32_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+FORCE_INLINE U32
+XXH32_digest_endian (const XXH32_state_t* state, XXH_endianness endian)
+{
+    U32 h32;
+
+    if (state->large_len) {
+        h32 = XXH_rotl32(state->v1, 1)
+            + XXH_rotl32(state->v2, 7)
+            + XXH_rotl32(state->v3, 12)
+            + XXH_rotl32(state->v4, 18);
+    } else {
+        h32 = state->v3 /* == seed */ + PRIME32_5;
+    }
+
+    h32 += state->total_len_32;
+
+    return XXH32_finalize(h32, state->mem32, state->memsize, endian, XXH_aligned);
+}
+
+
+XXH_PUBLIC_API unsigned int XXH32_digest (const XXH32_state_t* state_in)
+{
+    XXH_endianness endian_detected = (XXH_endianness)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH32_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+/*======   Canonical representation   ======*/
+
+/*! Default XXH result types are basic unsigned 32 and 64 bits.
+*   The canonical representation follows human-readable write convention, aka big-endian (large digits first).
+*   These functions allow transformation of hash result into and from its canonical format.
+*   This way, hash values can be written into a file or buffer, remaining comparable across different systems.
+*/
+
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH32_canonical_t) == sizeof(XXH32_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+    memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src)
+{
+    return XXH_readBE32(src);
+}
+
+
+#ifndef XXH_NO_LONG_LONG
+
+/* *******************************************************************
+*  64-bit hash functions
+*********************************************************************/
+
+/*======   Memory access   ======*/
+
+#ifndef MEM_MODULE
+# define MEM_MODULE
+# if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint64_t U64;
+# else
+    /* if compiler doesn't support unsigned long long, replace by another 64-bit type */
+    typedef unsigned long long U64;
+# endif
+#endif
+
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static U64 XXH_read64(const void* memPtr) { return *(const U64*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+typedef union { U32 u32; U64 u64; } __attribute__((packed)) unalign64;
+static U64 XXH_read64(const void* ptr) { return ((const unalign64*)ptr)->u64; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+
+static U64 XXH_read64(const void* memPtr)
+{
+    U64 val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap64 _byteswap_uint64
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap64 __builtin_bswap64
+#else
+static U64 XXH_swap64 (U64 x)
+{
+    return  ((x << 56) & 0xff00000000000000ULL) |
+            ((x << 40) & 0x00ff000000000000ULL) |
+            ((x << 24) & 0x0000ff0000000000ULL) |
+            ((x << 8)  & 0x000000ff00000000ULL) |
+            ((x >> 8)  & 0x00000000ff000000ULL) |
+            ((x >> 24) & 0x0000000000ff0000ULL) |
+            ((x >> 40) & 0x000000000000ff00ULL) |
+            ((x >> 56) & 0x00000000000000ffULL);
+}
+#endif
+
+FORCE_INLINE U64 XXH_readLE64_align(const void* ptr, XXH_endianness endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+    else
+        return endian==XXH_littleEndian ? *(const U64*)ptr : XXH_swap64(*(const U64*)ptr);
+}
+
+FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianness endian)
+{
+    return XXH_readLE64_align(ptr, endian, XXH_unaligned);
+}
+
+static U64 XXH_readBE64(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
+}
+
+
+/*======   xxh64   ======*/
+
+static const U64 PRIME64_1 = 11400714785074694791ULL;
+static const U64 PRIME64_2 = 14029467366897019727ULL;
+static const U64 PRIME64_3 =  1609587929392839161ULL;
+static const U64 PRIME64_4 =  9650029242287828579ULL;
+static const U64 PRIME64_5 =  2870177450012600261ULL;
+
+static U64 XXH64_round(U64 acc, U64 input)
+{
+    acc += input * PRIME64_2;
+    acc  = XXH_rotl64(acc, 31);
+    acc *= PRIME64_1;
+    return acc;
+}
+
+static U64 XXH64_mergeRound(U64 acc, U64 val)
+{
+    val  = XXH64_round(0, val);
+    acc ^= val;
+    acc  = acc * PRIME64_1 + PRIME64_4;
+    return acc;
+}
+
+static U64 XXH64_avalanche(U64 h64)
+{
+    h64 ^= h64 >> 33;
+    h64 *= PRIME64_2;
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+    return h64;
+}
+
+
+#define XXH_get64bits(p) XXH_readLE64_align(p, endian, align)
+
+static U64
+XXH64_finalize(U64 h64, const void* ptr, size_t len,
+               XXH_endianness endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)ptr;
+
+#define PROCESS1_64            \
+    h64 ^= (*p++) * PRIME64_5; \
+    h64 = XXH_rotl64(h64, 11) * PRIME64_1;
+
+#define PROCESS4_64          \
+    h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1; \
+    p+=4;                    \
+    h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+
+#define PROCESS8_64 {        \
+    U64 const k1 = XXH64_round(0, XXH_get64bits(p)); \
+    p+=8;                    \
+    h64 ^= k1;               \
+    h64  = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4; \
+}
+
+    switch(len&31) {
+      case 24: PROCESS8_64;
+                    /* fallthrough */
+      case 16: PROCESS8_64;
+                    /* fallthrough */
+      case  8: PROCESS8_64;
+               return XXH64_avalanche(h64);
+
+      case 28: PROCESS8_64;
+                    /* fallthrough */
+      case 20: PROCESS8_64;
+                    /* fallthrough */
+      case 12: PROCESS8_64;
+                    /* fallthrough */
+      case  4: PROCESS4_64;
+               return XXH64_avalanche(h64);
+
+      case 25: PROCESS8_64;
+                    /* fallthrough */
+      case 17: PROCESS8_64;
+                    /* fallthrough */
+      case  9: PROCESS8_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 29: PROCESS8_64;
+                    /* fallthrough */
+      case 21: PROCESS8_64;
+                    /* fallthrough */
+      case 13: PROCESS8_64;
+                    /* fallthrough */
+      case  5: PROCESS4_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 26: PROCESS8_64;
+                    /* fallthrough */
+      case 18: PROCESS8_64;
+                    /* fallthrough */
+      case 10: PROCESS8_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 30: PROCESS8_64;
+                    /* fallthrough */
+      case 22: PROCESS8_64;
+                    /* fallthrough */
+      case 14: PROCESS8_64;
+                    /* fallthrough */
+      case  6: PROCESS4_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 27: PROCESS8_64;
+                    /* fallthrough */
+      case 19: PROCESS8_64;
+                    /* fallthrough */
+      case 11: PROCESS8_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               PROCESS1_64;
+               return XXH64_avalanche(h64);
+
+      case 31: PROCESS8_64;
+                    /* fallthrough */
+      case 23: PROCESS8_64;
+                    /* fallthrough */
+      case 15: PROCESS8_64;
+                    /* fallthrough */
+      case  7: PROCESS4_64;
+                    /* fallthrough */
+      case  3: PROCESS1_64;
+                    /* fallthrough */
+      case  2: PROCESS1_64;
+                    /* fallthrough */
+      case  1: PROCESS1_64;
+                    /* fallthrough */
+      case  0: return XXH64_avalanche(h64);
+    }
+
+    /* impossible to reach */
+    assert(0);
+    return 0;  /* unreachable, but some compilers complain without it */
+}
+
+FORCE_INLINE U64
+XXH64_endian_align(const void* input, size_t len, U64 seed,
+                XXH_endianness endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U64 h64;
+
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+    if (p==NULL) {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)32;
+    }
+#endif
+
+    if (len>=32) {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = seed + PRIME64_1 + PRIME64_2;
+        U64 v2 = seed + PRIME64_2;
+        U64 v3 = seed + 0;
+        U64 v4 = seed - PRIME64_1;
+
+        do {
+            v1 = XXH64_round(v1, XXH_get64bits(p)); p+=8;
+            v2 = XXH64_round(v2, XXH_get64bits(p)); p+=8;
+            v3 = XXH64_round(v3, XXH_get64bits(p)); p+=8;
+            v4 = XXH64_round(v4, XXH_get64bits(p)); p+=8;
+        } while (p<=limit);
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+
+    } else {
+        h64  = seed + PRIME64_5;
+    }
+
+    h64 += (U64) len;
+
+    return XXH64_finalize(h64, p, len, endian, align);
+}
+
+
+XXH_PUBLIC_API unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
+{
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH64_state_t state;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, input, len);
+    return XXH64_digest(&state);
+#else
+    XXH_endianness endian_detected = (XXH_endianness)XXH_CPU_LITTLE_ENDIAN;
+
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
+            if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+                return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+            else
+                return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }   }
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+/*======   Hash Streaming   ======*/
+
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void)
+{
+    return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dstState, const XXH64_state_t* srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long long seed)
+{
+    XXH64_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
+    memset(&state, 0, sizeof(state));
+    state.v1 = seed + PRIME64_1 + PRIME64_2;
+    state.v2 = seed + PRIME64_2;
+    state.v3 = seed + 0;
+    state.v4 = seed - PRIME64_1;
+     /* do not write into reserved, planned to be removed in a future version */
+    memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
+    return XXH_OK;
+}
+
+FORCE_INLINE XXH_errorcode
+XXH64_update_endian (XXH64_state_t* state, const void* input, size_t len, XXH_endianness endian)
+{
+    if (input==NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+        return XXH_OK;
+#else
+        return XXH_ERROR;
+#endif
+
+    {   const BYTE* p = (const BYTE*)input;
+        const BYTE* const bEnd = p + len;
+
+        state->total_len += len;
+
+        if (state->memsize + len < 32) {  /* fill in tmp buffer */
+            XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
+            state->memsize += (U32)len;
+            return XXH_OK;
+        }
+
+        if (state->memsize) {   /* tmp buffer is full */
+            XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32-state->memsize);
+            state->v1 = XXH64_round(state->v1, XXH_readLE64(state->mem64+0, endian));
+            state->v2 = XXH64_round(state->v2, XXH_readLE64(state->mem64+1, endian));
+            state->v3 = XXH64_round(state->v3, XXH_readLE64(state->mem64+2, endian));
+            state->v4 = XXH64_round(state->v4, XXH_readLE64(state->mem64+3, endian));
+            p += 32-state->memsize;
+            state->memsize = 0;
+        }
+
+        if (p+32 <= bEnd) {
+            const BYTE* const limit = bEnd - 32;
+            U64 v1 = state->v1;
+            U64 v2 = state->v2;
+            U64 v3 = state->v3;
+            U64 v4 = state->v4;
+
+            do {
+                v1 = XXH64_round(v1, XXH_readLE64(p, endian)); p+=8;
+                v2 = XXH64_round(v2, XXH_readLE64(p, endian)); p+=8;
+                v3 = XXH64_round(v3, XXH_readLE64(p, endian)); p+=8;
+                v4 = XXH64_round(v4, XXH_readLE64(p, endian)); p+=8;
+            } while (p<=limit);
+
+            state->v1 = v1;
+            state->v2 = v2;
+            state->v3 = v3;
+            state->v4 = v4;
+        }
+
+        if (p < bEnd) {
+            XXH_memcpy(state->mem64, p, (size_t)(bEnd-p));
+            state->memsize = (unsigned)(bEnd-p);
+        }
+    }
+
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianness endian_detected = (XXH_endianness)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH64_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state, XXH_endianness endian)
+{
+    U64 h64;
+
+    if (state->total_len >= 32) {
+        U64 const v1 = state->v1;
+        U64 const v2 = state->v2;
+        U64 const v3 = state->v3;
+        U64 const v4 = state->v4;
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+    } else {
+        h64  = state->v3 /*seed*/ + PRIME64_5;
+    }
+
+    h64 += (U64) state->total_len;
+
+    return XXH64_finalize(h64, state->mem64, (size_t)state->total_len, endian, XXH_aligned);
+}
+
+XXH_PUBLIC_API unsigned long long XXH64_digest (const XXH64_state_t* state_in)
+{
+    XXH_endianness endian_detected = (XXH_endianness)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH64_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+/*====== Canonical representation   ======*/
+
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH64_canonical_t) == sizeof(XXH64_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+    memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src)
+{
+    return XXH_readBE64(src);
+}
+
+#endif  /* XXH_NO_LONG_LONG */

--- a/deps/lz4/xxhash.h
+++ b/deps/lz4/xxhash.h
@@ -1,0 +1,328 @@
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Header File
+   Copyright (C) 2012-2016, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* Notice extracted from xxHash homepage :
+
+xxHash is an extremely fast Hash algorithm, running at RAM speed limits.
+It also successfully passes all tests from the SMHasher suite.
+
+Comparison (single thread, Windows Seven 32 bits, using SMHasher on a Core 2 Duo @3GHz)
+
+Name            Speed       Q.Score   Author
+xxHash          5.4 GB/s     10
+CrapWow         3.2 GB/s      2       Andrew
+MumurHash 3a    2.7 GB/s     10       Austin Appleby
+SpookyHash      2.0 GB/s     10       Bob Jenkins
+SBox            1.4 GB/s      9       Bret Mulvey
+Lookup3         1.2 GB/s      9       Bob Jenkins
+SuperFastHash   1.2 GB/s      1       Paul Hsieh
+CityHash64      1.05 GB/s    10       Pike & Alakuijala
+FNV             0.55 GB/s     5       Fowler, Noll, Vo
+CRC32           0.43 GB/s     9
+MD5-32          0.33 GB/s    10       Ronald L. Rivest
+SHA1-32         0.28 GB/s    10
+
+Q.Score is a measure of quality of the hash function.
+It depends on successfully passing SMHasher test set.
+10 is a perfect score.
+
+A 64-bit version, named XXH64, is available since r35.
+It offers much better speed, but for 64-bit applications only.
+Name     Speed on 64 bits    Speed on 32 bits
+XXH64       13.8 GB/s            1.9 GB/s
+XXH32        6.8 GB/s            6.0 GB/s
+*/
+
+#ifndef XXHASH_H_5627135585666179
+#define XXHASH_H_5627135585666179 1
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+
+/* ****************************
+*  Definitions
+******************************/
+#include <stddef.h>   /* size_t */
+typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
+
+
+/* ****************************
+ *  API modifier
+ ******************************/
+/** XXH_INLINE_ALL (and XXH_PRIVATE_API)
+ *  This is useful to include xxhash functions in `static` mode
+ *  in order to inline them, and remove their symbol from the public list.
+ *  Inlining can offer dramatic performance improvement on small keys.
+ *  Methodology :
+ *     #define XXH_INLINE_ALL
+ *     #include "xxhash.h"
+ * `xxhash.c` is automatically included.
+ *  It's not useful to compile and link it as a separate module.
+ */
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  ifndef XXH_STATIC_LINKING_ONLY
+#    define XXH_STATIC_LINKING_ONLY
+#  endif
+#  if defined(__GNUC__)
+#    define XXH_PUBLIC_API static __inline __attribute__((unused))
+#  elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#    define XXH_PUBLIC_API static inline
+#  elif defined(_MSC_VER)
+#    define XXH_PUBLIC_API static __inline
+#  else
+     /* this version may generate warnings for unused static functions */
+#    define XXH_PUBLIC_API static
+#  endif
+#else
+#  define XXH_PUBLIC_API   /* do nothing */
+#endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
+
+/*! XXH_NAMESPACE, aka Namespace Emulation :
+ *
+ * If you want to include _and expose_ xxHash functions from within your own library,
+ * but also want to avoid symbol collisions with other libraries which may also include xxHash,
+ *
+ * you can use XXH_NAMESPACE, to automatically prefix any public symbol from xxhash library
+ * with the value of XXH_NAMESPACE (therefore, avoid NULL and numeric values).
+ *
+ * Note that no change is required within the calling program as long as it includes `xxhash.h` :
+ * regular symbol name will be automatically translated by this header.
+ */
+#ifdef XXH_NAMESPACE
+#  define XXH_CAT(A,B) A##B
+#  define XXH_NAME2(A,B) XXH_CAT(A,B)
+#  define XXH_versionNumber XXH_NAME2(XXH_NAMESPACE, XXH_versionNumber)
+#  define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
+#  define XXH32_createState XXH_NAME2(XXH_NAMESPACE, XXH32_createState)
+#  define XXH32_freeState XXH_NAME2(XXH_NAMESPACE, XXH32_freeState)
+#  define XXH32_reset XXH_NAME2(XXH_NAMESPACE, XXH32_reset)
+#  define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
+#  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
+#  define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
+#  define XXH32_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH32_canonicalFromHash)
+#  define XXH32_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH32_hashFromCanonical)
+#  define XXH64 XXH_NAME2(XXH_NAMESPACE, XXH64)
+#  define XXH64_createState XXH_NAME2(XXH_NAMESPACE, XXH64_createState)
+#  define XXH64_freeState XXH_NAME2(XXH_NAMESPACE, XXH64_freeState)
+#  define XXH64_reset XXH_NAME2(XXH_NAMESPACE, XXH64_reset)
+#  define XXH64_update XXH_NAME2(XXH_NAMESPACE, XXH64_update)
+#  define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
+#  define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
+#  define XXH64_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH64_canonicalFromHash)
+#  define XXH64_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH64_hashFromCanonical)
+#endif
+
+
+/* *************************************
+*  Version
+***************************************/
+#define XXH_VERSION_MAJOR    0
+#define XXH_VERSION_MINOR    6
+#define XXH_VERSION_RELEASE  5
+#define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
+XXH_PUBLIC_API unsigned XXH_versionNumber (void);
+
+
+/*-**********************************************************************
+*  32-bit hash
+************************************************************************/
+typedef unsigned int XXH32_hash_t;
+
+/*! XXH32() :
+    Calculate the 32-bit hash of sequence "length" bytes stored at memory address "input".
+    The memory between input & input+length must be valid (allocated and read-accessible).
+    "seed" can be used to alter the result predictably.
+    Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s */
+XXH_PUBLIC_API XXH32_hash_t XXH32 (const void* input, size_t length, unsigned int seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH32_state_s XXH32_state_t;   /* incomplete type */
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void);
+XXH_PUBLIC_API XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dst_state, const XXH32_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, unsigned int seed);
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH32_hash_t  XXH32_digest (const XXH32_state_t* statePtr);
+
+/*
+ * Streaming functions generate the xxHash of an input provided in multiple segments.
+ * Note that, for small input, they are slower than single-call functions, due to state management.
+ * For small inputs, prefer `XXH32()` and `XXH64()`, which are better optimized.
+ *
+ * XXH state must first be allocated, using XXH*_createState() .
+ *
+ * Start a new hash by initializing state with a seed, using XXH*_reset().
+ *
+ * Then, feed the hash state by calling XXH*_update() as many times as necessary.
+ * The function returns an error code, with 0 meaning OK, and any other value meaning there is an error.
+ *
+ * Finally, a hash value can be produced anytime, by using XXH*_digest().
+ * This function returns the nn-bits hash as an int or long long.
+ *
+ * It's still possible to continue inserting input into the hash state after a digest,
+ * and generate some new hashes later on, by calling again XXH*_digest().
+ *
+ * When done, free XXH state space if it was allocated dynamically.
+ */
+
+/*======   Canonical representation   ======*/
+
+typedef struct { unsigned char digest[4]; } XXH32_canonical_t;
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash);
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src);
+
+/* Default result type for XXH functions are primitive unsigned 32 and 64 bits.
+ * The canonical representation uses human-readable write convention, aka big-endian (large digits first).
+ * These functions allow transformation of hash result into and from its canonical format.
+ * This way, hash values can be written into a file / memory, and remain comparable on different systems and programs.
+ */
+
+
+#ifndef XXH_NO_LONG_LONG
+/*-**********************************************************************
+*  64-bit hash
+************************************************************************/
+typedef unsigned long long XXH64_hash_t;
+
+/*! XXH64() :
+    Calculate the 64-bit hash of sequence of length "len" stored at memory address "input".
+    "seed" can be used to alter the result predictably.
+    This function runs faster on 64-bit systems, but slower on 32-bit systems (see benchmark).
+*/
+XXH_PUBLIC_API XXH64_hash_t XXH64 (const void* input, size_t length, unsigned long long seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH64_state_s XXH64_state_t;   /* incomplete type */
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void);
+XXH_PUBLIC_API XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dst_state, const XXH64_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH64_hash_t  XXH64_digest (const XXH64_state_t* statePtr);
+
+/*======   Canonical representation   ======*/
+typedef struct { unsigned char digest[8]; } XXH64_canonical_t;
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash);
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src);
+#endif  /* XXH_NO_LONG_LONG */
+
+
+
+#ifdef XXH_STATIC_LINKING_ONLY
+
+/* ================================================================================================
+   This section contains declarations which are not guaranteed to remain stable.
+   They may change in future versions, becoming incompatible with a different version of the library.
+   These declarations should only be used with static linking.
+   Never use them in association with dynamic linking !
+=================================================================================================== */
+
+/* These definitions are only present to allow
+ * static allocation of XXH state, on stack or in a struct for example.
+ * Never **ever** use members directly. */
+
+#if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+
+struct XXH32_state_s {
+   uint32_t total_len_32;
+   uint32_t large_len;
+   uint32_t v1;
+   uint32_t v2;
+   uint32_t v3;
+   uint32_t v4;
+   uint32_t mem32[4];
+   uint32_t memsize;
+   uint32_t reserved;   /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH32_state_t */
+
+struct XXH64_state_s {
+   uint64_t total_len;
+   uint64_t v1;
+   uint64_t v2;
+   uint64_t v3;
+   uint64_t v4;
+   uint64_t mem64[4];
+   uint32_t memsize;
+   uint32_t reserved[2];          /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH64_state_t */
+
+# else
+
+struct XXH32_state_s {
+   unsigned total_len_32;
+   unsigned large_len;
+   unsigned v1;
+   unsigned v2;
+   unsigned v3;
+   unsigned v4;
+   unsigned mem32[4];
+   unsigned memsize;
+   unsigned reserved;   /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH32_state_t */
+
+#   ifndef XXH_NO_LONG_LONG  /* remove 64-bit support */
+struct XXH64_state_s {
+   unsigned long long total_len;
+   unsigned long long v1;
+   unsigned long long v2;
+   unsigned long long v3;
+   unsigned long long v4;
+   unsigned long long mem64[4];
+   unsigned memsize;
+   unsigned reserved[2];     /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH64_state_t */
+#    endif
+
+# endif
+
+
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  include "xxhash.c"   /* include xxhash function bodies as `static`, for inlining */
+#endif
+
+#endif /* XXH_STATIC_LINKING_ONLY */
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* XXHASH_H_5627135585666179 */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ get_valkey_server_linker_option(VALKEY_SERVER_LDFLAGS)
 list(APPEND SERVER_LIBS "fpconv")
 list(APPEND SERVER_LIBS "hdr_histogram")
 list(APPEND SERVER_LIBS "ffc")
+list(APPEND SERVER_LIBS "lz4")
 valkey_build_and_install_bin(valkey-server "${VALKEY_SERVER_SRCS}" "${VALKEY_SERVER_LDFLAGS}" "${SERVER_LIBS}"
                              "redis-server")
 add_dependencies(valkey-server generate_commands_def)

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ endif
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer
 endif
-DEPENDENCY_TARGETS=libvalkey linenoise hdr_histogram fpconv
+DEPENDENCY_TARGETS=libvalkey linenoise hdr_histogram fpconv lz4
 NODEPS:=clean distclean
 
 # Default settings
@@ -256,7 +256,7 @@ ifdef OPENSSL_PREFIX
 endif
 
 # Include paths to dependencies
-FINAL_CFLAGS+= -I../deps/libvalkey/include -I../deps/linenoise -I../deps/hdr_histogram -I../deps/fpconv -I../deps/fast_float
+FINAL_CFLAGS+= -I../deps/libvalkey/include -I../deps/linenoise -I../deps/hdr_histogram -I../deps/fpconv -I../deps/fast_float -I../deps/lz4
 
 # Lua scripting engine module
 ifeq ($(BUILD_LUA),no)
@@ -488,6 +488,10 @@ ENGINE_SERVER_OBJ = \
     cluster_slot_stats.o \
     commandlog.o \
     commands.o \
+    compression.o \
+    compression_lz4.o \
+    compression_stream.o \
+    compression_rio.o \
     config.o \
     connection.o \
     crc16.o \
@@ -639,6 +643,13 @@ ENGINE_LIB_NAME=lib$(ENGINE_NAME).a
 ENGINE_UNIT_GTESTS:=$(ENGINE_NAME)-unit-gtests$(PROG_SUFFIX)
 ALL_SOURCES=$(sort $(patsubst %.o,%.c,$(ENGINE_SERVER_OBJ) $(ENGINE_CLI_OBJ) $(ENGINE_BENCHMARK_OBJ)))
 
+USE_FAST_FLOAT?=no
+ifeq ($(USE_FAST_FLOAT),yes)
+	# valkey_strtod.c embeds the header-only ffc.h implementation, so this
+	# compatibility option only needs the preprocessor define.
+	FINAL_CFLAGS += -D USE_FAST_FLOAT
+endif
+
 USE_LIBBACKTRACE?=no
 ifeq ($(USE_LIBBACKTRACE),yes)
 	FINAL_CFLAGS += -DUSE_LIBBACKTRACE
@@ -670,7 +681,8 @@ endif
 all-with-unit-tests: all $(ENGINE_UNIT_GTESTS)
 .PHONY: all
 
-persist-settings: distclean
+write-make-settings:
+	rm -f .make-settings
 	echo STD=$(STD) >> .make-settings
 	echo WARN=$(WARN) >> .make-settings
 	echo OPT=$(OPT) >> .make-settings
@@ -680,6 +692,7 @@ persist-settings: distclean
 	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
 	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
 	echo BUILD_LUA=$(BUILD_LUA) >> .make-settings
+	echo USE_FAST_FLOAT=$(USE_FAST_FLOAT) >> .make-settings
 	echo USE_LIBBACKTRACE=$(USE_LIBBACKTRACE) >> .make-settings
 	echo LIBBACKTRACE_PREFIX=$(LIBBACKTRACE_PREFIX) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
@@ -689,6 +702,10 @@ persist-settings: distclean
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
 	echo ENGINE_SERVER_OBJ=$(ENGINE_SERVER_OBJ) >> .make-settings
+
+.PHONY: write-make-settings
+
+persist-settings: distclean write-make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))
 
 .PHONY: persist-settings
@@ -708,10 +725,11 @@ endif
 
 # valkey-server
 $(SERVER_NAME): $(ENGINE_SERVER_OBJ) $(LUA_MODULE)
-	$(SERVER_LD) -o $@ $(ENGINE_SERVER_OBJ) ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS) $(LUA_LDFLAGS)
+	$(SERVER_LD) -o $@ $(ENGINE_SERVER_OBJ) ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a ../deps/lz4/liblz4.a $(FINAL_LIBS) $(LUA_LDFLAGS)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
+	rm -f $@
 	$(SERVER_AR) rcs $@ $^
 
 # valkey-sentinel

--- a/src/Makefile
+++ b/src/Makefile
@@ -643,13 +643,6 @@ ENGINE_LIB_NAME=lib$(ENGINE_NAME).a
 ENGINE_UNIT_GTESTS:=$(ENGINE_NAME)-unit-gtests$(PROG_SUFFIX)
 ALL_SOURCES=$(sort $(patsubst %.o,%.c,$(ENGINE_SERVER_OBJ) $(ENGINE_CLI_OBJ) $(ENGINE_BENCHMARK_OBJ)))
 
-USE_FAST_FLOAT?=no
-ifeq ($(USE_FAST_FLOAT),yes)
-	# valkey_strtod.c embeds the header-only ffc.h implementation, so this
-	# compatibility option only needs the preprocessor define.
-	FINAL_CFLAGS += -D USE_FAST_FLOAT
-endif
-
 USE_LIBBACKTRACE?=no
 ifeq ($(USE_LIBBACKTRACE),yes)
 	FINAL_CFLAGS += -DUSE_LIBBACKTRACE
@@ -681,8 +674,7 @@ endif
 all-with-unit-tests: all $(ENGINE_UNIT_GTESTS)
 .PHONY: all
 
-write-make-settings:
-	rm -f .make-settings
+persist-settings: distclean
 	echo STD=$(STD) >> .make-settings
 	echo WARN=$(WARN) >> .make-settings
 	echo OPT=$(OPT) >> .make-settings
@@ -692,7 +684,6 @@ write-make-settings:
 	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
 	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
 	echo BUILD_LUA=$(BUILD_LUA) >> .make-settings
-	echo USE_FAST_FLOAT=$(USE_FAST_FLOAT) >> .make-settings
 	echo USE_LIBBACKTRACE=$(USE_LIBBACKTRACE) >> .make-settings
 	echo LIBBACKTRACE_PREFIX=$(LIBBACKTRACE_PREFIX) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
@@ -702,10 +693,6 @@ write-make-settings:
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
 	echo ENGINE_SERVER_OBJ=$(ENGINE_SERVER_OBJ) >> .make-settings
-
-.PHONY: write-make-settings
-
-persist-settings: distclean write-make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))
 
 .PHONY: persist-settings

--- a/src/aof.c
+++ b/src/aof.c
@@ -32,6 +32,7 @@
 #include "rio.h"
 #include "functions.h"
 #include "module.h"
+#include "compression_stream.h"
 
 #include <signal.h>
 #include <fcntl.h>
@@ -1010,7 +1011,7 @@ int startAppendOnly(void) {
  * Returns C_OK on success; on C_ERR caller should fallback to
  * restartAOFAfterSYNC(). */
 static int rdbFileUsesStreamingCompression(const char *filename) {
-    unsigned char header[4];
+    unsigned char header[VKCS_ENVELOPE_SIZE];
     int fd = open(filename, O_RDONLY);
     if (fd == -1) return -1;
 
@@ -1023,7 +1024,10 @@ static int rdbFileUsesStreamingCompression(const char *filename) {
         return -1;
     }
     if (nread < (ssize_t)sizeof(header)) return 0;
-    return memcmp(header, "VKCS", sizeof(header)) == 0;
+    /* Validate the full 8-byte VKCS envelope (magic + version + codec)
+     * so a file that happens to start with "VKCS" but has an invalid
+     * version or codec is not misclassified as compressed. */
+    return memcmp(header, "VKCS", 4) == 0 && header[4] == VKCS_VERSION;
 }
 
 int restartAOFWithSyncRdb(void) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -1009,6 +1009,23 @@ int startAppendOnly(void) {
  * as the new BASE file (RDB preamble mode), avoiding a redundant AOFRW.
  * Returns C_OK on success; on C_ERR caller should fallback to
  * restartAOFAfterSYNC(). */
+static int rdbFileUsesStreamingCompression(const char *filename) {
+    unsigned char header[4];
+    int fd = open(filename, O_RDONLY);
+    if (fd == -1) return -1;
+
+    ssize_t nread = read(fd, header, sizeof(header));
+    int read_errno = errno;
+    close(fd);
+
+    if (nread == -1) {
+        errno = read_errno;
+        return -1;
+    }
+    if (nread < (ssize_t)sizeof(header)) return 0;
+    return memcmp(header, "VKCS", sizeof(header)) == 0;
+}
+
 int restartAOFWithSyncRdb(void) {
     serverAssert(server.aof_state == AOF_OFF);
 
@@ -1019,6 +1036,19 @@ int restartAOFWithSyncRdb(void) {
     sds new_incr_filename = NULL;
     sds new_incr_filepath = NULL;
     aofManifest *temp_am = NULL;
+
+    int compressed_sync_rdb = rdbFileUsesStreamingCompression(server.rdb_filename);
+    if (compressed_sync_rdb == -1) {
+        serverLog(LL_WARNING, "Error inspecting the RDB file %s before AOF reuse: %s",
+                  server.rdb_filename, strerror(errno));
+        goto cleanup;
+    }
+    if (compressed_sync_rdb) {
+        serverLog(LL_NOTICE,
+                  "Sync RDB file %s uses streaming compression, falling back to BGREWRITEAOF instead of reusing it as an AOF base",
+                  server.rdb_filename);
+        return C_ERR;
+    }
 
     if (dirCreateIfMissing(server.aof_dirname) == -1) {
         serverLog(LL_WARNING, "Can't open or create append-only dir %s: %s", server.aof_dirname, strerror(errno));

--- a/src/aof.c
+++ b/src/aof.c
@@ -1006,10 +1006,8 @@ int startAppendOnly(void) {
     return C_OK;
 }
 
-/* Try to restart AOF after replica full sync by adopting `server.rdb_filename`
- * as the new BASE file (RDB preamble mode), avoiding a redundant AOFRW.
- * Returns C_OK on success; on C_ERR caller should fallback to
- * restartAOFAfterSYNC(). */
+/* Check whether an RDB file uses VKCS streaming compression by probing
+ * the first 8 bytes for a valid VKCS envelope (magic + version). */
 static int rdbFileUsesStreamingCompression(const char *filename) {
     unsigned char header[VKCS_ENVELOPE_SIZE];
     int fd = open(filename, O_RDONLY);
@@ -1030,6 +1028,10 @@ static int rdbFileUsesStreamingCompression(const char *filename) {
     return memcmp(header, "VKCS", 4) == 0 && header[4] == VKCS_VERSION;
 }
 
+/* Try to restart AOF after replica full sync by adopting `server.rdb_filename`
+ * as the new BASE file (RDB preamble mode), avoiding a redundant AOFRW.
+ * Returns C_OK on success; on C_ERR caller should fallback to
+ * restartAOFAfterSYNC(). */
 int restartAOFWithSyncRdb(void) {
     serverAssert(server.aof_state == AOF_OFF);
 

--- a/src/compression.c
+++ b/src/compression.c
@@ -132,6 +132,10 @@ void streamDecompressorDestroy(stream_decompressor_t *sd) {
     memset(sd, 0, sizeof(*sd));
 }
 
+bool streamDecompressorFrameDone(const stream_decompressor_t *sd) {
+    return sd && sd->frame_done;
+}
+
 size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len) {
     if (!sc) return 0;
     const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);

--- a/src/compression.c
+++ b/src/compression.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Streaming compression/decompression dispatch.
+ * Codec-specific implementations live in implementation files. */
+
+#include "compression.h"
+#include "compression_lz4.h"
+#include <string.h>
+
+typedef struct {
+    int (*compressor_init)(stream_compressor_t *sc);
+    void (*compressor_destroy)(stream_compressor_t *sc);
+    int (*decompressor_init)(stream_decompressor_t *sd);
+    void (*decompressor_destroy)(stream_decompressor_t *sd);
+    size_t (*compress_output_bound)(size_t input_len);
+    ssize_t (*compress_feed)(stream_compressor_t *sc,
+                             uint8_t *output,
+                             size_t output_capacity,
+                             const uint8_t *input,
+                             size_t input_len,
+                             compress_flush_mode_t flush_mode);
+    ssize_t (*decompress_feed)(stream_decompressor_t *sd,
+                               uint8_t *output,
+                               size_t output_capacity,
+                               const uint8_t *input,
+                               size_t input_len,
+                               size_t *input_consumed);
+} compression_codec_impl_t;
+
+static const compression_codec_impl_t compression_lz4_codec_impl = {
+    .compressor_init = compressionLz4CompressorInit,
+    .compressor_destroy = compressionLz4CompressorDestroy,
+    .decompressor_init = compressionLz4DecompressorInit,
+    .decompressor_destroy = compressionLz4DecompressorDestroy,
+    .compress_output_bound = compressionLz4OutputBound,
+    .compress_feed = compressionLz4CompressFeed,
+    .decompress_feed = compressionLz4DecompressFeed,
+};
+
+static const char *const compression_algo_name_by_algo[] = {
+    [ALGO_NONE] = "none",
+    [ALGO_LZF] = "lzf",
+    [ALGO_LZ4] = "lz4",
+};
+
+static const compression_codec_impl_t *const compression_codec_impl_by_algo[] = {
+    [ALGO_LZ4] = &compression_lz4_codec_impl,
+};
+
+static const char *compressionAlgoNameForAlgo(compression_algo_t algo) {
+    unsigned int algo_index = (unsigned int)algo;
+
+    if (algo_index >= sizeof(compression_algo_name_by_algo) / sizeof(compression_algo_name_by_algo[0])) {
+        return NULL;
+    }
+    return compression_algo_name_by_algo[algo_index];
+}
+
+static const compression_codec_impl_t *compressionCodecImplForAlgo(compression_algo_t algo) {
+    unsigned int algo_index = (unsigned int)algo;
+
+    if (algo_index >= sizeof(compression_codec_impl_by_algo) / sizeof(compression_codec_impl_by_algo[0])) {
+        return NULL;
+    }
+    return compression_codec_impl_by_algo[algo_index];
+}
+
+bool compressionAlgoSupportsStreaming(compression_algo_t algo) {
+    return compressionCodecImplForAlgo(algo) != NULL;
+}
+
+const char *compressionAlgoName(compression_algo_t algo) {
+    const char *algo_name = compressionAlgoNameForAlgo(algo);
+
+    return algo_name ? algo_name : "unknown";
+}
+
+int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int level) {
+    if (!sc) return -1;
+    memset(sc, 0, sizeof(*sc));
+
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+    if (!codec_impl || !codec_impl->compressor_init) return -1;
+
+    sc->algo = algo;
+    sc->level = level;
+
+    if (codec_impl->compressor_init(sc) != 0) {
+        streamCompressorDestroy(sc);
+        return -1;
+    }
+    return 0;
+}
+
+void streamCompressorDestroy(stream_compressor_t *sc) {
+    if (!sc) return;
+
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    if (codec_impl && codec_impl->compressor_destroy) {
+        codec_impl->compressor_destroy(sc);
+    }
+    memset(sc, 0, sizeof(*sc));
+}
+
+int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo) {
+    if (!sd) return -1;
+    memset(sd, 0, sizeof(*sd));
+
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+    if (!codec_impl || !codec_impl->decompressor_init) return -1;
+
+    sd->algo = algo;
+
+    if (codec_impl->decompressor_init(sd) != 0) {
+        streamDecompressorDestroy(sd);
+        return -1;
+    }
+    return 0;
+}
+
+void streamDecompressorDestroy(stream_decompressor_t *sd) {
+    if (!sd) return;
+
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sd->algo);
+    if (codec_impl && codec_impl->decompressor_destroy) {
+        codec_impl->decompressor_destroy(sd);
+    }
+    memset(sd, 0, sizeof(*sd));
+}
+
+size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len) {
+    if (!sc) return 0;
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    if (!codec_impl || !codec_impl->compress_output_bound) return 0;
+    return codec_impl->compress_output_bound(input_len);
+}
+
+ssize_t streamCompressFeed(stream_compressor_t *sc,
+                           uint8_t *output,
+                           size_t output_capacity,
+                           const uint8_t *input,
+                           size_t input_len,
+                           compress_flush_mode_t flush_mode) {
+    if (!sc || !output) return -1;
+    if (sc->errored) return -1;
+    if (input_len > 0 && !input) return -1;
+
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    if (!codec_impl || !codec_impl->compress_feed) return -1;
+
+    return codec_impl->compress_feed(sc, output, output_capacity,
+                                     input, input_len, flush_mode);
+}
+
+ssize_t streamDecompressFeed(stream_decompressor_t *sd,
+                             uint8_t *output,
+                             size_t output_capacity,
+                             const uint8_t *input,
+                             size_t input_len,
+                             size_t *input_consumed) {
+    if (!sd || !input_consumed) return -1;
+    if (sd->errored) return -1;
+    *input_consumed = 0;
+    if (sd->frame_done) return 0;
+    /* Zero output capacity is a caller bug — returning 0 with no progress
+     * would cause streaming loops to spin forever. */
+    if (!output || output_capacity == 0) {
+        sd->errored = true;
+        return -1;
+    }
+
+    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sd->algo);
+    if (!codec_impl || !codec_impl->decompress_feed) {
+        sd->errored = true;
+        return -1;
+    }
+
+    return codec_impl->decompress_feed(sd, output, output_capacity,
+                                       input, input_len, input_consumed);
+}

--- a/src/compression.c
+++ b/src/compression.c
@@ -12,26 +12,26 @@
 #include <string.h>
 
 typedef struct {
-    int (*compressor_init)(stream_compressor_t *sc);
-    void (*compressor_destroy)(stream_compressor_t *sc);
-    int (*decompressor_init)(stream_decompressor_t *sd);
-    void (*decompressor_destroy)(stream_decompressor_t *sd);
+    int (*compressor_init)(streamCompressor *sc);
+    void (*compressor_destroy)(streamCompressor *sc);
+    int (*decompressor_init)(streamDecompressor *sd);
+    void (*decompressor_destroy)(streamDecompressor *sd);
     size_t (*compress_output_bound)(size_t input_len);
-    ssize_t (*compress_feed)(stream_compressor_t *sc,
+    ssize_t (*compress_feed)(streamCompressor *sc,
                              uint8_t *output,
                              size_t output_capacity,
                              const uint8_t *input,
                              size_t input_len,
-                             compress_flush_mode_t flush_mode);
-    ssize_t (*decompress_feed)(stream_decompressor_t *sd,
+                             compressFlushMode flush_mode);
+    ssize_t (*decompress_feed)(streamDecompressor *sd,
                                uint8_t *output,
                                size_t output_capacity,
                                const uint8_t *input,
                                size_t input_len,
                                size_t *input_consumed);
-} compression_codec_impl_t;
+} compressionCodecImpl;
 
-static const compression_codec_impl_t compression_lz4_codec_impl = {
+static const compressionCodecImpl compressionLz4CodecImpl = {
     .compressor_init = compressionLz4CompressorInit,
     .compressor_destroy = compressionLz4CompressorDestroy,
     .decompressor_init = compressionLz4DecompressorInit,
@@ -41,49 +41,49 @@ static const compression_codec_impl_t compression_lz4_codec_impl = {
     .decompress_feed = compressionLz4DecompressFeed,
 };
 
-static const char *const compression_algo_name_by_algo[] = {
+static const char *const compressionAlgoNameByAlgo[] = {
     [ALGO_NONE] = "none",
     [ALGO_LZF] = "lzf",
     [ALGO_LZ4] = "lz4",
 };
 
-static const compression_codec_impl_t *const compression_codec_impl_by_algo[] = {
-    [ALGO_LZ4] = &compression_lz4_codec_impl,
+static const compressionCodecImpl *const compressionCodecImplByAlgo[] = {
+    [ALGO_LZ4] = &compressionLz4CodecImpl,
 };
 
-static const char *compressionAlgoNameForAlgo(compression_algo_t algo) {
+static const char *compressionAlgoNameForAlgo(compressionAlgo algo) {
     unsigned int algo_index = (unsigned int)algo;
 
-    if (algo_index >= sizeof(compression_algo_name_by_algo) / sizeof(compression_algo_name_by_algo[0])) {
+    if (algo_index >= sizeof(compressionAlgoNameByAlgo) / sizeof(compressionAlgoNameByAlgo[0])) {
         return NULL;
     }
-    return compression_algo_name_by_algo[algo_index];
+    return compressionAlgoNameByAlgo[algo_index];
 }
 
-static const compression_codec_impl_t *compressionCodecImplForAlgo(compression_algo_t algo) {
+static const compressionCodecImpl *compressionCodecImplForAlgo(compressionAlgo algo) {
     unsigned int algo_index = (unsigned int)algo;
 
-    if (algo_index >= sizeof(compression_codec_impl_by_algo) / sizeof(compression_codec_impl_by_algo[0])) {
+    if (algo_index >= sizeof(compressionCodecImplByAlgo) / sizeof(compressionCodecImplByAlgo[0])) {
         return NULL;
     }
-    return compression_codec_impl_by_algo[algo_index];
+    return compressionCodecImplByAlgo[algo_index];
 }
 
-bool compressionAlgoSupportsStreaming(compression_algo_t algo) {
+bool compressionAlgoSupportsStreaming(compressionAlgo algo) {
     return compressionCodecImplForAlgo(algo) != NULL;
 }
 
-const char *compressionAlgoName(compression_algo_t algo) {
+const char *compressionAlgoName(compressionAlgo algo) {
     const char *algo_name = compressionAlgoNameForAlgo(algo);
 
     return algo_name ? algo_name : "unknown";
 }
 
-int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int level) {
+int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) {
     if (!sc) return -1;
     memset(sc, 0, sizeof(*sc));
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
     if (!codec_impl || !codec_impl->compressor_init) return -1;
 
     sc->algo = algo;
@@ -96,21 +96,21 @@ int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int l
     return 0;
 }
 
-void streamCompressorDestroy(stream_compressor_t *sc) {
+void streamCompressorDestroy(streamCompressor *sc) {
     if (!sc) return;
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
     if (codec_impl && codec_impl->compressor_destroy) {
         codec_impl->compressor_destroy(sc);
     }
     memset(sc, 0, sizeof(*sc));
 }
 
-int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo) {
+int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
     if (!sd) return -1;
     memset(sd, 0, sizeof(*sd));
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(algo);
     if (!codec_impl || !codec_impl->decompressor_init) return -1;
 
     sd->algo = algo;
@@ -122,45 +122,45 @@ int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo) {
     return 0;
 }
 
-void streamDecompressorDestroy(stream_decompressor_t *sd) {
+void streamDecompressorDestroy(streamDecompressor *sd) {
     if (!sd) return;
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sd->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sd->algo);
     if (codec_impl && codec_impl->decompressor_destroy) {
         codec_impl->decompressor_destroy(sd);
     }
     memset(sd, 0, sizeof(*sd));
 }
 
-bool streamDecompressorFrameDone(const stream_decompressor_t *sd) {
+bool streamDecompressorFrameDone(const streamDecompressor *sd) {
     return sd && sd->frame_done;
 }
 
-size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len) {
+size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len) {
     if (!sc) return 0;
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
     if (!codec_impl || !codec_impl->compress_output_bound) return 0;
     return codec_impl->compress_output_bound(input_len);
 }
 
-ssize_t streamCompressFeed(stream_compressor_t *sc,
+ssize_t streamCompressFeed(streamCompressor *sc,
                            uint8_t *output,
                            size_t output_capacity,
                            const uint8_t *input,
                            size_t input_len,
-                           compress_flush_mode_t flush_mode) {
+                           compressFlushMode flush_mode) {
     if (!sc || !output) return -1;
     if (sc->errored) return -1;
     if (input_len > 0 && !input) return -1;
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sc->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
     if (!codec_impl || !codec_impl->compress_feed) return -1;
 
     return codec_impl->compress_feed(sc, output, output_capacity,
                                      input, input_len, flush_mode);
 }
 
-ssize_t streamDecompressFeed(stream_decompressor_t *sd,
+ssize_t streamDecompressFeed(streamDecompressor *sd,
                              uint8_t *output,
                              size_t output_capacity,
                              const uint8_t *input,
@@ -177,7 +177,7 @@ ssize_t streamDecompressFeed(stream_decompressor_t *sd,
         return -1;
     }
 
-    const compression_codec_impl_t *codec_impl = compressionCodecImplForAlgo(sd->algo);
+    const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sd->algo);
     if (!codec_impl || !codec_impl->decompress_feed) {
         sd->errored = true;
         return -1;

--- a/src/compression.c
+++ b/src/compression.c
@@ -42,13 +42,13 @@ static const compressionCodecImpl compressionLz4CodecImpl = {
 };
 
 static const char *const compressionAlgoNameByAlgo[] = {
-    [ALGO_NONE] = "none",
-    [ALGO_LZF] = "lzf",
-    [ALGO_LZ4] = "lz4",
+    [COMPRESSION_ALGO_NONE] = "none",
+    [COMPRESSION_ALGO_LZF] = "lzf",
+    [COMPRESSION_ALGO_LZ4] = "lz4",
 };
 
 static const compressionCodecImpl *const compressionCodecImplByAlgo[] = {
-    [ALGO_LZ4] = &compressionLz4CodecImpl,
+    [COMPRESSION_ALGO_LZ4] = &compressionLz4CodecImpl,
 };
 
 static const char *compressionAlgoNameForAlgo(compressionAlgo algo) {

--- a/src/compression.h
+++ b/src/compression.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMPRESSION_H
+#define COMPRESSION_H
+
+#include "fmacros.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/* --- Algorithm identifiers --- */
+typedef enum {
+    ALGO_NONE = 0x00, /* Disabled */
+    ALGO_LZF = 0x01,  /* Per-string LZF (RDB only, existing behavior) */
+    ALGO_LZ4 = 0x02,
+} compression_algo_t;
+
+/* --- Flush modes for streaming compression --- */
+typedef enum {
+    FLUSH_CONTINUE = 0, /* Buffer internally */
+    FLUSH_SYNC = 1,     /* Emit all buffered data, keep frame open */
+    FLUSH_END = 2,      /* Finalize frame */
+} compress_flush_mode_t;
+
+/* --- Streaming compressor context --- */
+typedef struct {
+    compression_algo_t algo;
+    int level;
+    void *ctx; /* Private codec-specific compressor context. */
+    bool frame_started;
+    bool errored;        /* Permanently failed — algorithm state is undefined after
+                          * an error. All subsequent streamCompressFeed calls return
+                          * -1 immediately. The caller must tear down the stream
+                          * (disconnect replica / abort RDB save). No mid-stream
+                          * retry is possible because already-emitted frame bytes
+                          * cannot be unsent. */
+    bool codec_checksum; /* Codec-native integrity toggle.
+                          * For LZ4 streams this maps to per-block checksums. */
+} stream_compressor_t;
+
+/* --- Streaming decompressor context --- */
+typedef struct {
+    compression_algo_t algo;
+    void *ctx;       /* Private codec-specific decompressor context. */
+    bool errored;    /* Permanently failed — algorithm state is undefined after
+                      * an error. All subsequent streamDecompressFeed calls
+                      * return -1 immediately until reinitialized. */
+    bool frame_done; /* Set when the codec frame is fully decoded.
+                      * Subsequent streamDecompressFeed calls return 0
+                      * immediately (no more output). */
+} stream_decompressor_t;
+
+/* Returns true if the algorithm supports streaming codec framing. */
+bool compressionAlgoSupportsStreaming(compression_algo_t algo);
+
+/* Returns a stable name for logging/debugging. */
+const char *compressionAlgoName(compression_algo_t algo);
+
+/* --- Streaming compression API --- */
+
+/* Initialize/destroy streaming compressor. */
+int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int level);
+void streamCompressorDestroy(stream_compressor_t *sc);
+
+/* Initialize/destroy streaming decompressor. */
+int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo);
+void streamDecompressorDestroy(stream_decompressor_t *sd);
+
+/* Return upper bound on compressed output size.
+ * The bound is conservative: it includes frame header, data, and flush/end
+ * overhead so the caller can allocate once and reuse for any flush mode. */
+size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len);
+
+/* Feed data through streaming compressor.
+ * flush_mode: FLUSH_CONTINUE, FLUSH_SYNC, or FLUSH_END.
+ * Returns bytes written to output, 0 for no output, -1 on error. */
+ssize_t streamCompressFeed(stream_compressor_t *sc,
+                           uint8_t *output,
+                           size_t output_capacity,
+                           const uint8_t *input,
+                           size_t input_len,
+                           compress_flush_mode_t flush_mode);
+
+/* Feed compressed data through streaming decompressor.
+ * Returns bytes written to output, 0 for no output, -1 on error.
+ * *input_consumed is set to the number of compressed bytes consumed.
+ * Fatal errors latch stream_decompressor_t.errored until reinit. */
+ssize_t streamDecompressFeed(stream_decompressor_t *sd,
+                             uint8_t *output,
+                             size_t output_capacity,
+                             const uint8_t *input,
+                             size_t input_len,
+                             size_t *input_consumed);
+
+#endif /* COMPRESSION_H */

--- a/src/compression.h
+++ b/src/compression.h
@@ -32,7 +32,7 @@ typedef struct {
     compression_algo_t algo;
     int level;
     void *ctx; /* Private codec-specific compressor context. */
-    bool frame_started;
+    bool stream_started;
     bool errored;        /* Permanently failed — algorithm state is undefined after
                           * an error. All subsequent streamCompressFeed calls return
                           * -1 immediately. The caller must tear down the stream
@@ -70,6 +70,9 @@ void streamCompressorDestroy(stream_compressor_t *sc);
 /* Initialize/destroy streaming decompressor. */
 int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo);
 void streamDecompressorDestroy(stream_decompressor_t *sd);
+
+/* Returns true when the codec frame has been fully decoded. */
+bool streamDecompressorFrameDone(const stream_decompressor_t *sd);
 
 /* Return upper bound on compressed output size.
  * The bound is conservative: it includes frame header, data, and flush/end

--- a/src/compression.h
+++ b/src/compression.h
@@ -18,18 +18,18 @@ typedef enum {
     ALGO_NONE = 0x00, /* Disabled */
     ALGO_LZF = 0x01,  /* Per-string LZF (RDB only, existing behavior) */
     ALGO_LZ4 = 0x02,
-} compression_algo_t;
+} compressionAlgo;
 
 /* --- Flush modes for streaming compression --- */
 typedef enum {
     FLUSH_CONTINUE = 0, /* Buffer internally */
     FLUSH_SYNC = 1,     /* Emit all buffered data, keep frame open */
     FLUSH_END = 2,      /* Finalize frame */
-} compress_flush_mode_t;
+} compressFlushMode;
 
 /* --- Streaming compressor context --- */
 typedef struct {
-    compression_algo_t algo;
+    compressionAlgo algo;
     int level;
     void *ctx; /* Private codec-specific compressor context. */
     bool stream_started;
@@ -41,11 +41,11 @@ typedef struct {
                           * cannot be unsent. */
     bool codec_checksum; /* Codec-native integrity toggle.
                           * For LZ4 streams this maps to per-block checksums. */
-} stream_compressor_t;
+} streamCompressor;
 
 /* --- Streaming decompressor context --- */
 typedef struct {
-    compression_algo_t algo;
+    compressionAlgo algo;
     void *ctx;       /* Private codec-specific decompressor context. */
     bool errored;    /* Permanently failed — algorithm state is undefined after
                       * an error. All subsequent streamDecompressFeed calls
@@ -53,47 +53,47 @@ typedef struct {
     bool frame_done; /* Set when the codec frame is fully decoded.
                       * Subsequent streamDecompressFeed calls return 0
                       * immediately (no more output). */
-} stream_decompressor_t;
+} streamDecompressor;
 
 /* Returns true if the algorithm supports streaming codec framing. */
-bool compressionAlgoSupportsStreaming(compression_algo_t algo);
+bool compressionAlgoSupportsStreaming(compressionAlgo algo);
 
 /* Returns a stable name for logging/debugging. */
-const char *compressionAlgoName(compression_algo_t algo);
+const char *compressionAlgoName(compressionAlgo algo);
 
 /* --- Streaming compression API --- */
 
 /* Initialize/destroy streaming compressor. */
-int streamCompressorInit(stream_compressor_t *sc, compression_algo_t algo, int level);
-void streamCompressorDestroy(stream_compressor_t *sc);
+int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level);
+void streamCompressorDestroy(streamCompressor *sc);
 
 /* Initialize/destroy streaming decompressor. */
-int streamDecompressorInit(stream_decompressor_t *sd, compression_algo_t algo);
-void streamDecompressorDestroy(stream_decompressor_t *sd);
+int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo);
+void streamDecompressorDestroy(streamDecompressor *sd);
 
 /* Returns true when the codec frame has been fully decoded. */
-bool streamDecompressorFrameDone(const stream_decompressor_t *sd);
+bool streamDecompressorFrameDone(const streamDecompressor *sd);
 
 /* Return upper bound on compressed output size.
  * The bound is conservative: it includes frame header, data, and flush/end
  * overhead so the caller can allocate once and reuse for any flush mode. */
-size_t streamCompressOutputBound(const stream_compressor_t *sc, size_t input_len);
+size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len);
 
 /* Feed data through streaming compressor.
  * flush_mode: FLUSH_CONTINUE, FLUSH_SYNC, or FLUSH_END.
  * Returns bytes written to output, 0 for no output, -1 on error. */
-ssize_t streamCompressFeed(stream_compressor_t *sc,
+ssize_t streamCompressFeed(streamCompressor *sc,
                            uint8_t *output,
                            size_t output_capacity,
                            const uint8_t *input,
                            size_t input_len,
-                           compress_flush_mode_t flush_mode);
+                           compressFlushMode flush_mode);
 
 /* Feed compressed data through streaming decompressor.
  * Returns bytes written to output, 0 for no output, -1 on error.
  * *input_consumed is set to the number of compressed bytes consumed.
- * Fatal errors latch stream_decompressor_t.errored until reinit. */
-ssize_t streamDecompressFeed(stream_decompressor_t *sd,
+ * Fatal errors latch streamDecompressor.errored until reinit. */
+ssize_t streamDecompressFeed(streamDecompressor *sd,
                              uint8_t *output,
                              size_t output_capacity,
                              const uint8_t *input,

--- a/src/compression.h
+++ b/src/compression.h
@@ -7,7 +7,6 @@
 #ifndef COMPRESSION_H
 #define COMPRESSION_H
 
-#include "fmacros.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -15,16 +14,16 @@
 
 /* --- Algorithm identifiers --- */
 typedef enum {
-    ALGO_NONE = 0x00, /* Disabled */
-    ALGO_LZF = 0x01,  /* Per-string LZF (RDB only, existing behavior) */
-    ALGO_LZ4 = 0x02,
+    COMPRESSION_ALGO_NONE = 0x00, /* Disabled */
+    COMPRESSION_ALGO_LZF = 0x01,  /* Per-string LZF (RDB only, existing behavior) */
+    COMPRESSION_ALGO_LZ4 = 0x02,
 } compressionAlgo;
 
 /* --- Flush modes for streaming compression --- */
 typedef enum {
-    FLUSH_CONTINUE = 0, /* Buffer internally */
-    FLUSH_SYNC = 1,     /* Emit all buffered data, keep frame open */
-    FLUSH_END = 2,      /* Finalize frame */
+    COMPRESS_FLUSH_CONTINUE = 0, /* Buffer internally */
+    COMPRESS_FLUSH_SYNC = 1,     /* Emit all buffered data, keep frame open */
+    COMPRESS_FLUSH_END = 2,      /* Finalize frame */
 } compressFlushMode;
 
 /* --- Streaming compressor context --- */
@@ -80,7 +79,7 @@ bool streamDecompressorFrameDone(const streamDecompressor *sd);
 size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len);
 
 /* Feed data through streaming compressor.
- * flush_mode: FLUSH_CONTINUE, FLUSH_SYNC, or FLUSH_END.
+ * flush_mode: COMPRESS_FLUSH_CONTINUE, COMPRESS_FLUSH_SYNC, or COMPRESS_FLUSH_END.
  * Returns bytes written to output, 0 for no output, -1 on error. */
 ssize_t streamCompressFeed(streamCompressor *sc,
                            uint8_t *output,

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -26,7 +26,7 @@ static const LZ4F_preferences_t lz4f_prefs = {
                             * compression uses sc->level via a local copy */
 };
 
-int compressionLz4CompressorInit(stream_compressor_t *sc) {
+int compressionLz4CompressorInit(streamCompressor *sc) {
     LZ4F_cctx *cctx = NULL;
     LZ4F_errorCode_t err;
 
@@ -39,14 +39,14 @@ int compressionLz4CompressorInit(stream_compressor_t *sc) {
     return 0;
 }
 
-void compressionLz4CompressorDestroy(stream_compressor_t *sc) {
+void compressionLz4CompressorDestroy(streamCompressor *sc) {
     if (!sc || !sc->ctx) return;
 
     LZ4F_freeCompressionContext((LZ4F_cctx *)sc->ctx);
     sc->ctx = NULL;
 }
 
-int compressionLz4DecompressorInit(stream_decompressor_t *sd) {
+int compressionLz4DecompressorInit(streamDecompressor *sd) {
     LZ4F_dctx *dctx = NULL;
     LZ4F_errorCode_t err;
 
@@ -59,7 +59,7 @@ int compressionLz4DecompressorInit(stream_decompressor_t *sd) {
     return 0;
 }
 
-void compressionLz4DecompressorDestroy(stream_decompressor_t *sd) {
+void compressionLz4DecompressorDestroy(streamDecompressor *sd) {
     if (!sd || !sd->ctx) return;
 
     LZ4F_freeDecompressionContext((LZ4F_dctx *)sd->ctx);
@@ -73,12 +73,12 @@ size_t compressionLz4OutputBound(size_t input_len) {
     return LZ4F_compressBound(input_len, &lz4f_prefs) + LZ4F_HEADER_SIZE_MAX + LZ4F_compressBound(0, &lz4f_prefs);
 }
 
-ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
+ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                    uint8_t *output,
                                    size_t output_capacity,
                                    const uint8_t *input,
                                    size_t input_len,
-                                   compress_flush_mode_t flush_mode) {
+                                   compressFlushMode flush_mode) {
     LZ4F_cctx *cctx;
     size_t offset = 0;
 
@@ -149,7 +149,7 @@ lz4_error:
     return -1;
 }
 
-ssize_t compressionLz4DecompressFeed(stream_decompressor_t *sd,
+ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
                                      uint8_t *output,
                                      size_t output_capacity,
                                      const uint8_t *input,

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -87,7 +87,7 @@ ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
     cctx = (LZ4F_cctx *)sc->ctx;
 
     /* Begin frame on first call */
-    if (!sc->frame_started) {
+    if (!sc->stream_started) {
         /* Local copy of shared prefs so we can set the actual level
          * and checksum mode per-stream. */
         LZ4F_preferences_t prefs = lz4f_prefs;
@@ -105,7 +105,7 @@ ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
             return -1;
         }
         offset = r;
-        sc->frame_started = true;
+        sc->stream_started = true;
     }
 
     /* Compress input data */
@@ -134,7 +134,7 @@ ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
         r = LZ4F_compressEnd(cctx, output + offset, output_capacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
         offset += r;
-        sc->frame_started = false;
+        sc->stream_started = false;
     }
 
     if (offset > (size_t)SSIZE_MAX) goto lz4_error;

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "compression_lz4.h"
+#include <limits.h>
+#include <lz4frame.h>
+
+/* Shared LZ4F preferences template.
+ * - Used by streamCompressOutputBound() for bounds.
+ * - Copied and selectively overridden in streamCompressFeed() before
+ *   LZ4F_compressBegin() (compression level and checksum mode).
+ *
+ * Bounds are computed with block-independent mode and block checksums enabled
+ * so the returned capacity is safe for both checksum settings. */
+static const LZ4F_preferences_t lz4f_prefs = {
+    .frameInfo = {
+        .blockChecksumFlag = LZ4F_blockChecksumEnabled,
+        .contentChecksumFlag = LZ4F_noContentChecksum,
+        .blockSizeID = LZ4F_max64KB,
+        .blockMode = LZ4F_blockIndependent,
+    },
+    .compressionLevel = 0, /* bound calculation uses 0 (worst-case); actual
+                            * compression uses sc->level via a local copy */
+};
+
+int compressionLz4CompressorInit(stream_compressor_t *sc) {
+    LZ4F_cctx *cctx = NULL;
+    LZ4F_errorCode_t err;
+
+    if (!sc) return -1;
+
+    err = LZ4F_createCompressionContext(&cctx, LZ4F_VERSION);
+    if (LZ4F_isError(err)) return -1;
+
+    sc->ctx = cctx;
+    return 0;
+}
+
+void compressionLz4CompressorDestroy(stream_compressor_t *sc) {
+    if (!sc || !sc->ctx) return;
+
+    LZ4F_freeCompressionContext((LZ4F_cctx *)sc->ctx);
+    sc->ctx = NULL;
+}
+
+int compressionLz4DecompressorInit(stream_decompressor_t *sd) {
+    LZ4F_dctx *dctx = NULL;
+    LZ4F_errorCode_t err;
+
+    if (!sd) return -1;
+
+    err = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
+    if (LZ4F_isError(err)) return -1;
+
+    sd->ctx = dctx;
+    return 0;
+}
+
+void compressionLz4DecompressorDestroy(stream_decompressor_t *sd) {
+    if (!sd || !sd->ctx) return;
+
+    LZ4F_freeDecompressionContext((LZ4F_dctx *)sd->ctx);
+    sd->ctx = NULL;
+}
+
+size_t compressionLz4OutputBound(size_t input_len) {
+    /* Conservative worst-case: data bound + frame header + flush/end overhead.
+     * Always includes all components so the caller can allocate once and reuse
+     * for any flush mode and frame state. */
+    return LZ4F_compressBound(input_len, &lz4f_prefs) + LZ4F_HEADER_SIZE_MAX + LZ4F_compressBound(0, &lz4f_prefs);
+}
+
+ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
+                                   uint8_t *output,
+                                   size_t output_capacity,
+                                   const uint8_t *input,
+                                   size_t input_len,
+                                   compress_flush_mode_t flush_mode) {
+    LZ4F_cctx *cctx;
+    size_t offset = 0;
+
+    if (!sc || !sc->ctx) return -1;
+
+    cctx = (LZ4F_cctx *)sc->ctx;
+
+    /* Begin frame on first call */
+    if (!sc->frame_started) {
+        /* Local copy of shared prefs so we can set the actual level
+         * and checksum mode per-stream. */
+        LZ4F_preferences_t prefs = lz4f_prefs;
+        size_t r;
+
+        prefs.compressionLevel = sc->level;
+        prefs.frameInfo.blockChecksumFlag = sc->codec_checksum
+                                                ? LZ4F_blockChecksumEnabled
+                                                : LZ4F_noBlockChecksum;
+        r = LZ4F_compressBegin(cctx, output, output_capacity, &prefs);
+        if (LZ4F_isError(r)) {
+            /* compressBegin failure before any frame bytes are emitted is
+             * recoverable — the LZ4F context is still clean. Caller can
+             * retry with a larger buffer. Don't set errored. */
+            return -1;
+        }
+        offset = r;
+        sc->frame_started = true;
+    }
+
+    /* Compress input data */
+    if (input_len > 0) {
+        size_t r;
+
+        if (offset >= output_capacity) return -1;
+        r = LZ4F_compressUpdate(cctx, output + offset, output_capacity - offset,
+                                input, input_len, NULL);
+        if (LZ4F_isError(r)) goto lz4_error;
+        offset += r;
+    }
+
+    /* Handle flush/end modes */
+    if (flush_mode == FLUSH_SYNC) {
+        size_t r;
+
+        if (offset >= output_capacity) return -1;
+        r = LZ4F_flush(cctx, output + offset, output_capacity - offset, NULL);
+        if (LZ4F_isError(r)) goto lz4_error;
+        offset += r;
+    } else if (flush_mode == FLUSH_END) {
+        size_t r;
+
+        if (offset >= output_capacity) return -1;
+        r = LZ4F_compressEnd(cctx, output + offset, output_capacity - offset, NULL);
+        if (LZ4F_isError(r)) goto lz4_error;
+        offset += r;
+        sc->frame_started = false;
+    }
+
+    if (offset > (size_t)SSIZE_MAX) goto lz4_error;
+    return (ssize_t)offset;
+
+lz4_error:
+    /* LZ4F state is undefined after an error (lz4frame.h line 325).
+     * Mark permanently failed — no mid-stream retry is possible because
+     * already-emitted frame bytes cannot be unsent. The caller must
+     * tear down the stream (disconnect replica / abort RDB save). */
+    sc->errored = true;
+    return -1;
+}
+
+ssize_t compressionLz4DecompressFeed(stream_decompressor_t *sd,
+                                     uint8_t *output,
+                                     size_t output_capacity,
+                                     const uint8_t *input,
+                                     size_t input_len,
+                                     size_t *input_consumed) {
+    LZ4F_dctx *dctx;
+    size_t dst_size;
+    size_t src_size;
+    size_t ret;
+
+    if (!sd || !sd->ctx || !input_consumed) return -1;
+
+    dctx = (LZ4F_dctx *)sd->ctx;
+    dst_size = output_capacity;
+    src_size = input_len;
+    ret = LZ4F_decompress(dctx, output, &dst_size, input, &src_size, NULL);
+    if (LZ4F_isError(ret)) {
+        sd->errored = true;
+        return -1;
+    }
+    *input_consumed = src_size;
+    if (ret == 0) sd->frame_done = true;
+    if (dst_size > (size_t)SSIZE_MAX) {
+        sd->errored = true;
+        return -1;
+    }
+    return (ssize_t)dst_size;
+}

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -120,14 +120,14 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
     }
 
     /* Handle flush/end modes */
-    if (flush_mode == FLUSH_SYNC) {
+    if (flush_mode == COMPRESS_FLUSH_SYNC) {
         size_t r;
 
         if (offset >= output_capacity) return -1;
         r = LZ4F_flush(cctx, output + offset, output_capacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
         offset += r;
-    } else if (flush_mode == FLUSH_END) {
+    } else if (flush_mode == COMPRESS_FLUSH_END) {
         size_t r;
 
         if (offset >= output_capacity) return -1;

--- a/src/compression_lz4.h
+++ b/src/compression_lz4.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMPRESSION_LZ4_H
+#define COMPRESSION_LZ4_H
+
+#include "compression.h"
+
+int compressionLz4CompressorInit(stream_compressor_t *sc);
+void compressionLz4CompressorDestroy(stream_compressor_t *sc);
+int compressionLz4DecompressorInit(stream_decompressor_t *sd);
+void compressionLz4DecompressorDestroy(stream_decompressor_t *sd);
+size_t compressionLz4OutputBound(size_t input_len);
+ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
+                                   uint8_t *output,
+                                   size_t output_capacity,
+                                   const uint8_t *input,
+                                   size_t input_len,
+                                   compress_flush_mode_t flush_mode);
+ssize_t compressionLz4DecompressFeed(stream_decompressor_t *sd,
+                                     uint8_t *output,
+                                     size_t output_capacity,
+                                     const uint8_t *input,
+                                     size_t input_len,
+                                     size_t *input_consumed);
+
+#endif /* COMPRESSION_LZ4_H */

--- a/src/compression_lz4.h
+++ b/src/compression_lz4.h
@@ -9,18 +9,18 @@
 
 #include "compression.h"
 
-int compressionLz4CompressorInit(stream_compressor_t *sc);
-void compressionLz4CompressorDestroy(stream_compressor_t *sc);
-int compressionLz4DecompressorInit(stream_decompressor_t *sd);
-void compressionLz4DecompressorDestroy(stream_decompressor_t *sd);
+int compressionLz4CompressorInit(streamCompressor *sc);
+void compressionLz4CompressorDestroy(streamCompressor *sc);
+int compressionLz4DecompressorInit(streamDecompressor *sd);
+void compressionLz4DecompressorDestroy(streamDecompressor *sd);
 size_t compressionLz4OutputBound(size_t input_len);
-ssize_t compressionLz4CompressFeed(stream_compressor_t *sc,
+ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                    uint8_t *output,
                                    size_t output_capacity,
                                    const uint8_t *input,
                                    size_t input_len,
-                                   compress_flush_mode_t flush_mode);
-ssize_t compressionLz4DecompressFeed(stream_decompressor_t *sd,
+                                   compressFlushMode flush_mode);
+ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
                                      uint8_t *output,
                                      size_t output_capacity,
                                      const uint8_t *input,

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -65,19 +65,19 @@ static void rioInitBase(rio *base,
 /* Emit callback for compress_rio: writes compressed bytes to inner rio.
  * Returns 0 on success, -1 on error. */
 static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
-    compress_rio_t *cr = (compress_rio_t *)ctx;
+    compressRio *cr = (compressRio *)ctx;
     if (rioWrite(cr->inner, data, len) == 0) return -1;
     return 0;
 }
 
 /* rio vtable: write callback — compress then delegate to inner rio */
 static size_t compressRioWrite(rio *r, const void *buf, size_t len) {
-    compress_rio_t *cr = (compress_rio_t *)r;
-    if (!cr->writer || cr->finalized || stream_writer_is_errored(cr->writer)) {
+    compressRio *cr = (compressRio *)r;
+    if (!cr->writer || cr->finalized || streamWriterIsErrored(cr->writer)) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
-    if (stream_writer_write(cr->writer, buf, len) < 0) {
+    if (streamWriterWrite(cr->writer, buf, len) < 0) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
@@ -93,14 +93,14 @@ static off_t compressRioTell(rio *r) {
  * keep frame open) + inner flush. Does NOT end the frame.
  * This is critical because some call sites flush mid-stream. */
 static int compressRioFlush(rio *r) {
-    compress_rio_t *cr = (compress_rio_t *)r;
-    if (!cr->writer || stream_writer_is_errored(cr->writer)) return 0;
+    compressRio *cr = (compressRio *)r;
+    if (!cr->writer || streamWriterIsErrored(cr->writer)) return 0;
     if (cr->finalized) return 1;
 
-    if (stream_writer_flush(cr->writer) != 0) return 0;
+    if (streamWriterFlush(cr->writer) != 0) return 0;
 
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->writer);
+        streamWriterSetError(cr->writer);
         return 0;
     }
     return 1;
@@ -108,9 +108,9 @@ static int compressRioFlush(rio *r) {
 
 /* Initialize a compression rio decorator wrapping an inner rio.
  * Sets up the rio vtable so callers can use standard rioWrite/rioFlush.
- * The compressor is initialized with a fresh algorithm context (fork-safe). */
-/* Returns 0 on success, -1 on failure (e.g., compressor init failed). */
-int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_config_t *cfg) {
+ * The writer is initialized with a fresh algorithm context (fork-safe). */
+/* Returns 0 on success, -1 on failure (e.g., writer init failed). */
+int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg) {
     if (!cr || !inner || !cfg) return -1;
 
     memset(cr, 0, sizeof(*cr));
@@ -131,57 +131,57 @@ int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_conf
 
     cr->inner = inner;
     cr->finalized = 0;
-    cr->writer = stream_writer_create(cfg, compressRioEmit, cr);
+    cr->writer = streamWriterCreate(cfg, compressRioEmit, cr);
     return cr->writer ? 0 : -1;
 }
 
 /* Finalize the compression frame and flush inner rio.
  * Must be called exactly once at end of stream.
  * Idempotent: safe to call multiple times (second call is a no-op). */
-/* Returns 0 on success, -1 if the compressor or inner flush errored. */
-int compress_rio_finish(compress_rio_t *cr) {
+/* Returns 0 on success, -1 if the writer or inner flush errored. */
+int compressRioFinish(compressRio *cr) {
     if (!cr) return -1;
     if (!cr->writer) return -1;
-    if (cr->finalized) return stream_writer_is_errored(cr->writer) ? -1 : 0;
+    if (cr->finalized) return streamWriterIsErrored(cr->writer) ? -1 : 0;
     cr->finalized = 1;
 
-    if (stream_writer_finish(cr->writer) != 0) {
+    if (streamWriterFinish(cr->writer) != 0) {
         return -1;
     }
 
     /* Flush inner rio to ensure all bytes reach the destination.
-     * Propagate flush failure to the compressor error state so
+     * Propagate flush failure to the writer error state so
      * callers can detect it. */
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->writer);
+        streamWriterSetError(cr->writer);
     }
-    return stream_writer_is_errored(cr->writer) ? -1 : 0;
+    return streamWriterIsErrored(cr->writer) ? -1 : 0;
 }
 
-/* Free compressor context and buffers. Does NOT finalize the frame.
- * Call compress_rio_finish() first on all exit paths. */
-void compress_rio_destroy(compress_rio_t *cr) {
+/* Free writer context and buffers. Does NOT finalize the frame.
+ * Call compressRioFinish() first on all exit paths. */
+void compressRioDestroy(compressRio *cr) {
     if (!cr) return;
     if (cr->writer) {
-        stream_writer_destroy(cr->writer);
+        streamWriterDestroy(cr->writer);
         cr->writer = NULL;
     }
 }
 
 /* ===================================================================
  * Decompression Rio Decorator
- * Thin rio adapter around stream_reader_t.
+ * Thin rio adapter around streamReader.
  * =================================================================== */
 
 /* Read up to `len` bytes from the inner rio (partial reads allowed).
  * Returns >0 bytes, 0 on EOF, -1 on error. */
 static ssize_t decompressRioReadPartial(void *ctx, void *buf, size_t len) {
-    decompress_rio_t *dr = (decompress_rio_t *)ctx;
+    decompressRio *dr = (decompressRio *)ctx;
     return rioReadPartial(dr->inner, buf, len);
 }
 
 static size_t decompressRioRead(rio *r, void *buf, size_t len) {
-    decompress_rio_t *dr = (decompress_rio_t *)r;
+    decompressRio *dr = (decompressRio *)r;
     if (dr->base.flags & RIO_FLAG_READ_ERROR) return 0;
     if (!dr->reader) {
         dr->base.flags |= RIO_FLAG_READ_ERROR;
@@ -191,7 +191,7 @@ static size_t decompressRioRead(rio *r, void *buf, size_t len) {
     uint8_t *dst = (uint8_t *)buf;
     size_t remaining = len;
     while (remaining > 0) {
-        ssize_t nread = stream_reader_read(dr->reader, dst, remaining);
+        ssize_t nread = streamReaderRead(dr->reader, dst, remaining);
         if (nread < 0) {
             dr->base.flags |= RIO_FLAG_READ_ERROR;
             return 0;
@@ -210,23 +210,23 @@ static size_t decompressRioRead(rio *r, void *buf, size_t len) {
 /* rio vtable: tell callback — report transport bytes consumed from the wrapped
  * rio so progress stays tied to source-stream position. */
 static off_t decompressRioTell(rio *r) {
-    decompress_rio_t *dr = (decompress_rio_t *)r;
+    decompressRio *dr = (decompressRio *)r;
     return (off_t)dr->inner->processed_bytes;
 }
 
-stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr) {
+streamReaderError decompressRioGetError(const decompressRio *dr) {
     if (!dr || !dr->reader) return STREAM_READER_ERROR_IO;
-    return stream_reader_get_error(dr->reader);
+    return streamReaderGetError(dr->reader);
 }
 
 /* Initialize a decompression rio and eagerly probe the wrapped stream so the
  * caller gets a stable classification up front: passthrough, compressed, or
  * incompatible envelope. */
-decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
-                                                   rio *inner,
-                                                   const stream_reader_config_t *cfg,
-                                                   stream_reader_info_t *info) {
-    stream_reader_info_t local_info = {0};
+decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
+                                              rio *inner,
+                                              const streamReaderConfig *cfg,
+                                              streamReaderInfo *info) {
+    streamReaderInfo local_info = {0};
 
     if (!dr || !inner || !cfg) return DECOMPRESS_RIO_INIT_ERROR;
 
@@ -237,14 +237,14 @@ decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
                 rioCheckType(inner));
     dr->inner = inner;
 
-    dr->reader = stream_reader_create(cfg, decompressRioReadPartial, dr);
+    dr->reader = streamReaderCreate(cfg, decompressRioReadPartial, dr);
     if (!dr->reader) {
         dr->base.flags |= RIO_FLAG_READ_ERROR;
         return DECOMPRESS_RIO_INIT_ERROR;
     }
-    if (stream_reader_get_info(dr->reader, &local_info) != 0) {
-        stream_reader_error_t error_kind = stream_reader_get_error(dr->reader);
-        decompress_rio_destroy(dr);
+    if (streamReaderGetInfo(dr->reader, &local_info) != 0) {
+        streamReaderError error_kind = streamReaderGetError(dr->reader);
+        decompressRioDestroy(dr);
         return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
                    ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
                    : DECOMPRESS_RIO_INIT_ERROR;
@@ -260,10 +260,10 @@ decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
     return DECOMPRESS_RIO_INIT_OK;
 }
 
-void decompress_rio_destroy(decompress_rio_t *dr) {
+void decompressRioDestroy(decompressRio *dr) {
     if (!dr) return;
     if (dr->reader) {
-        stream_reader_destroy(dr->reader);
+        streamReaderDestroy(dr->reader);
         dr->reader = NULL;
     }
 }

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -73,11 +73,11 @@ static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
 /* rio vtable: write callback — compress then delegate to inner rio */
 static size_t compressRioWrite(rio *r, const void *buf, size_t len) {
     compress_rio_t *cr = (compress_rio_t *)r;
-    if (!cr->compressor || cr->finalized || stream_writer_is_errored(cr->compressor)) {
+    if (!cr->writer || cr->finalized || stream_writer_is_errored(cr->writer)) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
-    if (stream_writer_write(cr->compressor, buf, len) < 0) {
+    if (stream_writer_write(cr->writer, buf, len) < 0) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
@@ -94,13 +94,13 @@ static off_t compressRioTell(rio *r) {
  * This is critical because some call sites flush mid-stream. */
 static int compressRioFlush(rio *r) {
     compress_rio_t *cr = (compress_rio_t *)r;
-    if (!cr->compressor || stream_writer_is_errored(cr->compressor)) return 0;
+    if (!cr->writer || stream_writer_is_errored(cr->writer)) return 0;
     if (cr->finalized) return 1;
 
-    if (stream_writer_flush(cr->compressor) != 0) return 0;
+    if (stream_writer_flush(cr->writer) != 0) return 0;
 
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->compressor);
+        stream_writer_set_error(cr->writer);
         return 0;
     }
     return 1;
@@ -131,8 +131,8 @@ int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_conf
 
     cr->inner = inner;
     cr->finalized = 0;
-    cr->compressor = stream_writer_create(cfg, compressRioEmit, cr);
-    return cr->compressor ? 0 : -1;
+    cr->writer = stream_writer_create(cfg, compressRioEmit, cr);
+    return cr->writer ? 0 : -1;
 }
 
 /* Finalize the compression frame and flush inner rio.
@@ -141,11 +141,11 @@ int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_conf
 /* Returns 0 on success, -1 if the compressor or inner flush errored. */
 int compress_rio_finish(compress_rio_t *cr) {
     if (!cr) return -1;
-    if (!cr->compressor) return -1;
-    if (cr->finalized) return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    if (!cr->writer) return -1;
+    if (cr->finalized) return stream_writer_is_errored(cr->writer) ? -1 : 0;
     cr->finalized = 1;
 
-    if (stream_writer_finish(cr->compressor) != 0) {
+    if (stream_writer_finish(cr->writer) != 0) {
         return -1;
     }
 
@@ -153,18 +153,18 @@ int compress_rio_finish(compress_rio_t *cr) {
      * Propagate flush failure to the compressor error state so
      * callers can detect it. */
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        stream_writer_set_error(cr->compressor);
+        stream_writer_set_error(cr->writer);
     }
-    return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    return stream_writer_is_errored(cr->writer) ? -1 : 0;
 }
 
 /* Free compressor context and buffers. Does NOT finalize the frame.
  * Call compress_rio_finish() first on all exit paths. */
 void compress_rio_destroy(compress_rio_t *cr) {
     if (!cr) return;
-    if (cr->compressor) {
-        stream_writer_destroy(cr->compressor);
-        cr->compressor = NULL;
+    if (cr->writer) {
+        stream_writer_destroy(cr->writer);
+        cr->writer = NULL;
     }
 }
 

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Rio decorators (compress_rio, decompress_rio). */
+
+#include "compression_rio.h"
+#include <string.h>
+#include <unistd.h>
+
+/* Shared rio callbacks for unsupported/no-op operations. */
+static size_t rioReadUnsupported(rio *r, void *buf, size_t len) {
+    (void)r;
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+static size_t rioWriteUnsupported(rio *r, const void *buf, size_t len) {
+    (void)r;
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+static int rioFlushNoop(rio *r) {
+    (void)r;
+    return 1;
+}
+
+/* Shared rio base initializer used by all decorators in this file. */
+static void rioInitBase(rio *base,
+                        size_t (*read_fn)(rio *, void *, size_t),
+                        size_t (*write_fn)(rio *, const void *, size_t),
+                        off_t (*tell_fn)(rio *),
+                        int (*flush_fn)(rio *),
+                        uint64_t flags,
+                        uint8_t type) {
+    base->read = read_fn;
+    base->write = write_fn;
+    base->tell = tell_fn;
+    base->flush = flush_fn;
+    base->read_some = NULL;
+    base->update_cksum = NULL;
+    base->cksum = 0;
+    base->flags = flags;
+    base->processed_bytes = 0;
+    base->max_processing_chunk = 0;
+    base->type = type;
+}
+
+/* ===================================================================
+ * Compression Rio Decorator
+ * Wraps an inner rio for transparent compression on write.
+ * Currently used by file-backed RDB save paths.
+ *
+ * RDB CHECKSUM SEMANTICS:
+ * - when codec checksums are enabled, they are the authoritative integrity
+ *   signal for the compressed stream and the RDB checksum field is left zero.
+ * - otherwise the standard RDB checksum protects the logical stream.
+ * =================================================================== */
+
+/* Emit callback for compress_rio: writes compressed bytes to inner rio.
+ * Returns 0 on success, -1 on error. */
+static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
+    compress_rio_t *cr = (compress_rio_t *)ctx;
+    if (rioWrite(cr->inner, data, len) == 0) return -1;
+    return 0;
+}
+
+/* rio vtable: write callback — compress then delegate to inner rio */
+static size_t compressRioWrite(rio *r, const void *buf, size_t len) {
+    compress_rio_t *cr = (compress_rio_t *)r;
+    if (!cr->compressor || cr->finalized || stream_writer_is_errored(cr->compressor)) {
+        r->flags |= RIO_FLAG_WRITE_ERROR;
+        return 0;
+    }
+    if (stream_writer_write(cr->compressor, buf, len) < 0) {
+        r->flags |= RIO_FLAG_WRITE_ERROR;
+        return 0;
+    }
+    return 1; /* rio write callback contract: 0 on error, non-zero on success */
+}
+
+/* rio vtable: tell callback — returns processed bytes from base */
+static off_t compressRioTell(rio *r) {
+    return (off_t)r->processed_bytes;
+}
+
+/* rio vtable: flush callback — algorithm flush (emit buffered data,
+ * keep frame open) + inner flush. Does NOT end the frame.
+ * This is critical because some call sites flush mid-stream. */
+static int compressRioFlush(rio *r) {
+    compress_rio_t *cr = (compress_rio_t *)r;
+    if (!cr->compressor || stream_writer_is_errored(cr->compressor)) return 0;
+    if (cr->finalized) return 1;
+
+    if (stream_writer_flush(cr->compressor) != 0) return 0;
+
+    if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
+        stream_writer_set_error(cr->compressor);
+        return 0;
+    }
+    return 1;
+}
+
+/* Initialize a compression rio decorator wrapping an inner rio.
+ * Sets up the rio vtable so callers can use standard rioWrite/rioFlush.
+ * The compressor is initialized with a fresh algorithm context (fork-safe). */
+/* Returns 0 on success, -1 on failure (e.g., compressor init failed). */
+int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_config_t *cfg) {
+    if (!cr || !inner || !cfg) return -1;
+
+    memset(cr, 0, sizeof(*cr));
+
+    uint64_t flags = RIO_FLAG_STREAMING_COMPRESSION;
+    if (cfg->codec_checksum_enabled) flags |= RIO_FLAG_STREAMING_CODEC_CHECKSUM;
+    flags |= inner->flags & RIO_FLAG_SKIP_RDB_CHECKSUM;
+
+    rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
+                compressRioFlush, flags, rioCheckType(inner));
+    /* Track the uncompressed byte stream only when the standard RDB checksum is
+     * the active integrity mechanism. Honor explicit skip requests from the
+     * wrapped rio and skip checksum tracking whenever codec checksums are
+     * authoritative. */
+    if (!(flags & (RIO_FLAG_SKIP_RDB_CHECKSUM | RIO_FLAG_STREAMING_CODEC_CHECKSUM))) {
+        cr->base.update_cksum = rioGenericUpdateChecksum;
+    }
+
+    cr->inner = inner;
+    cr->finalized = 0;
+    cr->compressor = stream_writer_create(cfg, compressRioEmit, cr);
+    return cr->compressor ? 0 : -1;
+}
+
+/* Finalize the compression frame and flush inner rio.
+ * Must be called exactly once at end of stream.
+ * Idempotent: safe to call multiple times (second call is a no-op). */
+/* Returns 0 on success, -1 if the compressor or inner flush errored. */
+int compress_rio_finish(compress_rio_t *cr) {
+    if (!cr) return -1;
+    if (!cr->compressor) return -1;
+    if (cr->finalized) return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+    cr->finalized = 1;
+
+    if (stream_writer_finish(cr->compressor) != 0) {
+        return -1;
+    }
+
+    /* Flush inner rio to ensure all bytes reach the destination.
+     * Propagate flush failure to the compressor error state so
+     * callers can detect it. */
+    if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
+        stream_writer_set_error(cr->compressor);
+    }
+    return stream_writer_is_errored(cr->compressor) ? -1 : 0;
+}
+
+/* Free compressor context and buffers. Does NOT finalize the frame.
+ * Call compress_rio_finish() first on all exit paths. */
+void compress_rio_destroy(compress_rio_t *cr) {
+    if (!cr) return;
+    if (cr->compressor) {
+        stream_writer_destroy(cr->compressor);
+        cr->compressor = NULL;
+    }
+}
+
+/* ===================================================================
+ * Decompression Rio Decorator
+ * Thin rio adapter around stream_reader_t.
+ * =================================================================== */
+
+/* Read up to `len` bytes from the inner rio (partial reads allowed).
+ * Returns >0 bytes, 0 on EOF, -1 on error. */
+static ssize_t decompressRioReadPartial(void *ctx, void *buf, size_t len) {
+    decompress_rio_t *dr = (decompress_rio_t *)ctx;
+    return rioReadPartial(dr->inner, buf, len);
+}
+
+static size_t decompressRioRead(rio *r, void *buf, size_t len) {
+    decompress_rio_t *dr = (decompress_rio_t *)r;
+    if (dr->base.flags & RIO_FLAG_READ_ERROR) return 0;
+    if (!dr->reader) {
+        dr->base.flags |= RIO_FLAG_READ_ERROR;
+        return 0;
+    }
+
+    uint8_t *dst = (uint8_t *)buf;
+    size_t remaining = len;
+    while (remaining > 0) {
+        ssize_t nread = stream_reader_read(dr->reader, dst, remaining);
+        if (nread < 0) {
+            dr->base.flags |= RIO_FLAG_READ_ERROR;
+            return 0;
+        }
+        if (nread == 0) {
+            /* rio contract: partial read is failure for requested len. */
+            dr->base.flags |= RIO_FLAG_READ_ERROR;
+            return 0;
+        }
+        remaining -= (size_t)nread;
+        dst += nread;
+    }
+    return len;
+}
+
+/* rio vtable: tell callback — report transport bytes consumed from the wrapped
+ * rio so progress stays tied to source-stream position. */
+static off_t decompressRioTell(rio *r) {
+    decompress_rio_t *dr = (decompress_rio_t *)r;
+    return (off_t)dr->inner->processed_bytes;
+}
+
+stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr) {
+    if (!dr || !dr->reader) return STREAM_READER_ERROR_IO;
+    return stream_reader_get_error(dr->reader);
+}
+
+/* Initialize a decompression rio and eagerly probe the wrapped stream so the
+ * caller gets a stable classification up front: passthrough, compressed, or
+ * incompatible envelope. */
+decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
+                                                   rio *inner,
+                                                   const stream_reader_config_t *cfg,
+                                                   stream_reader_info_t *info) {
+    stream_reader_info_t local_info = {0};
+
+    if (!dr || !inner || !cfg) return DECOMPRESS_RIO_INIT_ERROR;
+
+    memset(dr, 0, sizeof(*dr));
+    rioInitBase(&dr->base, decompressRioRead, rioWriteUnsupported, decompressRioTell,
+                rioFlushNoop,
+                RIO_FLAG_STREAMING_DECOMPRESSION | (inner->flags & RIO_FLAG_SKIP_RDB_CHECKSUM),
+                rioCheckType(inner));
+    dr->inner = inner;
+
+    dr->reader = stream_reader_create(cfg, decompressRioReadPartial, dr);
+    if (!dr->reader) {
+        dr->base.flags |= RIO_FLAG_READ_ERROR;
+        return DECOMPRESS_RIO_INIT_ERROR;
+    }
+    if (stream_reader_get_info(dr->reader, &local_info) != 0) {
+        stream_reader_error_t error_kind = stream_reader_get_error(dr->reader);
+        decompress_rio_destroy(dr);
+        return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
+                   ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
+                   : DECOMPRESS_RIO_INIT_ERROR;
+    }
+
+    if (local_info.compressed) {
+        dr->base.flags |= RIO_FLAG_STREAMING_COMPRESSION;
+        if (local_info.codec_checksum_enabled) {
+            dr->base.flags |= RIO_FLAG_STREAMING_CODEC_CHECKSUM;
+        }
+    }
+    if (info) *info = local_info;
+    return DECOMPRESS_RIO_INIT_OK;
+}
+
+void decompress_rio_destroy(decompress_rio_t *dr) {
+    if (!dr) return;
+    if (dr->reader) {
+        stream_reader_destroy(dr->reader);
+        dr->reader = NULL;
+    }
+}

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -14,37 +14,37 @@
 typedef struct {
     rio base; /* Must be first — allows casting to (rio *) */
     rio *inner;
-    stream_writer_t *writer;
+    streamWriter *writer;
     bool finalized;
-} compress_rio_t;
+} compressRio;
 
 /* Decompression rio wrapper. */
 typedef struct {
     rio base; /* Must be first */
     rio *inner;
-    stream_reader_t *reader;
-} decompress_rio_t;
+    streamReader *reader;
+} decompressRio;
 
 typedef enum {
     DECOMPRESS_RIO_INIT_ERROR = -1,
     DECOMPRESS_RIO_INIT_OK = 0,
     DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
-} decompress_rio_init_result_t;
+} decompressRioInitResult;
 
 /* --- Rio Decorator API --- */
-int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_config_t *cfg);
-int compress_rio_finish(compress_rio_t *cr);
-void compress_rio_destroy(compress_rio_t *cr);
+int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg);
+int compressRioFinish(compressRio *cr);
+void compressRioDestroy(compressRio *cr);
 
 /* Initialize and probe a decompression adapter in one step.
  * Returns OK for both passthrough and compressed streams, INCOMPATIBLE for
  * malformed/unexpected stream envelopes, and ERROR for I/O or setup failures. */
-decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
-                                                   rio *inner,
-                                                   const stream_reader_config_t *cfg,
-                                                   stream_reader_info_t *info);
-stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr);
+decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
+                                              rio *inner,
+                                              const streamReaderConfig *cfg,
+                                              streamReaderInfo *info);
+streamReaderError decompressRioGetError(const decompressRio *dr);
 /* Destroy the adapter without additional I/O. */
-void decompress_rio_destroy(decompress_rio_t *dr);
+void decompressRioDestroy(decompressRio *dr);
 
 #endif /* COMPRESSION_RIO_H */

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -14,7 +14,7 @@
 typedef struct {
     rio base; /* Must be first — allows casting to (rio *) */
     rio *inner;
-    stream_writer_t *compressor;
+    stream_writer_t *writer;
     bool finalized;
 } compress_rio_t;
 

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMPRESSION_RIO_H
+#define COMPRESSION_RIO_H
+
+#include "compression_stream.h"
+#include "rio.h"
+
+/* Compression rio wrapper. */
+typedef struct {
+    rio base; /* Must be first — allows casting to (rio *) */
+    rio *inner;
+    stream_writer_t *compressor;
+    bool finalized;
+} compress_rio_t;
+
+/* Decompression rio wrapper. */
+typedef struct {
+    rio base; /* Must be first */
+    rio *inner;
+    stream_reader_t *reader;
+} decompress_rio_t;
+
+typedef enum {
+    DECOMPRESS_RIO_INIT_ERROR = -1,
+    DECOMPRESS_RIO_INIT_OK = 0,
+    DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
+} decompress_rio_init_result_t;
+
+/* --- Rio Decorator API --- */
+int rioInitWithCompress(compress_rio_t *cr, rio *inner, const stream_writer_config_t *cfg);
+int compress_rio_finish(compress_rio_t *cr);
+void compress_rio_destroy(compress_rio_t *cr);
+
+/* Initialize and probe a decompression adapter in one step.
+ * Returns OK for both passthrough and compressed streams, INCOMPATIBLE for
+ * malformed/unexpected stream envelopes, and ERROR for I/O or setup failures. */
+decompress_rio_init_result_t rioInitWithDecompress(decompress_rio_t *dr,
+                                                   rio *inner,
+                                                   const stream_reader_config_t *cfg,
+                                                   stream_reader_info_t *info);
+stream_reader_error_t decompress_rio_get_error(const decompress_rio_t *dr);
+/* Destroy the adapter without additional I/O. */
+void decompress_rio_destroy(decompress_rio_t *dr);
+
+#endif /* COMPRESSION_RIO_H */

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -398,7 +398,7 @@ int stream_writer_flush(stream_writer_t *t) {
     /* Flush-after-finish is a harmless no-op: frame is already closed. */
     if (t->finished) return 0;
 
-    if (!t->envelope_written || !t->compressor.frame_started) return 0;
+    if (!t->envelope_written || !t->compressor.stream_started) return 0;
     if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_SYNC) != 0) return -1;
     return 0;
 }
@@ -735,7 +735,7 @@ static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size
                     t->error_kind == STREAM_READER_ERROR_NONE ? STREAM_READER_ERROR_IO
                                                               : t->error_kind);
             }
-            if (filled == 0 && !t->decompressor.frame_done) {
+            if (filled == 0 && !streamDecompressorFrameDone(&t->decompressor)) {
                 return streamReaderFailWithError(t, total, STREAM_READER_ERROR_CORRUPT);
             }
             if (filled == 0) break;

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -1,0 +1,785 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "compression_stream.h"
+#include "zmalloc.h"
+#include <limits.h>
+#include <string.h>
+
+/* --- VKCS envelope --- */
+
+typedef enum {
+    VKCS_PROBE_NEED_INPUT = 0,
+    VKCS_PROBE_PASSTHROUGH = 1,
+    VKCS_PROBE_COMPRESSED = 2,
+    VKCS_PROBE_ERROR = 3,
+} vkcs_probe_result_t;
+
+/* Probe options. */
+typedef struct {
+    bool allow_passthrough;
+    uint8_t expected_stream_kind;
+} vkcs_probe_config_t;
+
+/* Probe state. */
+typedef struct {
+    uint8_t header[VKCS_ENVELOPE_SIZE];
+    size_t header_len;
+    bool ready;
+    bool compressed;
+    bool codec_checksum_enabled;
+    compression_algo_t algo;
+    uint8_t stream_kind;
+} vkcs_probe_t;
+
+/* Write 8-byte VKCS envelope via callback.
+ * Layout:
+ *   [0..3] magic  "VKCS" (0x56 0x4B 0x43 0x53)
+ *   [4]    version (VKCS_VERSION, currently 1)
+ *   [5]    codec_id (VKCS codec registry)
+ *   [6]    flags   (bit 0 = codec checksum enabled, remaining bits reserved)
+ *   [7]    stream_kind (full 8-bit kind)
+ *
+ * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
+static bool vkcsCodecIsSupported(vkcs_codec_t codec) {
+    return codec == VKCS_CODEC_LZ4;
+}
+
+static bool vkcsProbeHasMagicPrefix(const vkcs_probe_t *probe) {
+    if (probe->header_len == 0) return false;
+    size_t magic_prefix_len = probe->header_len < 4 ? probe->header_len : 4;
+    return memcmp(probe->header, "VKCS", magic_prefix_len) == 0;
+}
+
+static void vkcsProbeSetPassthrough(vkcs_probe_t *probe) {
+    probe->ready = true;
+    probe->compressed = false;
+    probe->codec_checksum_enabled = false;
+    probe->algo = ALGO_NONE;
+    probe->stream_kind = 0;
+}
+
+static void vkcsProbeSetCompressed(vkcs_probe_t *probe,
+                                   compression_algo_t algo,
+                                   uint8_t stream_kind,
+                                   bool codec_checksum_enabled) {
+    probe->ready = true;
+    probe->compressed = true;
+    probe->codec_checksum_enabled = codec_checksum_enabled;
+    probe->algo = algo;
+    probe->stream_kind = stream_kind;
+}
+
+static int compressionAlgoToVkcsCodec(compression_algo_t algo, vkcs_codec_t *codec) {
+    switch (algo) {
+    case ALGO_LZ4:
+        *codec = VKCS_CODEC_LZ4;
+        return 0;
+    default:
+        return -1;
+    }
+}
+
+static int vkcsCodecToCompressionAlgo(vkcs_codec_t codec, compression_algo_t *algo) {
+    switch (codec) {
+    case VKCS_CODEC_LZ4:
+        *algo = ALGO_LZ4;
+        return 0;
+    default:
+        return -1;
+    }
+}
+
+static int write_vkcs_envelope(vkcs_emit_fn emit_cb,
+                               void *ctx,
+                               vkcs_codec_t codec,
+                               uint8_t stream_kind,
+                               bool codec_checksum_enabled) {
+    if (!emit_cb) return -1;
+    if (!vkcsCodecIsSupported(codec)) return -1;
+
+    uint8_t envelope[VKCS_ENVELOPE_SIZE];
+    envelope[0] = VKCS_MAGIC_0;
+    envelope[1] = VKCS_MAGIC_1;
+    envelope[2] = VKCS_MAGIC_2;
+    envelope[3] = VKCS_MAGIC_3;
+    envelope[4] = VKCS_VERSION;
+    envelope[5] = (uint8_t)codec;
+    envelope[6] = codec_checksum_enabled ? VKCS_FLAG_CODEC_CHECKSUM : 0;
+    envelope[7] = stream_kind;
+
+    return emit_cb(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
+}
+
+/* Parse 8-byte VKCS envelope from buffer.
+ * Validates magic bytes, version, codec, and reserved fields.
+ * Rejects envelopes with unknown flag bits so future versions are detected
+ * early rather than causing silent data corruption.
+ * On success populates *codec and *stream_kind and returns 0.
+ * Returns -1 on error (bad magic, unsupported version, unknown codec,
+ * reserved bits set). */
+static int read_vkcs_envelope(const uint8_t *buf,
+                              size_t len,
+                              vkcs_codec_t *codec,
+                              uint8_t *stream_kind,
+                              bool *codec_checksum_enabled) {
+    if (!buf || len < VKCS_ENVELOPE_SIZE) return -1;
+
+    if (buf[0] != VKCS_MAGIC_0 || buf[1] != VKCS_MAGIC_1 ||
+        buf[2] != VKCS_MAGIC_2 || buf[3] != VKCS_MAGIC_3) {
+        return -1;
+    }
+    if (buf[4] != VKCS_VERSION) return -1;
+
+    vkcs_codec_t parsed_codec = (vkcs_codec_t)buf[5];
+    if (!vkcsCodecIsSupported(parsed_codec)) return -1;
+
+    uint8_t flags = buf[6];
+    if (flags & ~VKCS_FLAG_CODEC_CHECKSUM) return -1;
+
+    if (codec) *codec = parsed_codec;
+    if (stream_kind) *stream_kind = buf[7];
+    if (codec_checksum_enabled) *codec_checksum_enabled = (flags & VKCS_FLAG_CODEC_CHECKSUM) != 0;
+    return 0;
+}
+
+static int readVkcsEnvelopeInfo(const uint8_t *buf,
+                                uint8_t expected_stream_kind,
+                                stream_reader_info_t *info) {
+    vkcs_codec_t codec;
+    uint8_t stream_kind = 0;
+    bool codec_checksum_enabled = false;
+    compression_algo_t algo = ALGO_NONE;
+
+    if (read_vkcs_envelope(buf, VKCS_ENVELOPE_SIZE,
+                           &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
+        stream_kind != expected_stream_kind ||
+        vkcsCodecToCompressionAlgo(codec, &algo) != 0) {
+        return -1;
+    }
+
+    info->compressed = true;
+    info->codec_checksum_enabled = codec_checksum_enabled;
+    info->algo = algo;
+    info->stream_kind = stream_kind;
+    return 0;
+}
+
+static void vkcsProbeInit(vkcs_probe_t *probe) {
+    memset(probe, 0, sizeof(*probe));
+    probe->algo = ALGO_NONE;
+    probe->codec_checksum_enabled = false;
+}
+
+/* Probe incrementally because wrapped rios may legally return fewer than
+ * VKCS_ENVELOPE_SIZE bytes per read. The probe also retains any consumed
+ * prefix so passthrough streams can replay those bytes exactly. */
+static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
+                                         const vkcs_probe_config_t *cfg,
+                                         const uint8_t *src,
+                                         size_t src_len,
+                                         bool input_eof,
+                                         size_t *src_consumed) {
+    size_t consumed = 0;
+
+    *src_consumed = 0;
+    if (probe->ready) {
+        return probe->compressed ? VKCS_PROBE_COMPRESSED : VKCS_PROBE_PASSTHROUGH;
+    }
+
+    while (consumed < src_len) {
+        size_t target = probe->header_len < 4 ? 4 : VKCS_ENVELOPE_SIZE;
+        size_t need = target - probe->header_len;
+        size_t take = src_len - consumed < need ? src_len - consumed : need;
+
+        memcpy(probe->header + probe->header_len, src + consumed, take);
+        probe->header_len += take;
+        consumed += take;
+
+        if (probe->header_len >= 4 &&
+            memcmp(probe->header, "VKCS", 4) != 0) {
+            *src_consumed = consumed;
+            if (!cfg->allow_passthrough) return VKCS_PROBE_ERROR;
+            vkcsProbeSetPassthrough(probe);
+            return VKCS_PROBE_PASSTHROUGH;
+        }
+
+        if (probe->header_len == VKCS_ENVELOPE_SIZE) {
+            stream_reader_info_t info = {0};
+
+            if (readVkcsEnvelopeInfo(probe->header, cfg->expected_stream_kind, &info) != 0) {
+                *src_consumed = consumed;
+                return VKCS_PROBE_ERROR;
+            }
+
+            vkcsProbeSetCompressed(probe, info.algo, info.stream_kind,
+                                   info.codec_checksum_enabled);
+            *src_consumed = consumed;
+            return VKCS_PROBE_COMPRESSED;
+        }
+    }
+
+    if (input_eof) {
+        *src_consumed = consumed;
+        /* If EOF lands in the middle of a potential VKCS header, treat it as
+         * a malformed compressed stream rather than silently downgrading it to
+         * passthrough mode. */
+        if (vkcsProbeHasMagicPrefix(probe)) return VKCS_PROBE_ERROR;
+        if (!cfg->allow_passthrough) return VKCS_PROBE_ERROR;
+        vkcsProbeSetPassthrough(probe);
+        return VKCS_PROBE_PASSTHROUGH;
+    }
+
+    *src_consumed = consumed;
+    return VKCS_PROBE_NEED_INPUT;
+}
+
+/* Generic streaming writer implementation. */
+
+#define STREAM_WRITER_INPUT_CHUNK_SIZE (1024 * 1024)
+
+/* Streaming writer context. */
+struct stream_writer {
+    stream_compressor_t compressor;
+    uint8_t *out_buf;     /* Reusable output buffer, sized via streamCompressOutputBound */
+    size_t out_buf_size;  /* Current allocation size of out_buf */
+    vkcs_emit_fn emit_cb; /* Returns 0 on success, -1 on error */
+    void *emit_ctx;
+    uint8_t stream_kind; /* Concrete on-wire stream kind */
+    bool envelope_written;
+    bool finished;          /* Set by stream_writer_finish — blocks further writes.
+                             * Prevents accidental multi-frame output under one envelope. */
+    bool errored;           /* Sticky error flag — once set, all writes fail */
+    uint64_t bytes_emitted; /* Running total of bytes successfully emitted */
+};
+
+static int streamWriterInitContext(stream_writer_t *t,
+                                   const stream_writer_config_t *cfg,
+                                   vkcs_emit_fn emit_cb,
+                                   void *emit_ctx) {
+    memset(t, 0, sizeof(*t));
+    t->emit_cb = emit_cb;
+    t->emit_ctx = emit_ctx;
+    t->stream_kind = cfg->stream_kind;
+
+    if (streamCompressorInit(&t->compressor, cfg->algo, cfg->level) != 0) {
+        return -1;
+    }
+    t->compressor.codec_checksum = cfg->codec_checksum_enabled;
+    return 0;
+}
+
+/* Emit envelope lazily on first write/flush/finish.
+ * Returns 0 on success, -1 on error (and sets t->errored). */
+static int streamWriterEnsureEnvelope(stream_writer_t *t) {
+    if (t->envelope_written) return 0;
+    vkcs_codec_t codec;
+    if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
+        write_vkcs_envelope(t->emit_cb, t->emit_ctx, codec,
+                            t->stream_kind, t->compressor.codec_checksum) != 0) {
+        t->errored = true;
+        return -1;
+    }
+    t->bytes_emitted += VKCS_ENVELOPE_SIZE;
+    t->envelope_written = true;
+    return 0;
+}
+
+/* Emit compressed bytes to the output sink.
+ * Returns 0 on success, -1 on error (and sets t->errored). */
+static int streamWriterEmit(stream_writer_t *t, const uint8_t *buf, size_t len) {
+    if (len == 0) return 0;
+    if (t->emit_cb(t->emit_ctx, buf, len) != 0) {
+        t->errored = true;
+        return -1;
+    }
+    t->bytes_emitted += len;
+    return 0;
+}
+
+/* Ensure the output buffer is large enough for the given input.
+ * Reuses the existing buffer when possible to avoid per-write allocation.
+ * zmalloc aborts on OOM, so this cannot fail. */
+static void streamWriterEnsureOutBuf(stream_writer_t *t, size_t input_len) {
+    size_t needed = streamCompressOutputBound(&t->compressor, input_len);
+    if (needed == 0) {
+        /* Ensure a minimal valid buffer so streamCompressFeed never gets NULL. */
+        if (t->out_buf == NULL) {
+            t->out_buf = zmalloc(64);
+            t->out_buf_size = 64;
+        }
+        return;
+    }
+    if (needed > t->out_buf_size) {
+        t->out_buf = zrealloc(t->out_buf, needed);
+        t->out_buf_size = needed;
+    }
+}
+
+/* Compress one chunk with the requested flush mode and emit produced bytes.
+ * Returns 0 on success, -1 on error (and sets t->errored). */
+static int streamWriterFeedAndEmit(stream_writer_t *t,
+                                   const uint8_t *input,
+                                   size_t input_len,
+                                   compress_flush_mode_t flush_mode) {
+    streamWriterEnsureOutBuf(t, input_len);
+
+    ssize_t compressed = streamCompressFeed(&t->compressor, t->out_buf,
+                                            t->out_buf_size,
+                                            input, input_len, flush_mode);
+    if (compressed < 0) {
+        t->errored = true;
+        return -1;
+    }
+    return streamWriterEmit(t, t->out_buf, (size_t)compressed);
+}
+
+/* Release stream compressor state owned by stream_writer_t.
+ * Does not free the context object itself. */
+static void streamWriterReleaseContext(stream_writer_t *t) {
+    streamCompressorDestroy(&t->compressor);
+    if (t->out_buf) {
+        zfree(t->out_buf);
+        t->out_buf = NULL;
+    }
+    t->out_buf_size = 0;
+}
+
+stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
+                                      vkcs_emit_fn emit_cb,
+                                      void *emit_ctx) {
+    if (!cfg || !emit_cb || !compressionAlgoSupportsStreaming(cfg->algo)) {
+        return NULL;
+    }
+
+    stream_writer_t *t = zmalloc(sizeof(*t));
+    if (streamWriterInitContext(t, cfg, emit_cb, emit_ctx) != 0) {
+        zfree(t);
+        return NULL;
+    }
+    return t;
+}
+
+ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len) {
+    if (!t) return -1;
+    if (t->errored) return -1;
+    /* Writes after finish are always a caller bug. Returning an error
+     * prevents silent data drops in shared API users (rio/replication). */
+    if (t->finished) return -1;
+    if (len == 0) return 0;
+    if (len > (size_t)SSIZE_MAX) return -1;
+
+    const uint8_t *src = (const uint8_t *)buf;
+    size_t remaining = len;
+    uint64_t emitted_before = t->bytes_emitted;
+    if (streamWriterEnsureEnvelope(t) != 0) return -1;
+    while (remaining > 0) {
+        size_t chunk_len = remaining < STREAM_WRITER_INPUT_CHUNK_SIZE
+                               ? remaining
+                               : STREAM_WRITER_INPUT_CHUNK_SIZE;
+        if (streamWriterFeedAndEmit(t, src, chunk_len, FLUSH_CONTINUE) != 0) return -1;
+        src += chunk_len;
+        remaining -= chunk_len;
+    }
+    uint64_t emitted_delta = t->bytes_emitted - emitted_before;
+    if (emitted_delta > (uint64_t)SSIZE_MAX) {
+        t->errored = true;
+        return -1;
+    }
+    return (ssize_t)emitted_delta;
+}
+
+int stream_writer_flush(stream_writer_t *t) {
+    if (!t) return -1;
+    if (t->errored) return -1;
+    /* Flush-after-finish is a harmless no-op: frame is already closed. */
+    if (t->finished) return 0;
+
+    if (!t->envelope_written || !t->compressor.frame_started) return 0;
+    if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_SYNC) != 0) return -1;
+    return 0;
+}
+
+int stream_writer_finish(stream_writer_t *t) {
+    if (!t) return -1;
+    if (t->errored) return -1;
+    if (t->finished) return 0;
+    t->finished = true;
+
+    /* If nothing was ever written, emit envelope + empty frame end. */
+    if (streamWriterEnsureEnvelope(t) != 0) return -1;
+    if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_END) != 0) return -1;
+    return 0;
+}
+
+void stream_writer_destroy(stream_writer_t *t) {
+    if (!t) return;
+    streamWriterReleaseContext(t);
+    zfree(t);
+}
+
+int stream_writer_is_errored(const stream_writer_t *t) {
+    return t && t->errored;
+}
+
+void stream_writer_set_error(stream_writer_t *t) {
+    if (!t) return;
+    t->errored = true;
+}
+
+/* Streaming reader context. */
+struct stream_reader {
+    stream_reader_read_fn read_cb; /* Returns >0 bytes, 0 EOF, -1 error */
+    void *read_ctx;
+
+    vkcs_probe_config_t probe_cfg;
+    vkcs_probe_t probe;
+    size_t probe_replay_pos; /* Unread passthrough bytes buffered by vkcsProbeFeed */
+    size_t buffer_size;
+    bool errored;
+    stream_reader_error_t error_kind;
+
+    stream_decompressor_t decompressor;
+    bool decompressor_initialized;
+
+    uint8_t *compressed_buf; /* Buffered compressed input */
+    size_t compressed_buf_pos;
+    size_t compressed_buf_len;
+
+    uint8_t *decompressed_buf; /* Buffered decompressed output for small caller reads */
+    size_t decompressed_buf_pos;
+    size_t decompressed_buf_len;
+};
+
+static void streamReaderSetError(stream_reader_t *t, stream_reader_error_t error_kind) {
+    t->errored = true;
+    if (t->error_kind == STREAM_READER_ERROR_NONE) {
+        t->error_kind = error_kind;
+    }
+}
+
+/* Preserve partial output on read errors while latching sticky error state. */
+static ssize_t streamReaderFail(stream_reader_t *t, size_t partial_bytes) {
+    streamReaderSetError(t, STREAM_READER_ERROR_IO);
+    return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
+}
+
+static ssize_t streamReaderFailWithError(stream_reader_t *t,
+                                         size_t partial_bytes,
+                                         stream_reader_error_t error_kind) {
+    streamReaderSetError(t, error_kind);
+    return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
+}
+
+static int streamReaderInitCompressedState(stream_reader_t *t, size_t buffer_size) {
+    if (streamDecompressorInit(&t->decompressor, t->probe.algo) != 0) {
+        return -1;
+    }
+    t->decompressor_initialized = true;
+
+    t->compressed_buf = zmalloc(buffer_size);
+    t->compressed_buf_pos = 0;
+    t->compressed_buf_len = 0;
+    t->decompressed_buf = zmalloc(buffer_size);
+    t->decompressed_buf_pos = 0;
+    t->decompressed_buf_len = 0;
+    return 0;
+}
+
+static void streamReaderResetCompressedState(stream_reader_t *t) {
+    if (t->decompressor_initialized) {
+        streamDecompressorDestroy(&t->decompressor);
+        t->decompressor_initialized = false;
+    }
+    if (t->compressed_buf) {
+        zfree(t->compressed_buf);
+        t->compressed_buf = NULL;
+    }
+    t->compressed_buf_pos = 0;
+    t->compressed_buf_len = 0;
+    if (t->decompressed_buf) {
+        zfree(t->decompressed_buf);
+        t->decompressed_buf = NULL;
+    }
+    t->decompressed_buf_pos = 0;
+    t->decompressed_buf_len = 0;
+}
+
+stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
+                                      stream_reader_read_fn read_cb,
+                                      void *read_ctx) {
+    if (!read_cb) return NULL;
+    if (!cfg) return NULL;
+
+    stream_reader_t *t = zmalloc(sizeof(*t));
+    memset(t, 0, sizeof(*t));
+    t->read_cb = read_cb;
+    t->read_ctx = read_ctx;
+    t->probe_cfg.allow_passthrough = cfg->allow_passthrough;
+    t->probe_cfg.expected_stream_kind = cfg->expected_stream_kind;
+    vkcsProbeInit(&t->probe);
+    t->buffer_size = cfg->buffer_size ? cfg->buffer_size : STREAM_READER_BUFFER_SIZE_DEFAULT;
+    if (t->buffer_size < STREAM_READER_BUFFER_SIZE_MIN) {
+        t->buffer_size = STREAM_READER_BUFFER_SIZE_MIN;
+    }
+    return t;
+}
+
+static size_t streamReaderProbeBytesNeeded(const stream_reader_t *t) {
+    if (t->probe.header_len < 4) return 4 - t->probe.header_len;
+    return VKCS_ENVELOPE_SIZE - t->probe.header_len;
+}
+
+int stream_reader_probe(stream_reader_t *t) {
+    if (!t) return -1;
+    if (t->errored) return -1;
+    if (t->probe.ready) return 0;
+
+    while (!t->probe.ready) {
+        uint8_t buf[VKCS_ENVELOPE_SIZE];
+        size_t need = streamReaderProbeBytesNeeded(t);
+        ssize_t got = t->read_cb(t->read_ctx, buf, need);
+        size_t consumed = 0;
+
+        if (got < 0 || (size_t)got > need) {
+            streamReaderSetError(t, STREAM_READER_ERROR_IO);
+            return -1;
+        }
+
+        vkcs_probe_result_t status = vkcsProbeFeed(&t->probe, &t->probe_cfg, buf,
+                                                   got > 0 ? (size_t)got : 0,
+                                                   got == 0, &consumed);
+        if (status == VKCS_PROBE_ERROR) {
+            streamReaderSetError(t, STREAM_READER_ERROR_INCOMPATIBLE);
+            return -1;
+        }
+        if (consumed != (size_t)(got > 0 ? got : 0)) {
+            streamReaderSetError(t, STREAM_READER_ERROR_IO);
+            return -1;
+        }
+        if (status == VKCS_PROBE_NEED_INPUT) continue;
+        if (status == VKCS_PROBE_COMPRESSED &&
+            !t->decompressor_initialized &&
+            streamReaderInitCompressedState(t, t->buffer_size) != 0) {
+            streamReaderSetError(t, STREAM_READER_ERROR_IO);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static size_t streamReaderProbeAvail(const stream_reader_t *t) {
+    if (t->probe.header_len <= t->probe_replay_pos) return 0;
+    return t->probe.header_len - t->probe_replay_pos;
+}
+
+/* Passthrough reads may need to replay probe bytes before reading directly
+ * from the wrapped source. On a transport read error after replaying some
+ * bytes, return the partial payload and latch a sticky error for the next call. */
+static ssize_t streamReaderReadPassthrough(stream_reader_t *t,
+                                           uint8_t *dst,
+                                           size_t len) {
+    size_t total = 0;
+
+    size_t prefix_avail = streamReaderProbeAvail(t);
+    if (prefix_avail > 0) {
+        size_t from_prefix = prefix_avail < len ? prefix_avail : len;
+        memcpy(dst, t->probe.header + t->probe_replay_pos, from_prefix);
+        t->probe_replay_pos += from_prefix;
+        dst += from_prefix;
+        len -= from_prefix;
+        total += from_prefix;
+    }
+
+    if (len == 0) return (ssize_t)total;
+
+    ssize_t got = t->read_cb(t->read_ctx, dst, len);
+    if (got < 0 || (size_t)got > len) return streamReaderFail(t, total);
+    return (ssize_t)(total + (size_t)got);
+}
+
+static int streamReaderDrainCompressedBuf(stream_reader_t *t,
+                                          uint8_t *out,
+                                          size_t out_size,
+                                          size_t *out_written) {
+    *out_written = 0;
+    while (t->compressed_buf_len > 0 && *out_written < out_size) {
+        size_t consumed = 0;
+        ssize_t produced = streamDecompressFeed(
+            &t->decompressor,
+            out + *out_written, out_size - *out_written,
+            t->compressed_buf + t->compressed_buf_pos,
+            t->compressed_buf_len, &consumed);
+        if (produced < 0) {
+            streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+            return -1;
+        }
+        if (consumed > t->compressed_buf_len ||
+            (size_t)produced > out_size - *out_written) {
+            streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+            return -1;
+        }
+        *out_written += (size_t)produced;
+        t->compressed_buf_pos += consumed;
+        t->compressed_buf_len -= consumed;
+        if (consumed == 0 && produced == 0) break;
+    }
+    if (t->compressed_buf_len == 0) t->compressed_buf_pos = 0;
+    return 0;
+}
+
+static size_t streamReaderCompressedBufTailSpace(stream_reader_t *t) {
+    size_t tail_space = t->buffer_size - t->compressed_buf_pos - t->compressed_buf_len;
+    if (tail_space > 0) return tail_space;
+
+    if (t->compressed_buf_len == 0) {
+        t->compressed_buf_pos = 0;
+        return t->buffer_size;
+    }
+
+    if (t->compressed_buf_pos > 0) {
+        memmove(t->compressed_buf, t->compressed_buf + t->compressed_buf_pos, t->compressed_buf_len);
+        t->compressed_buf_pos = 0;
+        return t->buffer_size - t->compressed_buf_len;
+    }
+
+    /* The generic stream reader intentionally keeps a fixed-size compressed
+     * input buffer and a fixed-size decompressed output window. If the codec
+     * cannot make progress while the compressed buffer is full, treat the
+     * stream as corrupt instead of growing more state. */
+    streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+    return 0;
+}
+
+static int streamReaderRefillCompressedBuf(stream_reader_t *t) {
+    size_t read_size = streamReaderCompressedBufTailSpace(t);
+    if (read_size > (size_t)SSIZE_MAX) read_size = (size_t)SSIZE_MAX;
+    if (read_size == 0) return -1;
+
+    ssize_t got = t->read_cb(
+        t->read_ctx,
+        t->compressed_buf + t->compressed_buf_pos + t->compressed_buf_len,
+        read_size);
+    if (got < 0) return -1;
+    if (got == 0) return 0;
+    if ((size_t)got > read_size) return -1;
+    t->compressed_buf_len += (size_t)got;
+    return 1;
+}
+
+static ssize_t streamReaderFillDecompressedBuf(stream_reader_t *t) {
+    size_t written = 0;
+
+    t->decompressed_buf_pos = 0;
+    t->decompressed_buf_len = 0;
+
+    while (written < t->buffer_size) {
+        if (t->compressed_buf_len > 0) {
+            size_t chunk_written = 0;
+            if (streamReaderDrainCompressedBuf(t, t->decompressed_buf + written,
+                                               t->buffer_size - written, &chunk_written) != 0) {
+                written += chunk_written;
+                break;
+            }
+            written += chunk_written;
+            if (written >= t->buffer_size) break;
+        }
+
+        int read_rc = streamReaderRefillCompressedBuf(t);
+        if (read_rc < 0) {
+            streamReaderSetError(t, STREAM_READER_ERROR_IO);
+            if (written == 0) return -1;
+            break;
+        }
+        if (read_rc == 0) break;
+    }
+
+    t->decompressed_buf_len = written;
+    return (ssize_t)written;
+}
+
+static inline size_t streamReaderDecompressedBufAvail(const stream_reader_t *t) {
+    if (t->decompressed_buf_len <= t->decompressed_buf_pos) return 0;
+    return t->decompressed_buf_len - t->decompressed_buf_pos;
+}
+
+static size_t streamReaderCopyFromDecompressedBuf(stream_reader_t *t,
+                                                  uint8_t **dst,
+                                                  size_t *remaining) {
+    size_t avail = streamReaderDecompressedBufAvail(t);
+    if (avail == 0 || *remaining == 0) return 0;
+
+    size_t to_copy = avail < *remaining ? avail : *remaining;
+    memcpy(*dst, t->decompressed_buf + t->decompressed_buf_pos, to_copy);
+    t->decompressed_buf_pos += to_copy;
+    *dst += to_copy;
+    *remaining -= to_copy;
+    return to_copy;
+}
+
+static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size_t len) {
+    size_t remaining = len;
+    size_t total = 0;
+
+    total += streamReaderCopyFromDecompressedBuf(t, &dst, &remaining);
+    while (remaining > 0) {
+        if (streamReaderDecompressedBufAvail(t) == 0) {
+            ssize_t filled = streamReaderFillDecompressedBuf(t);
+            if (filled < 0) {
+                return streamReaderFailWithError(
+                    t, total,
+                    t->error_kind == STREAM_READER_ERROR_NONE ? STREAM_READER_ERROR_IO
+                                                              : t->error_kind);
+            }
+            if (filled == 0 && !t->decompressor.frame_done) {
+                return streamReaderFailWithError(t, total, STREAM_READER_ERROR_CORRUPT);
+            }
+            if (filled == 0) break;
+        }
+
+        total += streamReaderCopyFromDecompressedBuf(t, &dst, &remaining);
+        if (t->errored) break;
+    }
+
+    return (ssize_t)total;
+}
+
+ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len) {
+    if (!t || !buf) return -1;
+    if (t->errored) return -1;
+    if (len == 0) return 0;
+    if (len > (size_t)SSIZE_MAX) return -1;
+
+    if (stream_reader_probe(t) != 0) return -1;
+
+    if (!t->probe.compressed) {
+        return streamReaderReadPassthrough(t, (uint8_t *)buf, len);
+    }
+
+    return streamReaderReadCompressed(t, (uint8_t *)buf, len);
+}
+
+int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info) {
+    if (!t || !info) return -1;
+    if (stream_reader_probe(t) != 0) return -1;
+
+    info->compressed = t->probe.compressed;
+    info->codec_checksum_enabled = t->probe.compressed ? t->probe.codec_checksum_enabled : false;
+    info->algo = t->probe.compressed ? t->probe.algo : ALGO_NONE;
+    info->stream_kind = t->probe.stream_kind;
+    return 0;
+}
+
+stream_reader_error_t stream_reader_get_error(const stream_reader_t *t) {
+    return t ? t->error_kind : STREAM_READER_ERROR_IO;
+}
+
+void stream_reader_destroy(stream_reader_t *t) {
+    if (!t) return;
+    streamReaderResetCompressedState(t);
+    zfree(t);
+}

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -6,6 +6,7 @@
 
 #include "compression_stream.h"
 #include "zmalloc.h"
+#include <assert.h>
 #include <limits.h>
 #include <string.h>
 
@@ -16,13 +17,13 @@ typedef enum {
     VKCS_PROBE_PASSTHROUGH = 1,
     VKCS_PROBE_COMPRESSED = 2,
     VKCS_PROBE_ERROR = 3,
-} vkcs_probe_result_t;
+} vkcsProbeResult;
 
 /* Probe options. */
 typedef struct {
     bool allow_passthrough;
     uint8_t expected_stream_kind;
-} vkcs_probe_config_t;
+} vkcsProbeConfig;
 
 /* Probe state. */
 typedef struct {
@@ -31,9 +32,9 @@ typedef struct {
     bool ready;
     bool compressed;
     bool codec_checksum_enabled;
-    compression_algo_t algo;
+    compressionAlgo algo;
     uint8_t stream_kind;
-} vkcs_probe_t;
+} vkcsProbe;
 
 /* Write 8-byte VKCS envelope via callback.
  * Layout:
@@ -44,17 +45,17 @@ typedef struct {
  *   [7]    stream_kind (full 8-bit kind)
  *
  * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
-static bool vkcsCodecIsSupported(vkcs_codec_t codec) {
+static bool vkcsCodecIsSupported(vkcsCodec codec) {
     return codec == VKCS_CODEC_LZ4;
 }
 
-static bool vkcsProbeHasMagicPrefix(const vkcs_probe_t *probe) {
+static bool vkcsProbeHasMagicPrefix(const vkcsProbe *probe) {
     if (probe->header_len == 0) return false;
     size_t magic_prefix_len = probe->header_len < 4 ? probe->header_len : 4;
     return memcmp(probe->header, "VKCS", magic_prefix_len) == 0;
 }
 
-static void vkcsProbeSetPassthrough(vkcs_probe_t *probe) {
+static void vkcsProbeSetPassthrough(vkcsProbe *probe) {
     probe->ready = true;
     probe->compressed = false;
     probe->codec_checksum_enabled = false;
@@ -62,8 +63,8 @@ static void vkcsProbeSetPassthrough(vkcs_probe_t *probe) {
     probe->stream_kind = 0;
 }
 
-static void vkcsProbeSetCompressed(vkcs_probe_t *probe,
-                                   compression_algo_t algo,
+static void vkcsProbeSetCompressed(vkcsProbe *probe,
+                                   compressionAlgo algo,
                                    uint8_t stream_kind,
                                    bool codec_checksum_enabled) {
     probe->ready = true;
@@ -73,7 +74,7 @@ static void vkcsProbeSetCompressed(vkcs_probe_t *probe,
     probe->stream_kind = stream_kind;
 }
 
-static int compressionAlgoToVkcsCodec(compression_algo_t algo, vkcs_codec_t *codec) {
+static int compressionAlgoToVkcsCodec(compressionAlgo algo, vkcsCodec *codec) {
     switch (algo) {
     case ALGO_LZ4:
         *codec = VKCS_CODEC_LZ4;
@@ -83,7 +84,7 @@ static int compressionAlgoToVkcsCodec(compression_algo_t algo, vkcs_codec_t *cod
     }
 }
 
-static int vkcsCodecToCompressionAlgo(vkcs_codec_t codec, compression_algo_t *algo) {
+static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
     switch (codec) {
     case VKCS_CODEC_LZ4:
         *algo = ALGO_LZ4;
@@ -93,11 +94,11 @@ static int vkcsCodecToCompressionAlgo(vkcs_codec_t codec, compression_algo_t *al
     }
 }
 
-static int write_vkcs_envelope(vkcs_emit_fn emit_cb,
-                               void *ctx,
-                               vkcs_codec_t codec,
-                               uint8_t stream_kind,
-                               bool codec_checksum_enabled) {
+static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
+                             void *ctx,
+                             vkcsCodec codec,
+                             uint8_t stream_kind,
+                             bool codec_checksum_enabled) {
     if (!emit_cb) return -1;
     if (!vkcsCodecIsSupported(codec)) return -1;
 
@@ -121,11 +122,11 @@ static int write_vkcs_envelope(vkcs_emit_fn emit_cb,
  * On success populates *codec and *stream_kind and returns 0.
  * Returns -1 on error (bad magic, unsupported version, unknown codec,
  * reserved bits set). */
-static int read_vkcs_envelope(const uint8_t *buf,
-                              size_t len,
-                              vkcs_codec_t *codec,
-                              uint8_t *stream_kind,
-                              bool *codec_checksum_enabled) {
+static int readVkcsEnvelope(const uint8_t *buf,
+                            size_t len,
+                            vkcsCodec *codec,
+                            uint8_t *stream_kind,
+                            bool *codec_checksum_enabled) {
     if (!buf || len < VKCS_ENVELOPE_SIZE) return -1;
 
     if (buf[0] != VKCS_MAGIC_0 || buf[1] != VKCS_MAGIC_1 ||
@@ -134,7 +135,7 @@ static int read_vkcs_envelope(const uint8_t *buf,
     }
     if (buf[4] != VKCS_VERSION) return -1;
 
-    vkcs_codec_t parsed_codec = (vkcs_codec_t)buf[5];
+    vkcsCodec parsed_codec = (vkcsCodec)buf[5];
     if (!vkcsCodecIsSupported(parsed_codec)) return -1;
 
     uint8_t flags = buf[6];
@@ -148,14 +149,14 @@ static int read_vkcs_envelope(const uint8_t *buf,
 
 static int readVkcsEnvelopeInfo(const uint8_t *buf,
                                 uint8_t expected_stream_kind,
-                                stream_reader_info_t *info) {
-    vkcs_codec_t codec;
+                                streamReaderInfo *info) {
+    vkcsCodec codec;
     uint8_t stream_kind = 0;
     bool codec_checksum_enabled = false;
-    compression_algo_t algo = ALGO_NONE;
+    compressionAlgo algo = ALGO_NONE;
 
-    if (read_vkcs_envelope(buf, VKCS_ENVELOPE_SIZE,
-                           &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
+    if (readVkcsEnvelope(buf, VKCS_ENVELOPE_SIZE,
+                         &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
         stream_kind != expected_stream_kind ||
         vkcsCodecToCompressionAlgo(codec, &algo) != 0) {
         return -1;
@@ -168,7 +169,7 @@ static int readVkcsEnvelopeInfo(const uint8_t *buf,
     return 0;
 }
 
-static void vkcsProbeInit(vkcs_probe_t *probe) {
+static void vkcsProbeInit(vkcsProbe *probe) {
     memset(probe, 0, sizeof(*probe));
     probe->algo = ALGO_NONE;
     probe->codec_checksum_enabled = false;
@@ -177,12 +178,12 @@ static void vkcsProbeInit(vkcs_probe_t *probe) {
 /* Probe incrementally because wrapped rios may legally return fewer than
  * VKCS_ENVELOPE_SIZE bytes per read. The probe also retains any consumed
  * prefix so passthrough streams can replay those bytes exactly. */
-static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
-                                         const vkcs_probe_config_t *cfg,
-                                         const uint8_t *src,
-                                         size_t src_len,
-                                         bool input_eof,
-                                         size_t *src_consumed) {
+static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
+                                     const vkcsProbeConfig *cfg,
+                                     const uint8_t *src,
+                                     size_t src_len,
+                                     bool input_eof,
+                                     size_t *src_consumed) {
     size_t consumed = 0;
 
     *src_consumed = 0;
@@ -208,7 +209,7 @@ static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
         }
 
         if (probe->header_len == VKCS_ENVELOPE_SIZE) {
-            stream_reader_info_t info = {0};
+            streamReaderInfo info = {0};
 
             if (readVkcsEnvelopeInfo(probe->header, cfg->expected_stream_kind, &info) != 0) {
                 *src_consumed = consumed;
@@ -242,23 +243,23 @@ static vkcs_probe_result_t vkcsProbeFeed(vkcs_probe_t *probe,
 #define STREAM_WRITER_INPUT_CHUNK_SIZE (1024 * 1024)
 
 /* Streaming writer context. */
-struct stream_writer {
-    stream_compressor_t compressor;
-    uint8_t *out_buf;     /* Reusable output buffer, sized via streamCompressOutputBound */
-    size_t out_buf_size;  /* Current allocation size of out_buf */
-    vkcs_emit_fn emit_cb; /* Returns 0 on success, -1 on error */
+struct streamWriter {
+    streamCompressor compressor;
+    uint8_t *out_buf;    /* Reusable output buffer, sized via streamCompressOutputBound */
+    size_t out_buf_size; /* Current allocation size of out_buf */
+    vkcsEmitFn emit_cb;  /* Returns 0 on success, -1 on error */
     void *emit_ctx;
     uint8_t stream_kind; /* Concrete on-wire stream kind */
     bool envelope_written;
-    bool finished;          /* Set by stream_writer_finish — blocks further writes.
+    bool finished;          /* Set by streamWriterFinish — blocks further writes.
                              * Prevents accidental multi-frame output under one envelope. */
     bool errored;           /* Sticky error flag — once set, all writes fail */
     uint64_t bytes_emitted; /* Running total of bytes successfully emitted */
 };
 
-static int streamWriterInitContext(stream_writer_t *t,
-                                   const stream_writer_config_t *cfg,
-                                   vkcs_emit_fn emit_cb,
+static int streamWriterInitContext(streamWriter *t,
+                                   const streamWriterConfig *cfg,
+                                   vkcsEmitFn emit_cb,
                                    void *emit_ctx) {
     memset(t, 0, sizeof(*t));
     t->emit_cb = emit_cb;
@@ -274,12 +275,12 @@ static int streamWriterInitContext(stream_writer_t *t,
 
 /* Emit envelope lazily on first write/flush/finish.
  * Returns 0 on success, -1 on error (and sets t->errored). */
-static int streamWriterEnsureEnvelope(stream_writer_t *t) {
+static int streamWriterEnsureEnvelope(streamWriter *t) {
     if (t->envelope_written) return 0;
-    vkcs_codec_t codec;
+    vkcsCodec codec;
     if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
-        write_vkcs_envelope(t->emit_cb, t->emit_ctx, codec,
-                            t->stream_kind, t->compressor.codec_checksum) != 0) {
+        writeVkcsEnvelope(t->emit_cb, t->emit_ctx, codec,
+                          t->stream_kind, t->compressor.codec_checksum) != 0) {
         t->errored = true;
         return -1;
     }
@@ -290,7 +291,7 @@ static int streamWriterEnsureEnvelope(stream_writer_t *t) {
 
 /* Emit compressed bytes to the output sink.
  * Returns 0 on success, -1 on error (and sets t->errored). */
-static int streamWriterEmit(stream_writer_t *t, const uint8_t *buf, size_t len) {
+static int streamWriterEmit(streamWriter *t, const uint8_t *buf, size_t len) {
     if (len == 0) return 0;
     if (t->emit_cb(t->emit_ctx, buf, len) != 0) {
         t->errored = true;
@@ -303,16 +304,11 @@ static int streamWriterEmit(stream_writer_t *t, const uint8_t *buf, size_t len) 
 /* Ensure the output buffer is large enough for the given input.
  * Reuses the existing buffer when possible to avoid per-write allocation.
  * zmalloc aborts on OOM, so this cannot fail. */
-static void streamWriterEnsureOutBuf(stream_writer_t *t, size_t input_len) {
+static void streamWriterEnsureOutBuf(streamWriter *t, size_t input_len) {
     size_t needed = streamCompressOutputBound(&t->compressor, input_len);
-    if (needed == 0) {
-        /* Ensure a minimal valid buffer so streamCompressFeed never gets NULL. */
-        if (t->out_buf == NULL) {
-            t->out_buf = zmalloc(64);
-            t->out_buf_size = 64;
-        }
-        return;
-    }
+    /* A zero bound means the compressor is in an invalid state (NULL or no
+     * codec). The caller should have failed before reaching this point. */
+    assert(needed > 0);
     if (needed > t->out_buf_size) {
         t->out_buf = zrealloc(t->out_buf, needed);
         t->out_buf_size = needed;
@@ -321,10 +317,10 @@ static void streamWriterEnsureOutBuf(stream_writer_t *t, size_t input_len) {
 
 /* Compress one chunk with the requested flush mode and emit produced bytes.
  * Returns 0 on success, -1 on error (and sets t->errored). */
-static int streamWriterFeedAndEmit(stream_writer_t *t,
+static int streamWriterFeedAndEmit(streamWriter *t,
                                    const uint8_t *input,
                                    size_t input_len,
-                                   compress_flush_mode_t flush_mode) {
+                                   compressFlushMode flush_mode) {
     streamWriterEnsureOutBuf(t, input_len);
 
     ssize_t compressed = streamCompressFeed(&t->compressor, t->out_buf,
@@ -337,9 +333,9 @@ static int streamWriterFeedAndEmit(stream_writer_t *t,
     return streamWriterEmit(t, t->out_buf, (size_t)compressed);
 }
 
-/* Release stream compressor state owned by stream_writer_t.
+/* Release stream compressor state owned by streamWriter.
  * Does not free the context object itself. */
-static void streamWriterReleaseContext(stream_writer_t *t) {
+static void streamWriterReleaseContext(streamWriter *t) {
     streamCompressorDestroy(&t->compressor);
     if (t->out_buf) {
         zfree(t->out_buf);
@@ -348,14 +344,14 @@ static void streamWriterReleaseContext(stream_writer_t *t) {
     t->out_buf_size = 0;
 }
 
-stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
-                                      vkcs_emit_fn emit_cb,
-                                      void *emit_ctx) {
+streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
+                                 vkcsEmitFn emit_cb,
+                                 void *emit_ctx) {
     if (!cfg || !emit_cb || !compressionAlgoSupportsStreaming(cfg->algo)) {
         return NULL;
     }
 
-    stream_writer_t *t = zmalloc(sizeof(*t));
+    streamWriter *t = zmalloc(sizeof(*t));
     if (streamWriterInitContext(t, cfg, emit_cb, emit_ctx) != 0) {
         zfree(t);
         return NULL;
@@ -363,7 +359,7 @@ stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
     return t;
 }
 
-ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len) {
+ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len) {
     if (!t) return -1;
     if (t->errored) return -1;
     /* Writes after finish are always a caller bug. Returning an error
@@ -392,7 +388,7 @@ ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len) {
     return (ssize_t)emitted_delta;
 }
 
-int stream_writer_flush(stream_writer_t *t) {
+int streamWriterFlush(streamWriter *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     /* Flush-after-finish is a harmless no-op: frame is already closed. */
@@ -403,7 +399,7 @@ int stream_writer_flush(stream_writer_t *t) {
     return 0;
 }
 
-int stream_writer_finish(stream_writer_t *t) {
+int streamWriterFinish(streamWriter *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     if (t->finished) return 0;
@@ -415,34 +411,34 @@ int stream_writer_finish(stream_writer_t *t) {
     return 0;
 }
 
-void stream_writer_destroy(stream_writer_t *t) {
+void streamWriterDestroy(streamWriter *t) {
     if (!t) return;
     streamWriterReleaseContext(t);
     zfree(t);
 }
 
-int stream_writer_is_errored(const stream_writer_t *t) {
+int streamWriterIsErrored(const streamWriter *t) {
     return t && t->errored;
 }
 
-void stream_writer_set_error(stream_writer_t *t) {
+void streamWriterSetError(streamWriter *t) {
     if (!t) return;
     t->errored = true;
 }
 
 /* Streaming reader context. */
-struct stream_reader {
-    stream_reader_read_fn read_cb; /* Returns >0 bytes, 0 EOF, -1 error */
+struct streamReader {
+    streamReaderReadFn read_cb; /* Returns >0 bytes, 0 EOF, -1 error */
     void *read_ctx;
 
-    vkcs_probe_config_t probe_cfg;
-    vkcs_probe_t probe;
+    vkcsProbeConfig probe_cfg;
+    vkcsProbe probe;
     size_t probe_replay_pos; /* Unread passthrough bytes buffered by vkcsProbeFeed */
     size_t buffer_size;
     bool errored;
-    stream_reader_error_t error_kind;
+    streamReaderError error_kind;
 
-    stream_decompressor_t decompressor;
+    streamDecompressor decompressor;
     bool decompressor_initialized;
 
     uint8_t *compressed_buf; /* Buffered compressed input */
@@ -454,7 +450,7 @@ struct stream_reader {
     size_t decompressed_buf_len;
 };
 
-static void streamReaderSetError(stream_reader_t *t, stream_reader_error_t error_kind) {
+static void streamReaderSetError(streamReader *t, streamReaderError error_kind) {
     t->errored = true;
     if (t->error_kind == STREAM_READER_ERROR_NONE) {
         t->error_kind = error_kind;
@@ -462,19 +458,19 @@ static void streamReaderSetError(stream_reader_t *t, stream_reader_error_t error
 }
 
 /* Preserve partial output on read errors while latching sticky error state. */
-static ssize_t streamReaderFail(stream_reader_t *t, size_t partial_bytes) {
+static ssize_t streamReaderFail(streamReader *t, size_t partial_bytes) {
     streamReaderSetError(t, STREAM_READER_ERROR_IO);
     return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
 }
 
-static ssize_t streamReaderFailWithError(stream_reader_t *t,
+static ssize_t streamReaderFailWithError(streamReader *t,
                                          size_t partial_bytes,
-                                         stream_reader_error_t error_kind) {
+                                         streamReaderError error_kind) {
     streamReaderSetError(t, error_kind);
     return partial_bytes > 0 ? (ssize_t)partial_bytes : -1;
 }
 
-static int streamReaderInitCompressedState(stream_reader_t *t, size_t buffer_size) {
+static int streamReaderInitCompressedState(streamReader *t, size_t buffer_size) {
     if (streamDecompressorInit(&t->decompressor, t->probe.algo) != 0) {
         return -1;
     }
@@ -489,7 +485,7 @@ static int streamReaderInitCompressedState(stream_reader_t *t, size_t buffer_siz
     return 0;
 }
 
-static void streamReaderResetCompressedState(stream_reader_t *t) {
+static void streamReaderResetCompressedState(streamReader *t) {
     if (t->decompressor_initialized) {
         streamDecompressorDestroy(&t->decompressor);
         t->decompressor_initialized = false;
@@ -508,13 +504,13 @@ static void streamReaderResetCompressedState(stream_reader_t *t) {
     t->decompressed_buf_len = 0;
 }
 
-stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
-                                      stream_reader_read_fn read_cb,
-                                      void *read_ctx) {
+streamReader *streamReaderCreate(const streamReaderConfig *cfg,
+                                 streamReaderReadFn read_cb,
+                                 void *read_ctx) {
     if (!read_cb) return NULL;
     if (!cfg) return NULL;
 
-    stream_reader_t *t = zmalloc(sizeof(*t));
+    streamReader *t = zmalloc(sizeof(*t));
     memset(t, 0, sizeof(*t));
     t->read_cb = read_cb;
     t->read_ctx = read_ctx;
@@ -528,12 +524,12 @@ stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
     return t;
 }
 
-static size_t streamReaderProbeBytesNeeded(const stream_reader_t *t) {
+static size_t streamReaderProbeBytesNeeded(const streamReader *t) {
     if (t->probe.header_len < 4) return 4 - t->probe.header_len;
     return VKCS_ENVELOPE_SIZE - t->probe.header_len;
 }
 
-int stream_reader_probe(stream_reader_t *t) {
+int streamReaderProbe(streamReader *t) {
     if (!t) return -1;
     if (t->errored) return -1;
     if (t->probe.ready) return 0;
@@ -549,9 +545,9 @@ int stream_reader_probe(stream_reader_t *t) {
             return -1;
         }
 
-        vkcs_probe_result_t status = vkcsProbeFeed(&t->probe, &t->probe_cfg, buf,
-                                                   got > 0 ? (size_t)got : 0,
-                                                   got == 0, &consumed);
+        vkcsProbeResult status = vkcsProbeFeed(&t->probe, &t->probe_cfg, buf,
+                                               got > 0 ? (size_t)got : 0,
+                                               got == 0, &consumed);
         if (status == VKCS_PROBE_ERROR) {
             streamReaderSetError(t, STREAM_READER_ERROR_INCOMPATIBLE);
             return -1;
@@ -572,7 +568,7 @@ int stream_reader_probe(stream_reader_t *t) {
     return 0;
 }
 
-static size_t streamReaderProbeAvail(const stream_reader_t *t) {
+static size_t streamReaderProbeAvail(const streamReader *t) {
     if (t->probe.header_len <= t->probe_replay_pos) return 0;
     return t->probe.header_len - t->probe_replay_pos;
 }
@@ -580,7 +576,7 @@ static size_t streamReaderProbeAvail(const stream_reader_t *t) {
 /* Passthrough reads may need to replay probe bytes before reading directly
  * from the wrapped source. On a transport read error after replaying some
  * bytes, return the partial payload and latch a sticky error for the next call. */
-static ssize_t streamReaderReadPassthrough(stream_reader_t *t,
+static ssize_t streamReaderReadPassthrough(streamReader *t,
                                            uint8_t *dst,
                                            size_t len) {
     size_t total = 0;
@@ -602,7 +598,7 @@ static ssize_t streamReaderReadPassthrough(stream_reader_t *t,
     return (ssize_t)(total + (size_t)got);
 }
 
-static int streamReaderDrainCompressedBuf(stream_reader_t *t,
+static int streamReaderDrainCompressedBuf(streamReader *t,
                                           uint8_t *out,
                                           size_t out_size,
                                           size_t *out_written) {
@@ -632,7 +628,7 @@ static int streamReaderDrainCompressedBuf(stream_reader_t *t,
     return 0;
 }
 
-static size_t streamReaderCompressedBufTailSpace(stream_reader_t *t) {
+static size_t streamReaderCompressedBufTailSpace(streamReader *t) {
     size_t tail_space = t->buffer_size - t->compressed_buf_pos - t->compressed_buf_len;
     if (tail_space > 0) return tail_space;
 
@@ -655,7 +651,7 @@ static size_t streamReaderCompressedBufTailSpace(stream_reader_t *t) {
     return 0;
 }
 
-static int streamReaderRefillCompressedBuf(stream_reader_t *t) {
+static int streamReaderRefillCompressedBuf(streamReader *t) {
     size_t read_size = streamReaderCompressedBufTailSpace(t);
     if (read_size > (size_t)SSIZE_MAX) read_size = (size_t)SSIZE_MAX;
     if (read_size == 0) return -1;
@@ -671,7 +667,7 @@ static int streamReaderRefillCompressedBuf(stream_reader_t *t) {
     return 1;
 }
 
-static ssize_t streamReaderFillDecompressedBuf(stream_reader_t *t) {
+static ssize_t streamReaderFillDecompressedBuf(streamReader *t) {
     size_t written = 0;
 
     t->decompressed_buf_pos = 0;
@@ -702,12 +698,12 @@ static ssize_t streamReaderFillDecompressedBuf(stream_reader_t *t) {
     return (ssize_t)written;
 }
 
-static inline size_t streamReaderDecompressedBufAvail(const stream_reader_t *t) {
+static inline size_t streamReaderDecompressedBufAvail(const streamReader *t) {
     if (t->decompressed_buf_len <= t->decompressed_buf_pos) return 0;
     return t->decompressed_buf_len - t->decompressed_buf_pos;
 }
 
-static size_t streamReaderCopyFromDecompressedBuf(stream_reader_t *t,
+static size_t streamReaderCopyFromDecompressedBuf(streamReader *t,
                                                   uint8_t **dst,
                                                   size_t *remaining) {
     size_t avail = streamReaderDecompressedBufAvail(t);
@@ -721,7 +717,7 @@ static size_t streamReaderCopyFromDecompressedBuf(stream_reader_t *t,
     return to_copy;
 }
 
-static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size_t len) {
+static ssize_t streamReaderReadCompressed(streamReader *t, uint8_t *dst, size_t len) {
     size_t remaining = len;
     size_t total = 0;
 
@@ -748,13 +744,13 @@ static ssize_t streamReaderReadCompressed(stream_reader_t *t, uint8_t *dst, size
     return (ssize_t)total;
 }
 
-ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len) {
+ssize_t streamReaderRead(streamReader *t, void *buf, size_t len) {
     if (!t || !buf) return -1;
     if (t->errored) return -1;
     if (len == 0) return 0;
     if (len > (size_t)SSIZE_MAX) return -1;
 
-    if (stream_reader_probe(t) != 0) return -1;
+    if (streamReaderProbe(t) != 0) return -1;
 
     if (!t->probe.compressed) {
         return streamReaderReadPassthrough(t, (uint8_t *)buf, len);
@@ -763,9 +759,9 @@ ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len) {
     return streamReaderReadCompressed(t, (uint8_t *)buf, len);
 }
 
-int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info) {
+int streamReaderGetInfo(streamReader *t, streamReaderInfo *info) {
     if (!t || !info) return -1;
-    if (stream_reader_probe(t) != 0) return -1;
+    if (streamReaderProbe(t) != 0) return -1;
 
     info->compressed = t->probe.compressed;
     info->codec_checksum_enabled = t->probe.compressed ? t->probe.codec_checksum_enabled : false;
@@ -774,11 +770,11 @@ int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info) {
     return 0;
 }
 
-stream_reader_error_t stream_reader_get_error(const stream_reader_t *t) {
+streamReaderError streamReaderGetError(const streamReader *t) {
     return t ? t->error_kind : STREAM_READER_ERROR_IO;
 }
 
-void stream_reader_destroy(stream_reader_t *t) {
+void streamReaderDestroy(streamReader *t) {
     if (!t) return;
     streamReaderResetCompressedState(t);
     zfree(t);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -6,7 +6,7 @@
 
 #include "compression_stream.h"
 #include "zmalloc.h"
-#include <assert.h>
+#include "serverassert.h"
 #include <limits.h>
 #include <string.h>
 
@@ -36,15 +36,6 @@ typedef struct {
     uint8_t stream_kind;
 } vkcsProbe;
 
-/* Write 8-byte VKCS envelope via callback.
- * Layout:
- *   [0..3] magic  "VKCS" (0x56 0x4B 0x43 0x53)
- *   [4]    version (VKCS_VERSION, currently 1)
- *   [5]    codec_id (VKCS codec registry)
- *   [6]    flags   (bit 0 = codec checksum enabled, remaining bits reserved)
- *   [7]    stream_kind (full 8-bit kind)
- *
- * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
 static bool vkcsCodecIsSupported(vkcsCodec codec) {
     return codec == VKCS_CODEC_LZ4;
 }
@@ -59,7 +50,7 @@ static void vkcsProbeSetPassthrough(vkcsProbe *probe) {
     probe->ready = true;
     probe->compressed = false;
     probe->codec_checksum_enabled = false;
-    probe->algo = ALGO_NONE;
+    probe->algo = COMPRESSION_ALGO_NONE;
     probe->stream_kind = 0;
 }
 
@@ -76,7 +67,7 @@ static void vkcsProbeSetCompressed(vkcsProbe *probe,
 
 static int compressionAlgoToVkcsCodec(compressionAlgo algo, vkcsCodec *codec) {
     switch (algo) {
-    case ALGO_LZ4:
+    case COMPRESSION_ALGO_LZ4:
         *codec = VKCS_CODEC_LZ4;
         return 0;
     default:
@@ -87,13 +78,22 @@ static int compressionAlgoToVkcsCodec(compressionAlgo algo, vkcsCodec *codec) {
 static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
     switch (codec) {
     case VKCS_CODEC_LZ4:
-        *algo = ALGO_LZ4;
+        *algo = COMPRESSION_ALGO_LZ4;
         return 0;
     default:
         return -1;
     }
 }
 
+/* Write 8-byte VKCS envelope via callback.
+ * Layout:
+ *   [0..3] magic  "VKCS" (0x56 0x4B 0x43 0x53)
+ *   [4]    version (VKCS_VERSION, currently 1)
+ *   [5]    codec_id (VKCS codec registry)
+ *   [6]    flags   (bit 0 = codec checksum enabled, remaining bits reserved)
+ *   [7]    stream_kind (full 8-bit kind)
+ *
+ * Returns 0 on success, -1 on error (invalid codec or emit_cb failure). */
 static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
                              void *ctx,
                              vkcsCodec codec,
@@ -153,7 +153,7 @@ static int readVkcsEnvelopeInfo(const uint8_t *buf,
     vkcsCodec codec;
     uint8_t stream_kind = 0;
     bool codec_checksum_enabled = false;
-    compressionAlgo algo = ALGO_NONE;
+    compressionAlgo algo = COMPRESSION_ALGO_NONE;
 
     if (readVkcsEnvelope(buf, VKCS_ENVELOPE_SIZE,
                          &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
@@ -171,7 +171,7 @@ static int readVkcsEnvelopeInfo(const uint8_t *buf,
 
 static void vkcsProbeInit(vkcsProbe *probe) {
     memset(probe, 0, sizeof(*probe));
-    probe->algo = ALGO_NONE;
+    probe->algo = COMPRESSION_ALGO_NONE;
     probe->codec_checksum_enabled = false;
 }
 
@@ -376,7 +376,7 @@ ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len) {
         size_t chunk_len = remaining < STREAM_WRITER_INPUT_CHUNK_SIZE
                                ? remaining
                                : STREAM_WRITER_INPUT_CHUNK_SIZE;
-        if (streamWriterFeedAndEmit(t, src, chunk_len, FLUSH_CONTINUE) != 0) return -1;
+        if (streamWriterFeedAndEmit(t, src, chunk_len, COMPRESS_FLUSH_CONTINUE) != 0) return -1;
         src += chunk_len;
         remaining -= chunk_len;
     }
@@ -395,7 +395,7 @@ int streamWriterFlush(streamWriter *t) {
     if (t->finished) return 0;
 
     if (!t->envelope_written || !t->compressor.stream_started) return 0;
-    if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_SYNC) != 0) return -1;
+    if (streamWriterFeedAndEmit(t, NULL, 0, COMPRESS_FLUSH_SYNC) != 0) return -1;
     return 0;
 }
 
@@ -407,7 +407,7 @@ int streamWriterFinish(streamWriter *t) {
 
     /* If nothing was ever written, emit envelope + empty frame end. */
     if (streamWriterEnsureEnvelope(t) != 0) return -1;
-    if (streamWriterFeedAndEmit(t, NULL, 0, FLUSH_END) != 0) return -1;
+    if (streamWriterFeedAndEmit(t, NULL, 0, COMPRESS_FLUSH_END) != 0) return -1;
     return 0;
 }
 
@@ -765,7 +765,7 @@ int streamReaderGetInfo(streamReader *t, streamReaderInfo *info) {
 
     info->compressed = t->probe.compressed;
     info->codec_checksum_enabled = t->probe.compressed ? t->probe.codec_checksum_enabled : false;
-    info->algo = t->probe.compressed ? t->probe.algo : ALGO_NONE;
+    info->algo = t->probe.compressed ? t->probe.algo : COMPRESSION_ALGO_NONE;
     info->stream_kind = t->probe.stream_kind;
     return 0;
 }

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -21,10 +21,10 @@
 
 typedef enum {
     VKCS_CODEC_LZ4 = 0x01,
-} vkcs_codec_t;
+} vkcsCodec;
 
 /* Emit callback used by the VKCS envelope and streaming writer. */
-typedef int (*vkcs_emit_fn)(void *ctx, const uint8_t *data, size_t len);
+typedef int (*vkcsEmitFn)(void *ctx, const uint8_t *data, size_t len);
 
 /* Default fixed buffer size for stream_reader when cfg->buffer_size == 0.
  * The reader uses one compressed input buffer and one decompressed output
@@ -36,11 +36,11 @@ typedef int (*vkcs_emit_fn)(void *ctx, const uint8_t *data, size_t len);
 
 /* Streaming writer config. */
 typedef struct {
-    compression_algo_t algo;     /* Compression algorithm for this stream. */
+    compressionAlgo algo;        /* Compression algorithm for this stream. */
     int level;                   /* Codec-specific compression level; ignored when unsupported. */
     uint8_t stream_kind;         /* Application-defined stream kind stored in the VKCS envelope. */
     bool codec_checksum_enabled; /* Enable codec-native integrity checks when supported. */
-} stream_writer_config_t;
+} streamWriterConfig;
 
 /* Streaming reader config.
  * - auto-detect VKCS envelope, decode if compressed
@@ -52,82 +52,82 @@ typedef struct {
     uint8_t expected_stream_kind; /* Required VKCS stream kind when the input is compressed. */
     bool allow_passthrough;       /* true => non-VKCS input is treated as raw bytes instead of an error. */
     size_t buffer_size;           /* Fixed compressed input buffer and decompressed output window size; 0 => internal default. */
-} stream_reader_config_t;
+} streamReaderConfig;
 
 /* Opaque streaming writer context. */
-typedef struct stream_writer stream_writer_t;
+typedef struct streamWriter streamWriter;
 /* Opaque streaming reader context. */
-typedef struct stream_reader stream_reader_t;
+typedef struct streamReader streamReader;
 
 /* Stream metadata returned after probing. */
 typedef struct {
     bool compressed;             /* true => input was classified as VKCS-compressed, false => passthrough. */
     bool codec_checksum_enabled; /* Parsed VKCS checksum policy. Ignore when compressed is false. */
-    compression_algo_t algo;     /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
+    compressionAlgo algo;        /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
     uint8_t stream_kind;         /* Parsed VKCS stream kind. Ignore when compressed is false. */
-} stream_reader_info_t;
+} streamReaderInfo;
 
 typedef enum {
     STREAM_READER_ERROR_NONE = 0,
     STREAM_READER_ERROR_IO = 1,
     STREAM_READER_ERROR_INCOMPATIBLE = 2,
     STREAM_READER_ERROR_CORRUPT = 3,
-} stream_reader_error_t;
+} streamReaderError;
 
 /* Caller-provided input callback.
  * Returns:
  * - >0: bytes read into buf (partial reads allowed)
  * -  0: EOF
  * - -1: read error */
-typedef ssize_t (*stream_reader_read_fn)(void *ctx, void *buf, size_t len);
+typedef ssize_t (*streamReaderReadFn)(void *ctx, void *buf, size_t len);
 
 /* Streaming writer API.
  * Ownership: returned context is owned by caller and must be destroyed.
- * Threading: stream_writer_t is NOT thread-safe; all API calls on a given
+ * Threading: streamWriter is NOT thread-safe; all API calls on a given
  * instance must be externally serialized and single-owner at any instant. */
-stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
-                                      vkcs_emit_fn emit_cb,
-                                      void *emit_ctx);
+streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
+                                 vkcsEmitFn emit_cb,
+                                 void *emit_ctx);
 /* Returns emitted bytes for this call (>=0), -1 on error.
  * NOTE: the return value is the number of *compressed* bytes emitted to the
  * output sink, NOT the number of input bytes consumed (which is always `len`
  * on success). On the first successful write this includes the 8-byte VKCS
  * envelope. Callers that need to track input progress should use `len`.
- * After stream_writer_finish(), write returns -1 and does not emit bytes. */
-ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len);
+ * After streamWriterFinish(), write returns -1 and does not emit bytes. */
+ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len);
 /* Returns 0 on success, -1 on error.
  * Flush-after-finish is a no-op success. */
-int stream_writer_flush(stream_writer_t *t);
+int streamWriterFlush(streamWriter *t);
 /* Returns 0 on success, -1 on error.
  * Calling finish more than once is a no-op success. */
-int stream_writer_finish(stream_writer_t *t);
-void stream_writer_destroy(stream_writer_t *t);
+int streamWriterFinish(streamWriter *t);
+void streamWriterDestroy(streamWriter *t);
 /* Snapshot only; cross-thread readers must synchronize externally
  * (for example via waitForClientIO-equivalent quiesce). */
-int stream_writer_is_errored(const stream_writer_t *t);
-void stream_writer_set_error(stream_writer_t *t);
+int streamWriterIsErrored(const streamWriter *t);
+void streamWriterSetError(streamWriter *t);
 
 /* Streaming reader API.
  * Ownership: returned context is owned by caller and must be destroyed. */
-stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
-                                      stream_reader_read_fn read_cb,
-                                      void *read_ctx);
+streamReader *streamReaderCreate(const streamReaderConfig *cfg,
+                                 streamReaderReadFn read_cb,
+                                 void *read_ctx);
 /* Ensure stream mode is detected and metadata is available.
  * Safe to call more than once.
  * Returns 0 on success, -1 on error. */
-int stream_reader_probe(stream_reader_t *t);
+int streamReaderProbe(streamReader *t);
 /* Read up to len bytes into buf.
  * len must fit in ssize_t; larger requests return -1 without consuming input.
  * Returns:
  * - >0: bytes produced (decompressed or passthrough)
  * -  0: EOF
  * - -1: error */
-ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len);
+ssize_t streamReaderRead(streamReader *t, void *buf, size_t len);
 /* Populate stream metadata after probing.
  * For passthrough streams: compressed=0, algo=ALGO_NONE, stream_kind=0.
  * Returns 0 on success, -1 on error. */
-int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info);
-stream_reader_error_t stream_reader_get_error(const stream_reader_t *t);
-void stream_reader_destroy(stream_reader_t *t);
+int streamReaderGetInfo(streamReader *t, streamReaderInfo *info);
+streamReaderError streamReaderGetError(const streamReader *t);
+void streamReaderDestroy(streamReader *t);
 
 #endif /* COMPRESSION_STREAM_H */

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMPRESSION_STREAM_H
+#define COMPRESSION_STREAM_H
+
+#include "compression.h"
+
+/* --- VKCS stream envelope --- */
+#define VKCS_MAGIC_0 0x56 /* 'V' */
+#define VKCS_MAGIC_1 0x4B /* 'K' */
+#define VKCS_MAGIC_2 0x43 /* 'C' */
+#define VKCS_MAGIC_3 0x53 /* 'S' */
+#define VKCS_ENVELOPE_SIZE 8
+#define VKCS_VERSION 1
+#define VKCS_FLAG_CODEC_CHECKSUM (1 << 0)
+#define STREAM_KIND_RDB 0x00
+
+typedef enum {
+    VKCS_CODEC_LZ4 = 0x01,
+} vkcs_codec_t;
+
+/* Emit callback used by the VKCS envelope and streaming writer. */
+typedef int (*vkcs_emit_fn)(void *ctx, const uint8_t *data, size_t len);
+
+/* Default fixed buffer size for stream_reader when cfg->buffer_size == 0.
+ * The reader uses one compressed input buffer and one decompressed output
+ * window of this size. */
+#define STREAM_READER_BUFFER_SIZE_DEFAULT (1024 * 1024)
+/* Tiny caller-provided buffer sizes are rounded up so the current LZ4 streaming
+ * decoder can always make forward progress without growing internal state. */
+#define STREAM_READER_BUFFER_SIZE_MIN (128 * 1024)
+
+/* Streaming writer config. */
+typedef struct {
+    compression_algo_t algo;     /* Compression algorithm for this stream. */
+    int level;                   /* Codec-specific compression level; ignored when unsupported. */
+    uint8_t stream_kind;         /* Application-defined stream kind stored in the VKCS envelope. */
+    bool codec_checksum_enabled; /* Enable codec-native integrity checks when supported. */
+} stream_writer_config_t;
+
+/* Streaming reader config.
+ * - auto-detect VKCS envelope, decode if compressed
+ * - allow_passthrough: forward non-VKCS bytes as-is
+ * - expected_stream_kind: enforce envelope stream kind when compressed
+ * - buffer_size=0: uses the internal default fixed buffer/window size
+ * - buffer_size>0: clamped to an internal minimum before allocating buffers */
+typedef struct {
+    uint8_t expected_stream_kind; /* Required VKCS stream kind when the input is compressed. */
+    bool allow_passthrough;       /* true => non-VKCS input is treated as raw bytes instead of an error. */
+    size_t buffer_size;           /* Fixed compressed input buffer and decompressed output window size; 0 => internal default. */
+} stream_reader_config_t;
+
+/* Opaque streaming writer context. */
+typedef struct stream_writer stream_writer_t;
+/* Opaque streaming reader context. */
+typedef struct stream_reader stream_reader_t;
+
+/* Stream metadata returned after probing. */
+typedef struct {
+    bool compressed;             /* true => input was classified as VKCS-compressed, false => passthrough. */
+    bool codec_checksum_enabled; /* Parsed VKCS checksum policy. Ignore when compressed is false. */
+    compression_algo_t algo;     /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
+    uint8_t stream_kind;         /* Parsed VKCS stream kind. Ignore when compressed is false. */
+} stream_reader_info_t;
+
+typedef enum {
+    STREAM_READER_ERROR_NONE = 0,
+    STREAM_READER_ERROR_IO = 1,
+    STREAM_READER_ERROR_INCOMPATIBLE = 2,
+    STREAM_READER_ERROR_CORRUPT = 3,
+} stream_reader_error_t;
+
+/* Caller-provided input callback.
+ * Returns:
+ * - >0: bytes read into buf (partial reads allowed)
+ * -  0: EOF
+ * - -1: read error */
+typedef ssize_t (*stream_reader_read_fn)(void *ctx, void *buf, size_t len);
+
+/* Streaming writer API.
+ * Ownership: returned context is owned by caller and must be destroyed.
+ * Threading: stream_writer_t is NOT thread-safe; all API calls on a given
+ * instance must be externally serialized and single-owner at any instant. */
+stream_writer_t *stream_writer_create(const stream_writer_config_t *cfg,
+                                      vkcs_emit_fn emit_cb,
+                                      void *emit_ctx);
+/* Returns emitted bytes for this call (>=0), -1 on error.
+ * NOTE: the return value is the number of *compressed* bytes emitted to the
+ * output sink, NOT the number of input bytes consumed (which is always `len`
+ * on success). On the first successful write this includes the 8-byte VKCS
+ * envelope. Callers that need to track input progress should use `len`.
+ * After stream_writer_finish(), write returns -1 and does not emit bytes. */
+ssize_t stream_writer_write(stream_writer_t *t, const void *buf, size_t len);
+/* Returns 0 on success, -1 on error.
+ * Flush-after-finish is a no-op success. */
+int stream_writer_flush(stream_writer_t *t);
+/* Returns 0 on success, -1 on error.
+ * Calling finish more than once is a no-op success. */
+int stream_writer_finish(stream_writer_t *t);
+void stream_writer_destroy(stream_writer_t *t);
+/* Snapshot only; cross-thread readers must synchronize externally
+ * (for example via waitForClientIO-equivalent quiesce). */
+int stream_writer_is_errored(const stream_writer_t *t);
+void stream_writer_set_error(stream_writer_t *t);
+
+/* Streaming reader API.
+ * Ownership: returned context is owned by caller and must be destroyed. */
+stream_reader_t *stream_reader_create(const stream_reader_config_t *cfg,
+                                      stream_reader_read_fn read_cb,
+                                      void *read_ctx);
+/* Ensure stream mode is detected and metadata is available.
+ * Safe to call more than once.
+ * Returns 0 on success, -1 on error. */
+int stream_reader_probe(stream_reader_t *t);
+/* Read up to len bytes into buf.
+ * len must fit in ssize_t; larger requests return -1 without consuming input.
+ * Returns:
+ * - >0: bytes produced (decompressed or passthrough)
+ * -  0: EOF
+ * - -1: error */
+ssize_t stream_reader_read(stream_reader_t *t, void *buf, size_t len);
+/* Populate stream metadata after probing.
+ * For passthrough streams: compressed=0, algo=ALGO_NONE, stream_kind=0.
+ * Returns 0 on success, -1 on error. */
+int stream_reader_get_info(stream_reader_t *t, stream_reader_info_t *info);
+stream_reader_error_t stream_reader_get_error(const stream_reader_t *t);
+void stream_reader_destroy(stream_reader_t *t);
+
+#endif /* COMPRESSION_STREAM_H */

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -63,7 +63,7 @@ typedef struct streamReader streamReader;
 typedef struct {
     bool compressed;             /* true => input was classified as VKCS-compressed, false => passthrough. */
     bool codec_checksum_enabled; /* Parsed VKCS checksum policy. Ignore when compressed is false. */
-    compressionAlgo algo;        /* Parsed compression algorithm, or ALGO_NONE for passthrough. */
+    compressionAlgo algo;        /* Parsed compression algorithm, or COMPRESSION_ALGO_NONE for passthrough. */
     uint8_t stream_kind;         /* Parsed VKCS stream kind. Ignore when compressed is false. */
 } streamReaderInfo;
 
@@ -124,7 +124,7 @@ int streamReaderProbe(streamReader *t);
  * - -1: error */
 ssize_t streamReaderRead(streamReader *t, void *buf, size_t len);
 /* Populate stream metadata after probing.
- * For passthrough streams: compressed=0, algo=ALGO_NONE, stream_kind=0.
+ * For passthrough streams: compressed=0, algo=COMPRESSION_ALGO_NONE, stream_kind=0.
  * Returns 0 on success, -1 on error. */
 int streamReaderGetInfo(streamReader *t, streamReaderInfo *info);
 streamReaderError streamReaderGetError(const streamReader *t);

--- a/src/config.c
+++ b/src/config.c
@@ -634,6 +634,7 @@ void loadServerConfigFromString(sds config) {
         err = "replicaof directive not allowed in cluster mode";
         goto loaderr;
     }
+
     /* To ensure backward compatibility and work while hz is out of range */
     if (server.hz < CONFIG_MIN_HZ) server.hz = CONFIG_MIN_HZ;
     if (server.hz > CONFIG_MAX_HZ) server.hz = CONFIG_MAX_HZ;

--- a/src/config.c
+++ b/src/config.c
@@ -38,6 +38,7 @@
 #include "cluster_migrateslots.h"
 #include "eval.h"
 #include "lrulfu.h"
+#include "compression.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -181,6 +182,10 @@ configEnum log_timestamp_format_enum[] = {{"legacy", LOG_TIMESTAMP_LEGACY},
 configEnum rdb_version_check_enum[] = {{"strict", RDB_VERSION_CHECK_STRICT},
                                        {"relaxed", RDB_VERSION_CHECK_RELAXED},
                                        {NULL, 0}};
+
+configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
+                                          {"lz4", ALGO_LZ4},
+                                          {NULL, 0}};
 
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
@@ -455,6 +460,8 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * within conf file parsing. This is only needed to support the deprecated
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
+/* Tracks nested config parsing depth (top-level + includes). */
+static int config_parse_depth;
 
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
@@ -474,6 +481,7 @@ void loadServerConfigFromString(sds config) {
     int argc;
 
     reading_config_file = 1;
+    config_parse_depth++;
     lines = sdssplitlen(config, sdslen(config), "\n", 1, &totlines);
 
     for (i = 0; i < totlines; i++) {
@@ -626,16 +634,18 @@ void loadServerConfigFromString(sds config) {
         err = "replicaof directive not allowed in cluster mode";
         goto loaderr;
     }
-
     /* To ensure backward compatibility and work while hz is out of range */
     if (server.hz < CONFIG_MIN_HZ) server.hz = CONFIG_MIN_HZ;
     if (server.hz > CONFIG_MAX_HZ) server.hz = CONFIG_MAX_HZ;
 
     sdsfreesplitres(lines, totlines);
-    reading_config_file = 0;
+    config_parse_depth--;
+    reading_config_file = config_parse_depth > 0;
     return;
 
 loaderr:
+    config_parse_depth--;
+    reading_config_file = config_parse_depth > 0;
     if (argv) sdsfreesplitres(argv, argc);
     fprintf(stderr, "\n*** FATAL CONFIG FILE ERROR (Version %s) ***\n", VALKEY_VERSION);
     if (i < totlines) {
@@ -3367,6 +3377,7 @@ standardConfig static_configs[] = {
     createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_LEGACY, NULL, NULL),
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
+    createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, ALGO_LZF, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -183,8 +183,8 @@ configEnum rdb_version_check_enum[] = {{"strict", RDB_VERSION_CHECK_STRICT},
                                        {"relaxed", RDB_VERSION_CHECK_RELAXED},
                                        {NULL, 0}};
 
-configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
-                                          {"lz4", ALGO_LZ4},
+configEnum rdb_compression_algo_enum[] = {{"lzf", COMPRESSION_ALGO_LZF},
+                                          {"lz4", COMPRESSION_ALGO_LZ4},
                                           {NULL, 0}};
 
 /* Output buffer limits presets. */
@@ -3378,7 +3378,7 @@ standardConfig static_configs[] = {
     createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_LEGACY, NULL, NULL),
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
-    createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, ALGO_LZF, NULL, NULL),
+    createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, COMPRESSION_ALGO_LZF, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -72,7 +72,7 @@
 /* Returns true if streaming compression is enabled for RDB saves. */
 static inline bool isRdbStreamingCompressionEnabled(void) {
     return server.rdb_compression &&
-           compressionAlgoSupportsStreaming((compression_algo_t)server.rdb_compression_algo);
+           compressionAlgoSupportsStreaming((compressionAlgo)server.rdb_compression_algo);
 }
 
 /* This macro tells if we are in the context of a RESTORE command, and not loading an RDB or AOF. */
@@ -1571,7 +1571,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     int saved_errno;
     char *err_op; /* For a detailed log */
     bool use_streaming_compression = isRdbStreamingCompressionEnabled();
-    compress_rio_t cr;
+    compressRio cr;
     bool cr_initialized = false;
 
     FILE *fp = fopen(filename, "w");
@@ -1596,12 +1596,12 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     }
 
     /* When streaming compression is enabled, wrap the file rio with
-     * compress_rio_t. rdbSaveRio writes through the compressor transparently.
+     * compressRio. rdbSaveRio writes through the compressor transparently.
      * Per-string LZF is already disabled in rdbSaveRawString when algo != LZF. */
     rio *save_rio = &rdb;
     if (use_streaming_compression) {
-        stream_writer_config_t cfg = {
-            .algo = (compression_algo_t)server.rdb_compression_algo,
+        streamWriterConfig cfg = {
+            .algo = (compressionAlgo)server.rdb_compression_algo,
             .level = 0,
             .stream_kind = STREAM_KIND_RDB,
             .codec_checksum_enabled = server.rdb_checksum != 0,
@@ -1628,14 +1628,14 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
 
     /* Finalize the compression frame before flushing to disk. */
     if (cr_initialized) {
-        if (compress_rio_finish(&cr) != 0) {
+        if (compressRioFinish(&cr) != 0) {
             errno = EIO; /* Compression finalization failure */
-            err_op = "compress_rio_finish";
-            compress_rio_destroy(&cr);
+            err_op = "compressRioFinish";
+            compressRioDestroy(&cr);
             cr_initialized = false;
             goto werr;
         }
-        compress_rio_destroy(&cr);
+        compressRioDestroy(&cr);
         cr_initialized = false;
     }
 
@@ -1665,7 +1665,7 @@ werr:
     if (cr_initialized) {
         /* Skip finish on error — output is being discarded (unlink below).
          * Just release resources. */
-        compress_rio_destroy(&cr);
+        compressRioDestroy(&cr);
     }
     if (fp) fclose(fp);
     unlink(filename);
@@ -1724,7 +1724,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
     serverLog(LL_NOTICE, "DB saved on disk");
     if (isRdbStreamingCompressionEnabled()) {
         serverLog(LL_VERBOSE, "RDB saved with %s streaming compression",
-                  compressionAlgoName((compression_algo_t)server.rdb_compression_algo));
+                  compressionAlgoName((compressionAlgo)server.rdb_compression_algo));
     }
     server.dirty = 0;
     server.lastsave = time(NULL);
@@ -3156,8 +3156,8 @@ void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio) {
     input->rdb_rio = raw_rio;
 }
 
-decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input) {
-    stream_reader_config_t reader_cfg = {
+decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
+    streamReaderConfig reader_cfg = {
         .expected_stream_kind = STREAM_KIND_RDB,
         .allow_passthrough = true,
         .buffer_size = 0,
@@ -3165,7 +3165,7 @@ decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input) {
 
     if (!input || !input->raw_rio) return DECOMPRESS_RIO_INIT_ERROR;
 
-    decompress_rio_init_result_t init_rc =
+    decompressRioInitResult init_rc =
         rioInitWithDecompress(&input->decompressor, input->raw_rio, &reader_cfg, &input->stream_info);
     if (init_rc == DECOMPRESS_RIO_INIT_OK) {
         input->initialized = true;
@@ -3177,15 +3177,18 @@ decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input) {
 void rdbInputStreamDestroy(rdbInputStream *input) {
     if (!input) return;
     if (input->initialized) {
-        decompress_rio_destroy(&input->decompressor);
+        decompressRioDestroy(&input->decompressor);
         input->initialized = false;
     }
     input->rdb_rio = input->raw_rio;
 }
 
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
+    /* SAFETY: the cast is valid because RIO_FLAG_STREAMING_DECOMPRESSION is
+     * only set by rioInitWithDecompress() on a decompressRio whose first
+     * member is `rio base`, so the pointer identity is guaranteed. */
     return (rdb->flags & RIO_FLAG_STREAMING_DECOMPRESSION) &&
-           decompress_rio_get_error((const decompress_rio_t *)rdb) == STREAM_READER_ERROR_CORRUPT;
+           decompressRioGetError((const decompressRio *)rdb) == STREAM_READER_ERROR_CORRUPT;
 }
 
 /* Save the given functions_ctx to the rdb.
@@ -3751,7 +3754,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     rioInitWithFile(&rdb, fp);
     rdbInputStreamInit(&input, &rdb);
 
-    decompress_rio_init_result_t init_rc = rdbInputStreamPrepare(&input);
+    decompressRioInitResult init_rc = rdbInputStreamPrepare(&input);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         serverLog(LL_WARNING, "Invalid RDB stream envelope in %s", filename);
         retval = RDB_INCOMPATIBLE;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -46,6 +46,8 @@
 #include "module.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
+#include "compression.h"
+#include "compression_rio.h"
 
 #include <math.h>
 #include <fcntl.h>
@@ -66,6 +68,12 @@
 #define rdbReportCorruptRDB(...) rdbReportError(1, __LINE__, __VA_ARGS__)
 /* This macro is called when RDB read failed (possibly a short read) */
 #define rdbReportReadError(...) rdbReportError(0, __LINE__, __VA_ARGS__)
+
+/* Returns true if streaming compression is enabled for RDB saves. */
+static inline bool isRdbStreamingCompressionEnabled(void) {
+    return server.rdb_compression &&
+           compressionAlgoSupportsStreaming((compression_algo_t)server.rdb_compression_algo);
+}
 
 /* This macro tells if we are in the context of a RESTORE command, and not loading an RDB or AOF. */
 #define isRestoreContext() ((server.current_client == NULL || server.current_client->id == CLIENT_ID_AOF) ? 0 : 1)
@@ -511,8 +519,13 @@ ssize_t rdbSaveRawString(rio *rdb, unsigned char *s, size_t len) {
     }
 
     /* Try LZF compression - under 20 bytes it's unable to compress even
-     * aaaaaaaaaaaaaaaaaa so skip it */
-    if (server.rdb_compression && len > 20) {
+     * aaaaaaaaaaaaaaaaaa so skip it.
+     * Skip per-string LZF only when THIS rio has streaming compression
+     * active (RIO_FLAG_STREAMING_COMPRESSION). This avoids double-compression
+     * while preserving LZF for paths without a compress_rio wrapper
+     * (diskless sync, DUMP, AOF rewrite). */
+    if (server.rdb_compression && len > 20 &&
+        !(rdb && (rdb->flags & RIO_FLAG_STREAMING_COMPRESSION))) {
         n = rdbSaveLzfStringObject(rdb, s, len);
         if (n == -1) return -1;
         if (n > 0) return n;
@@ -1480,7 +1493,10 @@ int rdbSaveRio(int req, int rdbver, rio *rdb, int *error, int rdbflags, rdbSaveI
     long key_counter = 0;
     int j;
 
-    if (server.rdb_checksum) rdb->update_cksum = rioGenericUpdateChecksum;
+    /* Track the RDB checksum whenever checksums are enabled and codec
+     * checksums are not the authoritative integrity mechanism. */
+    if (server.rdb_checksum && !(rdb->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM))
+        rdb->update_cksum = rioGenericUpdateChecksum;
     const char *magic_prefix = rdbUseValkeyMagic(rdbver) ? "VALKEY" : "REDIS0";
     serverAssert(rdbver >= 0 && rdbver <= RDB_VERSION);
     snprintf(magic, sizeof(magic), "%s%03d", magic_prefix, rdbver);
@@ -1506,7 +1522,7 @@ int rdbSaveRio(int req, int rdbver, rio *rdb, int *error, int rdbflags, rdbSaveI
     /* EOF opcode */
     if (rdbSaveType(rdb, RDB_OPCODE_EOF) == -1) goto werr;
 
-    /* CRC64 checksum. It will be zero if checksum computation is disabled, the
+    /* RDB checksum field. It will be zero if checksum computation is disabled, the
      * loading code skips the check in this case. */
     cksum = rdb->cksum;
     memrev64ifbe(&cksum);
@@ -1554,6 +1570,9 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     int error = 0;
     int saved_errno;
     char *err_op; /* For a detailed log */
+    bool use_streaming_compression = isRdbStreamingCompressionEnabled();
+    compress_rio_t cr;
+    bool cr_initialized = false;
 
     FILE *fp = fopen(filename, "w");
     if (!fp) {
@@ -1569,16 +1588,55 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     }
 
     rioInitWithFile(&rdb, fp);
+    if (!server.rdb_checksum) rdb.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
     if (server.rdb_save_incremental_fsync) {
         rioSetAutoSync(&rdb, REDIS_AUTOSYNC_BYTES);
         if (!(rdbflags & RDBFLAGS_KEEP_CACHE)) rioSetReclaimCache(&rdb, 1);
     }
 
-    if (rdbSaveRio(req, RDB_VERSION, &rdb, &error, rdbflags, rsi) == C_ERR) {
+    /* When streaming compression is enabled, wrap the file rio with
+     * compress_rio_t. rdbSaveRio writes through the compressor transparently.
+     * Per-string LZF is already disabled in rdbSaveRawString when algo != LZF. */
+    rio *save_rio = &rdb;
+    if (use_streaming_compression) {
+        stream_writer_config_t cfg = {
+            .algo = (compression_algo_t)server.rdb_compression_algo,
+            .level = 0,
+            .stream_kind = STREAM_KIND_RDB,
+            .codec_checksum_enabled = server.rdb_checksum != 0,
+        };
+        if (rioInitWithCompress(&cr, &rdb, &cfg) != 0) {
+            errno = EIO; /* Compressor init failure — set errno for werr log */
+            err_op = "rioInitWithCompress";
+            goto werr;
+        }
+        save_rio = (rio *)&cr;
+        cr_initialized = true;
+    }
+    if (!server.rdb_checksum) {
+        save_rio->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
+        save_rio->update_cksum = NULL;
+        save_rio->cksum = 0;
+    }
+
+    if (rdbSaveRio(req, RDB_VERSION, save_rio, &error, rdbflags, rsi) == C_ERR) {
         errno = error;
         err_op = "rdbSaveRio";
         goto werr;
+    }
+
+    /* Finalize the compression frame before flushing to disk. */
+    if (cr_initialized) {
+        if (compress_rio_finish(&cr) != 0) {
+            errno = EIO; /* Compression finalization failure */
+            err_op = "compress_rio_finish";
+            compress_rio_destroy(&cr);
+            cr_initialized = false;
+            goto werr;
+        }
+        compress_rio_destroy(&cr);
+        cr_initialized = false;
     }
 
     /* Make sure data will not remain on the OS's output buffers */
@@ -1604,6 +1662,11 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
 werr:
     saved_errno = errno;
     serverLog(LL_WARNING, "Write error while saving DB to the disk(%s): %s", err_op, strerror(errno));
+    if (cr_initialized) {
+        /* Skip finish on error — output is being discarded (unlink below).
+         * Just release resources. */
+        compress_rio_destroy(&cr);
+    }
     if (fp) fclose(fp);
     unlink(filename);
     errno = saved_errno;
@@ -1659,6 +1722,10 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
     }
 
     serverLog(LL_NOTICE, "DB saved on disk");
+    if (isRdbStreamingCompressionEnabled()) {
+        serverLog(LL_VERBOSE, "RDB saved with %s streaming compression",
+                  compressionAlgoName((compression_algo_t)server.rdb_compression_algo));
+    }
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;
@@ -3051,18 +3118,74 @@ void stopSaving(int success) {
 /* Track loading progress in order to serve client's from time to time
    and if needed calculate rdb checksum  */
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
-    if (server.rdb_checksum) rioGenericUpdateChecksum(r, buf, len);
+    /* Track the RDB checksum only when codec checksums are not authoritative
+     * for this stream. */
+    if (server.rdb_checksum && !(r->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM))
+        rioGenericUpdateChecksum(r, buf, len);
+
+    /* Event scheduling uses decoded (logical) bytes so that
+     * processEventsWhileBlocked() fires based on actual parsing work, even
+     * when the stream reader is draining its internal decompressed buffer
+     * without advancing the transport position.
+     *
+     * Progress reporting uses transport bytes for decompression paths so the
+     * loading percentage stays consistent with the file size passed to
+     * startLoadingFile(). */
+    off_t decoded_pos = (off_t)(r->processed_bytes + len);
+    off_t report_pos = decoded_pos;
+    if (r->flags & RIO_FLAG_STREAMING_DECOMPRESSION) {
+        report_pos = rioTell(r);
+    }
+
     if (server.loading_process_events_interval_bytes &&
-        (r->processed_bytes + len) / server.loading_process_events_interval_bytes >
-            r->processed_bytes / server.loading_process_events_interval_bytes) {
+        decoded_pos / server.loading_process_events_interval_bytes >
+            (off_t)r->processed_bytes / server.loading_process_events_interval_bytes) {
         if (server.primary_host && server.repl_state == REPL_STATE_TRANSFER) replicationSendNewlineToPrimary();
-        loadingAbsProgress(r->processed_bytes);
+        loadingAbsProgress(report_pos);
         processEventsWhileBlocked();
         processModuleLoadingProgressEvent(0);
     }
     if (server.repl_state == REPL_STATE_TRANSFER && rioCheckType(r) == RIO_TYPE_CONN) {
         server.stat_net_repl_input_bytes += len;
     }
+}
+
+void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio) {
+    memset(input, 0, sizeof(*input));
+    input->raw_rio = raw_rio;
+    input->rdb_rio = raw_rio;
+}
+
+decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input) {
+    stream_reader_config_t reader_cfg = {
+        .expected_stream_kind = STREAM_KIND_RDB,
+        .allow_passthrough = true,
+        .buffer_size = 0,
+    };
+
+    if (!input || !input->raw_rio) return DECOMPRESS_RIO_INIT_ERROR;
+
+    decompress_rio_init_result_t init_rc =
+        rioInitWithDecompress(&input->decompressor, input->raw_rio, &reader_cfg, &input->stream_info);
+    if (init_rc == DECOMPRESS_RIO_INIT_OK) {
+        input->initialized = true;
+        input->rdb_rio = (rio *)&input->decompressor;
+    }
+    return init_rc;
+}
+
+void rdbInputStreamDestroy(rdbInputStream *input) {
+    if (!input) return;
+    if (input->initialized) {
+        decompress_rio_destroy(&input->decompressor);
+        input->initialized = false;
+    }
+    input->rdb_rio = input->raw_rio;
+}
+
+bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
+    return (rdb->flags & RIO_FLAG_STREAMING_DECOMPRESSION) &&
+           decompress_rio_get_error((const decompress_rio_t *)rdb) == STREAM_READER_ERROR_CORRUPT;
 }
 
 /* Save the given functions_ctx to the rdb.
@@ -3557,7 +3680,10 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         if (rioRead(rdb, &cksum, 8) == 0) goto eoferr;
         if (server.rdb_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
-            if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
+            if (rdb->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) {
+                serverLog(LL_NOTICE,
+                          "Streaming-compressed RDB: integrity validated by codec checksums.");
+            } else if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
                 serverLog(LL_NOTICE, "RDB file was saved with checksum disabled: skipped checksum for this transfer");
             } else if (cksum == 0) {
                 serverLog(LL_NOTICE, "RDB file was saved with checksum disabled: no check performed.");
@@ -3586,6 +3712,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
      * the RDB file from a socket during initial SYNC (diskless replica mode),
      * we'll report the error to the caller, so that we can retry. */
 eoferr:
+    if (rdbRioHasCorruptCompressedInput(rdb)) {
+        serverLog(LL_WARNING, "Corrupt streaming-compressed RDB input. Unrecoverable error, aborting now.");
+        rdbReportCorruptRDB("Corrupt compressed RDB stream");
+        return RDB_FAILED;
+    }
     serverLog(LL_WARNING, "Short read or OOM loading DB. Unrecoverable error, aborting now.");
     rdbReportReadError("Unexpected EOF reading RDB file");
     return RDB_FAILED;
@@ -3601,7 +3732,8 @@ eoferr:
 int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     FILE *fp;
     rio rdb;
-    int retval;
+    rdbInputStream input;
+    int retval = RDB_FAILED;
     struct stat sb;
     int rdb_fd;
 
@@ -3617,9 +3749,27 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
 
     startLoadingFile(sb.st_size, filename, rdbflags);
     rioInitWithFile(&rdb, fp);
+    rdbInputStreamInit(&input, &rdb);
 
-    retval = rdbLoadRio(&rdb, rdbflags, rsi);
+    decompress_rio_init_result_t init_rc = rdbInputStreamPrepare(&input);
+    if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
+        serverLog(LL_WARNING, "Invalid RDB stream envelope in %s", filename);
+        retval = RDB_INCOMPATIBLE;
+        goto done;
+    }
+    if (init_rc == DECOMPRESS_RIO_INIT_ERROR) {
+        serverLog(LL_WARNING, "Failed to initialize RDB stream reader for %s", filename);
+        goto done;
+    }
+    if (input.stream_info.compressed) {
+        serverLog(LL_NOTICE, "Loading compressed RDB (algo=%s) from %s",
+                  compressionAlgoName(input.stream_info.algo), filename);
+    }
 
+    retval = rdbLoadRio(input.rdb_rio, rdbflags, rsi);
+
+done:
+    rdbInputStreamDestroy(&input);
     fclose(fp);
     stopLoading(retval == RDB_OK);
     /* Reclaim the cache backed by rdb */

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -31,6 +31,8 @@
 #define __RDB_H
 
 #include <stdio.h>
+#include <string.h>
+#include "compression_rio.h"
 #include "rio.h"
 
 /* TBD: include only necessary headers. */
@@ -70,6 +72,17 @@ static inline bool rdbIsForeignVersion(int rdbver) {
 
 static inline bool rdbUseValkeyMagic(int rdbver) {
     return rdbver > RDB_FOREIGN_VERSION_MAX;
+}
+
+/* Check whether a buffer starts with a recognized RDB magic prefix.
+ * "VALKEY" is the exact 6-byte magic for Valkey-format RDB (e.g. "VALKEY080").
+ * "REDIS" + digit matches the legacy format (e.g. "REDIS0080") for all
+ * versions 0000-9999, avoiding a forward-compatibility cliff at version 1000.
+ * Matches the same checks used in rdbLoadRio() (rdb.c). */
+static inline bool rdbIsValidMagic(const uint8_t *header, size_t len) {
+    if (len < 6) return false;
+    if (memcmp(header, "VALKEY", 6) == 0) return true;
+    return memcmp(header, "REDIS", 5) == 0 && header[5] >= '0' && header[5] <= '9';
 }
 
 /* Defines related to the dump file format. To store 32 bits lengths for short
@@ -186,6 +199,15 @@ enum RdbType {
 #define RDB_LOAD_ERR_OTHER 3             /* Any other errors */
 #define RDB_LOAD_ERR_ALL_ITEMS_EXPIRED 4 /* All fields expired */
 
+/* Wrapper state for preparing a raw input rio as a logical RDB byte stream. */
+typedef struct {
+    rio *raw_rio;
+    rio *rdb_rio;
+    decompress_rio_t decompressor;
+    stream_reader_info_t stream_info;
+    bool initialized;
+} rdbInputStream;
+
 bool rdbIsVersionAccepted(int rdbver, bool is_valkey_magic, bool is_redis_magic);
 ssize_t rdbWriteRaw(rio *rdb, void *p, size_t len);
 int rdbSaveType(rio *rdb, unsigned char type);
@@ -221,6 +243,10 @@ int rdbSaveBinaryFloatValue(rio *rdb, float val);
 int rdbLoadBinaryFloatValue(rio *rdb, float *val);
 int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtxScopedRdb(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
+void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
+decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input);
+void rdbInputStreamDestroy(rdbInputStream *input);
+bool rdbRioHasCorruptCompressedInput(const rio *rdb);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, sds *err);
 int rdbSaveRio(int req, int rdbver, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi);
 ssize_t rdbSaveFunctions(rio *rdb);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -203,8 +203,8 @@ enum RdbType {
 typedef struct {
     rio *raw_rio;
     rio *rdb_rio;
-    decompress_rio_t decompressor;
-    stream_reader_info_t stream_info;
+    decompressRio decompressor;
+    streamReaderInfo stream_info;
     bool initialized;
 } rdbInputStream;
 
@@ -244,7 +244,7 @@ int rdbLoadBinaryFloatValue(rio *rdb, float *val);
 int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtxScopedRdb(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
 void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
-decompress_rio_init_result_t rdbInputStreamPrepare(rdbInputStream *input);
+decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input);
 void rdbInputStreamDestroy(rdbInputStream *input);
 bool rdbRioHasCorruptCompressedInput(const rio *rdb);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, sds *err);

--- a/src/rio.c
+++ b/src/rio.c
@@ -74,6 +74,17 @@ static size_t rioBufferRead(rio *r, void *buf, size_t len) {
     return 1;
 }
 
+/* Partial-read variant: returns bytes read (may be less than len), 0 on EOF. */
+static ssize_t rioBufferReadSome(rio *r, void *buf, size_t len) {
+    size_t avail = sdslen(r->io.buffer.ptr) - r->io.buffer.pos;
+    if (avail == 0) return 0;
+
+    size_t got = avail < len ? avail : len;
+    memcpy(buf, r->io.buffer.ptr + r->io.buffer.pos, got);
+    r->io.buffer.pos += got;
+    return (ssize_t)got;
+}
+
 /* Returns read/write position in buffer. */
 static off_t rioBufferTell(rio *r) {
     return r->io.buffer.pos;
@@ -87,16 +98,18 @@ static int rioBufferFlush(rio *r) {
 }
 
 static const rio rioBufferIO = {
-    rioBufferRead,
-    rioBufferWrite,
-    rioBufferTell,
-    rioBufferFlush,
-    NULL,       /* update_checksum */
-    0,          /* current checksum */
-    0,          /* flags */
-    0,          /* bytes read or written */
-    0,          /* read/write chunk size */
-    {{NULL, 0}} /* union for io-specific vars */
+    .read = rioBufferRead,
+    .write = rioBufferWrite,
+    .tell = rioBufferTell,
+    .flush = rioBufferFlush,
+    .read_some = rioBufferReadSome,
+    .update_cksum = NULL,
+    .cksum = 0,
+    .flags = 0,
+    .processed_bytes = 0,
+    .max_processing_chunk = 0,
+    .type = RIO_TYPE_BUFFER,
+    .io = {{NULL, 0}},
 };
 
 void rioInitWithBuffer(rio *r, sds s) {
@@ -167,7 +180,14 @@ static size_t rioFileWrite(rio *r, const void *buf, size_t len) {
 
 /* Returns 1 or 0 for success/failure. */
 static size_t rioFileRead(rio *r, void *buf, size_t len) {
-    return fread(buf, len, 1, r->io.file.fp);
+    return fread(buf, 1, len, r->io.file.fp) == len;
+}
+
+/* Partial-read variant: returns bytes read (may be less than len), 0 on EOF, -1 on error. */
+static ssize_t rioFileReadSome(rio *r, void *buf, size_t len) {
+    size_t got = fread(buf, 1, len, r->io.file.fp);
+    if (got == 0 && ferror(r->io.file.fp)) return -1;
+    return (ssize_t)got;
 }
 
 /* Returns read/write position in file. */
@@ -182,16 +202,18 @@ static int rioFileFlush(rio *r) {
 }
 
 static const rio rioFileIO = {
-    rioFileRead,
-    rioFileWrite,
-    rioFileTell,
-    rioFileFlush,
-    NULL,       /* update_checksum */
-    0,          /* current checksum */
-    0,          /* flags */
-    0,          /* bytes read or written */
-    0,          /* read/write chunk size */
-    {{NULL, 0}} /* union for io-specific vars */
+    .read = rioFileRead,
+    .write = rioFileWrite,
+    .tell = rioFileTell,
+    .flush = rioFileFlush,
+    .read_some = rioFileReadSome,
+    .update_cksum = NULL,
+    .cksum = 0,
+    .flags = 0,
+    .processed_bytes = 0,
+    .max_processing_chunk = 0,
+    .type = RIO_TYPE_FILE,
+    .io = {{NULL, 0}},
 };
 
 void rioInitWithFile(rio *r, FILE *fp) {
@@ -215,55 +237,88 @@ static size_t rioConnWrite(rio *r, const void *buf, size_t len) {
     return 0; /* Error, this target does not yet support writing. */
 }
 
-/* Returns 1 or 0 for success/failure. */
-static size_t rioConnRead(rio *r, void *buf, size_t len) {
+/* Fill the conn read buffer until at least min_read bytes are available.
+ * When strict_limit is set, returns -1 if the request exceeds read_limit.
+ * Returns 1 on success, 0 on EOF, -1 on error. */
+static int rioConnFillBuffer(rio *r, size_t min_read, int strict_limit) {
     size_t avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
 
+    if (strict_limit && r->io.conn.read_limit != 0 &&
+        r->io.conn.read_limit < r->io.conn.read_so_far + min_read) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+
     /* If the buffer is too small for the entire request: realloc. */
-    if (sdslen(r->io.conn.buf) + sdsavail(r->io.conn.buf) < len)
-        r->io.conn.buf = sdsMakeRoomFor(r->io.conn.buf, len - sdslen(r->io.conn.buf));
+    if (sdslen(r->io.conn.buf) + sdsavail(r->io.conn.buf) < min_read)
+        r->io.conn.buf = sdsMakeRoomFor(r->io.conn.buf, min_read - sdslen(r->io.conn.buf));
 
     /* If the remaining unused buffer is not large enough: memmove so that we
      * can read the rest. */
-    if (len > avail && sdsavail(r->io.conn.buf) < len - avail) {
+    if (min_read > avail && sdsavail(r->io.conn.buf) < min_read - avail) {
         sdsrange(r->io.conn.buf, r->io.conn.pos, -1);
         r->io.conn.pos = 0;
     }
 
-    /* Make sure the caller didn't request to read past the limit.
-     * If they didn't we'll buffer till the limit, if they did, we'll
-     * return an error. */
-    if (r->io.conn.read_limit != 0 && r->io.conn.read_limit < r->io.conn.read_so_far + len) {
-        errno = EOVERFLOW;
-        return 0;
-    }
-
-    /* If we don't already have all the data in the sds, read more */
-    while (len > sdslen(r->io.conn.buf) - r->io.conn.pos) {
-        size_t buffered = sdslen(r->io.conn.buf) - r->io.conn.pos;
-        size_t needs = len - buffered;
+    while (avail < min_read) {
+        size_t needs = min_read - avail;
         /* Read either what's missing, or PROTO_IOBUF_LEN, the bigger of
          * the two. */
         size_t toread = needs < PROTO_IOBUF_LEN ? PROTO_IOBUF_LEN : needs;
         if (toread > sdsavail(r->io.conn.buf)) toread = sdsavail(r->io.conn.buf);
-        if (r->io.conn.read_limit != 0 && r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit) {
-            toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
+        if (r->io.conn.read_limit != 0 &&
+            r->io.conn.read_so_far + avail + toread > r->io.conn.read_limit) {
+            toread = r->io.conn.read_limit - r->io.conn.read_so_far - avail;
         }
+        if (toread == 0) return 0;
+
         int retval = connRead(r->io.conn.conn, (char *)r->io.conn.buf + sdslen(r->io.conn.buf), toread);
         if (retval == 0) {
             return 0;
         } else if (retval < 0) {
             if (connLastErrorRetryable(r->io.conn.conn)) continue;
             if (errno == EWOULDBLOCK) errno = ETIMEDOUT;
-            return 0;
+            return -1;
         }
         sdsIncrLen(r->io.conn.buf, retval);
+        avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
     }
+
+    return 1;
+}
+
+/* Partial-read variant: returns bytes read, 0 on EOF, -1 on error. */
+static ssize_t rioConnReadSome(rio *r, void *buf, size_t len) {
+    size_t avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
+
+    if (r->io.conn.read_limit != 0 && r->io.conn.read_so_far >= r->io.conn.read_limit) {
+        return 0;
+    }
+    if (avail == 0) {
+        int fill_rc = rioConnFillBuffer(r, 1, 0);
+        if (fill_rc <= 0) return fill_rc;
+        avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
+    }
+    if (r->io.conn.read_limit != 0) {
+        size_t remaining = r->io.conn.read_limit - r->io.conn.read_so_far;
+        if (len > remaining) len = remaining;
+    }
+
+    size_t got = avail < len ? avail : len;
+    memcpy(buf, (char *)r->io.conn.buf + r->io.conn.pos, got);
+    r->io.conn.read_so_far += got;
+    r->io.conn.pos += got;
+    return (ssize_t)got;
+}
+
+/* Returns 1 or 0 for success/failure. */
+static size_t rioConnRead(rio *r, void *buf, size_t len) {
+    if (rioConnFillBuffer(r, len, 1) != 1) return 0;
 
     memcpy(buf, (char *)r->io.conn.buf + r->io.conn.pos, len);
     r->io.conn.read_so_far += len;
     r->io.conn.pos += len;
-    return len;
+    return 1;
 }
 
 /* Returns read/write position in file. */
@@ -280,16 +335,18 @@ static int rioConnFlush(rio *r) {
 }
 
 static const rio rioConnIO = {
-    rioConnRead,
-    rioConnWrite,
-    rioConnTell,
-    rioConnFlush,
-    NULL,       /* update_checksum */
-    0,          /* current checksum */
-    0,          /* flags */
-    0,          /* bytes read or written */
-    0,          /* read/write chunk size */
-    {{NULL, 0}} /* union for io-specific vars */
+    .read = rioConnRead,
+    .write = rioConnWrite,
+    .tell = rioConnTell,
+    .flush = rioConnFlush,
+    .read_some = rioConnReadSome,
+    .update_cksum = NULL,
+    .cksum = 0,
+    .flags = 0,
+    .processed_bytes = 0,
+    .max_processing_chunk = 0,
+    .type = RIO_TYPE_CONN,
+    .io = {{NULL, 0}},
 };
 
 /* Create an RIO that implements a buffered read from an fd
@@ -396,16 +453,18 @@ static int rioFdFlush(rio *r) {
 }
 
 static const rio rioFdIO = {
-    rioFdRead,
-    rioFdWrite,
-    rioFdTell,
-    rioFdFlush,
-    NULL,       /* update_checksum */
-    0,          /* current checksum */
-    0,          /* flags */
-    0,          /* bytes read or written */
-    0,          /* read/write chunk size */
-    {{NULL, 0}} /* union for io-specific vars */
+    .read = rioFdRead,
+    .write = rioFdWrite,
+    .tell = rioFdTell,
+    .flush = rioFdFlush,
+    .read_some = NULL,
+    .update_cksum = NULL,
+    .cksum = 0,
+    .flags = 0,
+    .processed_bytes = 0,
+    .max_processing_chunk = 0,
+    .type = RIO_TYPE_FD,
+    .io = {{NULL, 0}},
 };
 
 void rioInitWithFd(rio *r, int fd) {
@@ -427,6 +486,35 @@ void rioFreeFd(rio *r) {
 void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len) {
     if ((r->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0) return; // skip RDB checksum
     r->cksum = crc64(r->cksum, buf, len);
+}
+
+/* Read up to `len` bytes from a readable rio without requiring a full-length
+ * transfer. Returns:
+ * - >0 bytes read
+ * -  0 on EOF
+ * - -1 on error (sticky read error is latched on the rio) */
+ssize_t rioReadPartial(rio *r, void *buf, size_t len) {
+    if (!r || !buf) return -1;
+    if (r->flags & (RIO_FLAG_READ_ERROR | RIO_FLAG_CLOSE_ASAP)) return -1;
+    if (len == 0) return 0;
+    if (!r->read_some) {
+        r->flags |= RIO_FLAG_READ_ERROR;
+        return -1;
+    }
+
+    size_t bytes_to_read =
+        (r->max_processing_chunk && r->max_processing_chunk < len) ? r->max_processing_chunk : len;
+    ssize_t got = r->read_some(r, buf, bytes_to_read);
+
+    if (got < 0) {
+        r->flags |= RIO_FLAG_READ_ERROR;
+        return -1;
+    }
+    if (got > 0) {
+        if (r->update_cksum) r->update_cksum(r, buf, (size_t)got);
+        r->processed_bytes += (size_t)got;
+    }
+    return got;
 }
 
 /* Set the file-based rio object to auto-fsync every 'bytes' file written.
@@ -453,16 +541,7 @@ void rioSetReclaimCache(rio *r, int enabled) {
 
 /* Check the type of rio. */
 uint8_t rioCheckType(rio *r) {
-    if (r->read == rioFileRead) {
-        return RIO_TYPE_FILE;
-    } else if (r->read == rioBufferRead) {
-        return RIO_TYPE_BUFFER;
-    } else if (r->read == rioConnRead) {
-        return RIO_TYPE_CONN;
-    } else {
-        /* r->read == rioFdRead */
-        return RIO_TYPE_FD;
-    }
+    return r->type;
 }
 
 /* --------------------------- Higher level interface --------------------------
@@ -604,16 +683,18 @@ static int rioConnsetFlush(rio *r) {
 }
 
 static const rio rioConnsetIO = {
-    rioConnsetRead,
-    rioConnsetWrite,
-    rioConnsetTell,
-    rioConnsetFlush,
-    NULL,       /* update_checksum */
-    0,          /* current checksum */
-    0,          /* flags */
-    0,          /* bytes read or written */
-    0,          /* read/write chunk size */
-    {{NULL, 0}} /* union for io-specific vars */
+    .read = rioConnsetRead,
+    .write = rioConnsetWrite,
+    .tell = rioConnsetTell,
+    .flush = rioConnsetFlush,
+    .read_some = NULL,
+    .update_cksum = NULL,
+    .cksum = 0,
+    .flags = 0,
+    .processed_bytes = 0,
+    .max_processing_chunk = 0,
+    .type = RIO_TYPE_CONN,
+    .io = {{NULL, 0}},
 };
 
 void rioInitWithConnset(rio *r, connection **conns, int numconns) {

--- a/src/rio.h
+++ b/src/rio.h
@@ -33,6 +33,7 @@
 #define VALKEY_RIO_H
 
 #include <stdio.h>
+#include <sys/types.h>
 #include <stdint.h>
 #include "sds.h"
 #include "connection.h"
@@ -41,6 +42,9 @@
 #define RIO_FLAG_WRITE_ERROR (1 << 1)
 #define RIO_FLAG_CLOSE_ASAP (1 << 2) /* Rio was closed asynchronously during the current rio operation. */
 #define RIO_FLAG_SKIP_RDB_CHECKSUM (1 << 3)
+#define RIO_FLAG_STREAMING_COMPRESSION (1 << 4)    /* Streaming compression active — skip per-string LZF */
+#define RIO_FLAG_STREAMING_DECOMPRESSION (1 << 5)  /* rio is a stream decompression adapter */
+#define RIO_FLAG_STREAMING_CODEC_CHECKSUM (1 << 6) /* Streaming frame integrity checks are authoritative */
 
 #define RIO_TYPE_FILE (1 << 0)
 #define RIO_TYPE_BUFFER (1 << 1)
@@ -55,6 +59,11 @@ struct _rio {
     size_t (*write)(struct _rio *, const void *buf, size_t len);
     off_t (*tell)(struct _rio *);
     int (*flush)(struct _rio *);
+    /* Partial-read backend: returns >0 bytes read, 0 on EOF, -1 on error.
+     * Unlike read(), partial results are allowed. Used by rioReadPartial()
+     * for streaming decompression and other adapters that need incremental
+     * input. NULL when the backend does not support reading. */
+    ssize_t (*read_some)(struct _rio *, void *buf, size_t len);
     /* The update_cksum method if not NULL is used to compute the checksum of
      * all the data that was read or written so far. The method should be
      * designed so that can be called with the current checksum, and the buf
@@ -70,6 +79,9 @@ struct _rio {
 
     /* maximum single read or write chunk size */
     size_t max_processing_chunk;
+
+    /* Backend type (RIO_TYPE_*). Decorators should preserve the wrapped type. */
+    uint8_t type;
 
     /* Backend-specific vars. */
     union {
@@ -200,6 +212,7 @@ struct serverObject;
 int rioWriteBulkObject(rio *r, struct serverObject *obj);
 
 void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len);
+ssize_t rioReadPartial(rio *r, void *buf, size_t len);
 void rioSetAutoSync(rio *r, off_t bytes);
 void rioSetReclaimCache(rio *r, int enabled);
 uint8_t rioCheckType(rio *r);

--- a/src/server.h
+++ b/src/server.h
@@ -2054,7 +2054,7 @@ struct valkeyServer {
     int saveparamslen;                    /* Number of saving points */
     char *rdb_filename;                   /* Name of RDB file */
     int rdb_compression;                  /* Use compression in RDB? */
-    int rdb_compression_algo;             /* RDB compression algorithm (compression_algo_t):
+    int rdb_compression_algo;             /* RDB compression algorithm (compressionAlgo):
                                            * ALGO_LZF (default), ALGO_LZ4 */
     int rdb_checksum;                     /* Use RDB checksum? */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if

--- a/src/server.h
+++ b/src/server.h
@@ -2055,7 +2055,7 @@ struct valkeyServer {
     char *rdb_filename;                   /* Name of RDB file */
     int rdb_compression;                  /* Use compression in RDB? */
     int rdb_compression_algo;             /* RDB compression algorithm (compressionAlgo):
-                                           * ALGO_LZF (default), ALGO_LZ4 */
+                                           * COMPRESSION_ALGO_LZF (default), COMPRESSION_ALGO_LZ4 */
     int rdb_checksum;                     /* Use RDB checksum? */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
                                              the instance does not use persistence. */

--- a/src/server.h
+++ b/src/server.h
@@ -2054,6 +2054,8 @@ struct valkeyServer {
     int saveparamslen;                    /* Number of saving points */
     char *rdb_filename;                   /* Name of RDB file */
     int rdb_compression;                  /* Use compression in RDB? */
+    int rdb_compression_algo;             /* RDB compression algorithm (compression_algo_t):
+                                           * ALGO_LZF (default), ALGO_LZ4 */
     int rdb_checksum;                     /* Use RDB checksum? */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
                                              the instance does not use persistence. */

--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -137,6 +137,7 @@ target_link_libraries(
     valkey-unit-gtests
     valkeylib-gtest
     fpconv
+    lz4
     lualib
     hdr_histogram
     valkey::valkey

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -107,9 +107,6 @@ ifeq ($(strip $(GTEST_LIBS)),)
     $(error googletest not found. Install gtest or set GTEST_CFLAGS/GTEST_LIBS explicitly)
 endif
 
-../.make-settings: ../Makefile
-	cd .. && $(MAKE) write-make-settings
-
 # On Darwin (macOS), the linker does not support -Wl,--wrap,
 # so we manually define __wrap_* and __real_* for each function in wrappers.h.
 # by copying all object files into the wrapped/ folder and applying symbol redefinitions.

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -94,6 +94,7 @@ HIREDIS_LIB := ../../deps/libvalkey/lib/libvalkey.a
 JEMALLOC_LIB := ../../deps/jemalloc/lib/libjemalloc.a
 HDR_HISTOGRAM_LIB := ../../deps/hdr_histogram/libhdrhistogram.a
 FPCONV_LIB := ../../deps/fpconv/libfpconv.a
+LZ4_LIB := ../../deps/lz4/liblz4.a
 TLS_LIBS := ../../deps/libvalkey/lib/libvalkey_tls.a -lssl -lcrypto
 GTEST_CFLAGS ?=
 GTEST_LIBS   ?=
@@ -105,6 +106,9 @@ endif
 ifeq ($(strip $(GTEST_LIBS)),)
     $(error googletest not found. Install gtest or set GTEST_CFLAGS/GTEST_LIBS explicitly)
 endif
+
+../.make-settings: ../Makefile
+	cd .. && $(MAKE) write-make-settings
 
 # On Darwin (macOS), the linker does not support -Wl,--wrap,
 # so we manually define __wrap_* and __real_* for each function in wrappers.h.
@@ -154,7 +158,8 @@ LD_LIBS := $(HIREDIS_LIB) \
 	$(JEMALLOC_LIB) \
 	$(GTEST_LIBS) \
 	$(HDR_HISTOGRAM_LIB) \
-	$(FPCONV_LIB)
+	$(FPCONV_LIB) \
+	$(LZ4_LIB)
 
 # Add libbacktrace support if enabled
 ifeq ($(USE_LIBBACKTRACE),yes)

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -121,7 +121,7 @@ TEST(compression, streamCompressorInitDestroy) {
     stream_compressor_t sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
     ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
-    ASSERT_TRUE(sc.frame_started == false) << "frame_started should be false";
+    ASSERT_TRUE(sc.stream_started == false) << "stream_started should be false";
     ASSERT_TRUE(sc.ctx != NULL) << "ctx should be non-NULL";
     streamCompressorDestroy(&sc);
     ASSERT_TRUE(sc.ctx == NULL) << "ctx should be NULL after destroy";
@@ -166,7 +166,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
                                                 (const uint8_t *)input, input_len,
                                                 FLUSH_END);
     ASSERT_TRUE(compressed_len > 0) << "compress should succeed";
-    ASSERT_TRUE(sc.frame_started == false) << "frame should be closed after FLUSH_END";
+    ASSERT_TRUE(sc.stream_started == false) << "frame should be closed after FLUSH_END";
     streamCompressorDestroy(&sc);
 
     /* Decompress */
@@ -296,7 +296,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
                                      (const uint8_t *)"test data", 9, FLUSH_END);
     ASSERT_TRUE(ret == -1) << "should fail with tiny buffer";
     ASSERT_TRUE(sc.errored == false) << "errored should NOT be set (pre-frame failure)";
-    ASSERT_TRUE(sc.frame_started == false) << "frame_started should still be false";
+    ASSERT_TRUE(sc.stream_started == false) << "stream_started should still be false";
 
     /* Retry with a proper buffer — should succeed */
     size_t bound = streamCompressOutputBound(&sc, 9);
@@ -317,7 +317,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     ssize_t ret3 = streamCompressFeed(&sc2, buf2, bound2,
                                       (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
     ASSERT_TRUE(ret3 >= 0) << "first write should succeed";
-    ASSERT_TRUE(sc2.frame_started == true) << "frame should be started";
+    ASSERT_TRUE(sc2.stream_started == true) << "stream should be started";
 
     /* Now force a mid-frame error with a tiny buffer */
     uint8_t tiny2[1];

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -1,0 +1,1623 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Tests for the compression streaming and rio decorator layers. */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <limits>
+
+extern "C" {
+#include "../../deps/lz4/lz4frame.h"
+#include "compression.h"
+#include "compression_rio.h"
+#include "compression_stream.h"
+#include "zmalloc.h"
+}
+
+/* zmalloc.h defines helper macros (__str/__xstr) that collide with libstdc++ internals.
+ * Keep them local to C headers in this C++ translation unit. */
+#ifdef __xstr
+#undef __xstr
+#endif
+#ifdef __str
+#undef __str
+#endif
+
+typedef struct {
+    const uint8_t *data;
+    size_t len;
+    size_t pos;
+    size_t max_chunk; /* 0 => unbounded */
+} mem_reader_t;
+
+typedef struct {
+    const uint8_t *data;
+    size_t len;
+    size_t pos;
+    size_t max_chunk;
+    int fail_after_success_reads;
+    int success_reads;
+} flaky_reader_t;
+
+static stream_reader_config_t makeReaderConfig(uint8_t expected_stream_kind,
+                                               bool allow_passthrough,
+                                               size_t buffer_size) {
+    stream_reader_config_t cfg = {};
+    cfg.expected_stream_kind = expected_stream_kind;
+    cfg.allow_passthrough = allow_passthrough;
+    cfg.buffer_size = buffer_size;
+    return cfg;
+}
+
+static stream_writer_config_t makeWriterConfig(compression_algo_t algo,
+                                               int level,
+                                               uint8_t stream_kind,
+                                               bool codec_checksum_enabled = false) {
+    stream_writer_config_t cfg = {};
+    cfg.algo = algo;
+    cfg.level = level;
+    cfg.stream_kind = stream_kind;
+    cfg.codec_checksum_enabled = codec_checksum_enabled;
+    return cfg;
+}
+
+static bool lz4FrameHasBlockChecksum(const uint8_t *data, size_t len) {
+    LZ4F_dctx *dctx = NULL;
+    EXPECT_FALSE(LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION)));
+    if (dctx == NULL) return false;
+
+    LZ4F_frameInfo_t frame_info = {};
+    size_t src_size = len;
+    size_t ret = LZ4F_getFrameInfo(dctx, &frame_info, data, &src_size);
+    bool has_block_checksum = !LZ4F_isError(ret) &&
+                              frame_info.blockChecksumFlag == LZ4F_blockChecksumEnabled;
+    LZ4F_freeDecompressionContext(dctx);
+    return has_block_checksum;
+}
+
+static ssize_t memReaderRead(void *ctx, void *buf, size_t len) {
+    mem_reader_t *r = (mem_reader_t *)ctx;
+    if (!r || !buf) return -1;
+    if (r->pos >= r->len) return 0;
+
+    size_t avail = r->len - r->pos;
+    size_t n = len < avail ? len : avail;
+    if (r->max_chunk && n > r->max_chunk) n = r->max_chunk;
+
+    memcpy(buf, r->data + r->pos, n);
+    r->pos += n;
+    return (ssize_t)n;
+}
+
+static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
+    flaky_reader_t *r = (flaky_reader_t *)ctx;
+    if (!r || !buf) return -1;
+    if (r->success_reads >= r->fail_after_success_reads) return -1;
+    if (r->pos >= r->len) return 0;
+
+    size_t avail = r->len - r->pos;
+    size_t n = len < avail ? len : avail;
+    if (r->max_chunk && n > r->max_chunk) n = r->max_chunk;
+
+    memcpy(buf, r->data + r->pos, n);
+    r->pos += n;
+    r->success_reads++;
+    return (ssize_t)n;
+}
+
+/* ===================================================================
+ * Streaming compression/decompression tests
+ * =================================================================== */
+
+/* --- Test: LZ4 compressor init/destroy lifecycle --- */
+TEST(compression, streamCompressorInitDestroy) {
+    stream_compressor_t sc;
+    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
+    ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
+    ASSERT_TRUE(sc.frame_started == false) << "frame_started should be false";
+    ASSERT_TRUE(sc.ctx != NULL) << "ctx should be non-NULL";
+    streamCompressorDestroy(&sc);
+    ASSERT_TRUE(sc.ctx == NULL) << "ctx should be NULL after destroy";
+    ASSERT_TRUE(sc.algo == ALGO_NONE) << "algo should be NONE after destroy";
+
+    /* ALGO_NONE should fail */
+    stream_compressor_t sc3;
+    ASSERT_TRUE(streamCompressorInit(&sc3, ALGO_NONE, 0) == -1) << "NONE init should fail";
+
+    /* NULL should fail */
+    ASSERT_TRUE(streamCompressorInit(NULL, ALGO_LZ4, 0) == -1) << "NULL init should fail";
+}
+
+/* --- Test: LZ4 decompressor init/destroy lifecycle --- */
+TEST(compression, streamDecompressorInitDestroy) {
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0) << "LZ4 decomp init should succeed";
+    ASSERT_TRUE(sd.algo == ALGO_LZ4) << "algo should be LZ4";
+    ASSERT_TRUE(sd.ctx != NULL) << "ctx should be non-NULL";
+    streamDecompressorDestroy(&sd);
+    ASSERT_TRUE(sd.ctx == NULL) << "ctx should be NULL after destroy";
+    ASSERT_TRUE(sd.algo == ALGO_NONE) << "algo should be NONE after destroy";
+
+    return;
+}
+
+/* --- Test: LZ4 compress → decompress round-trip --- */
+TEST(compression, streamCompressDecompressRoundTrip) {
+    const char *input = "Hello, Valkey compression module! This is a test payload.";
+    size_t input_len = strlen(input);
+
+    /* Compress */
+    stream_compressor_t sc;
+    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+
+    size_t bound = streamCompressOutputBound(&sc, input_len);
+    ASSERT_TRUE(bound > 0) << "bound should be > 0";
+
+    uint8_t *compressed = (uint8_t *)zmalloc(bound);
+    ASSERT_TRUE(compressed != NULL);
+    ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
+                                                (const uint8_t *)input, input_len,
+                                                FLUSH_END);
+    ASSERT_TRUE(compressed_len > 0) << "compress should succeed";
+    ASSERT_TRUE(sc.frame_started == false) << "frame should be closed after FLUSH_END";
+    streamCompressorDestroy(&sc);
+
+    /* Decompress */
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+
+    uint8_t decompressed[256];
+    size_t input_consumed = 0;
+    ssize_t decompressed_len = streamDecompressFeed(&sd, decompressed, sizeof(decompressed),
+                                                    compressed, (size_t)compressed_len,
+                                                    &input_consumed);
+    ASSERT_TRUE(decompressed_len > 0) << "decompress should succeed";
+    ASSERT_TRUE((size_t)decompressed_len == input_len) << "decompressed length should match input";
+    ASSERT_TRUE(memcmp(decompressed, input, input_len) == 0) << "decompressed content should match input";
+    ASSERT_TRUE(input_consumed == (size_t)compressed_len) << "all compressed input should be consumed";
+
+    streamDecompressorDestroy(&sd);
+    zfree(compressed);
+    return;
+}
+
+/* --- Test: streamCompressOutputBound returns sane values --- */
+TEST(compression, streamCompressOutputBound) {
+    stream_compressor_t sc;
+    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+
+    /* Basic: bound for 1KB input should be > 0 */
+    size_t b1 = streamCompressOutputBound(&sc, 1024);
+    ASSERT_TRUE(b1 > 0) << "bound for 1KB should be > 0";
+
+    /* Bound is always conservative (includes frame header + flush overhead),
+     * so it should be stable regardless of frame state. */
+    size_t b_before = streamCompressOutputBound(&sc, 1024);
+    uint8_t *seed_buf = (uint8_t *)zmalloc(b_before);
+    ASSERT_TRUE(seed_buf != NULL);
+    ASSERT_TRUE(streamCompressFeed(&sc, seed_buf, b_before,
+                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) >= 0)
+        << "seed write should start the frame";
+    size_t b_after = streamCompressOutputBound(&sc, 1024);
+    ASSERT_TRUE(b_before == b_after) << "bound should be the same before and after frame start";
+
+    /* Zero input should still return > 0 (frame header + flush overhead) */
+    size_t b_zero = streamCompressOutputBound(&sc, 0);
+    ASSERT_TRUE(b_zero > 0) << "zero input bound should be > 0";
+
+    zfree(seed_buf);
+    streamCompressorDestroy(&sc);
+    return;
+}
+
+/* --- Test: streamCompressFeed error paths --- */
+TEST(compression, streamCompressFeedErrors) {
+    uint8_t buf[64];
+    /* NULL compressor */
+    ASSERT_TRUE(streamCompressFeed(NULL, buf, sizeof(buf),
+                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
+        << "NULL sc should return -1";
+
+    /* NULL output buffer */
+    stream_compressor_t sc;
+    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressFeed(&sc, NULL, sizeof(buf),
+                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
+        << "NULL output should return -1";
+    streamCompressorDestroy(&sc);
+
+    return;
+}
+
+/* --- Test: streamDecompressFeed error paths --- */
+TEST(compression, streamDecompressFeedErrors) {
+    const char *payload = "decompress sticky error";
+    uint8_t buf[64];
+    uint8_t out[128];
+    size_t consumed = 0;
+
+    /* NULL decompressor */
+    ASSERT_TRUE(streamDecompressFeed(NULL, buf, sizeof(buf),
+                                     (const uint8_t *)"x", 1, &consumed) == -1)
+        << "NULL sd should return -1";
+
+    /* NULL input_consumed */
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressFeed(&sd, buf, sizeof(buf),
+                                     (const uint8_t *)"x", 1, NULL) == -1)
+        << "NULL input_consumed should return -1";
+    ASSERT_TRUE(sd.errored == false) << "decompressor should not be errored by NULL bookkeeping arg";
+
+    /* Zero output capacity should return -1 (no-progress prevention) */
+    ASSERT_TRUE(streamDecompressFeed(&sd, buf, 0,
+                                     (const uint8_t *)"x", 1, &consumed) == -1)
+        << "zero output capacity should return -1";
+    ASSERT_TRUE(sd.errored == true) << "decompressor should enter sticky errored state";
+
+    /* Once errored, all subsequent feeds fail immediately. */
+    stream_compressor_t sc;
+    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    size_t bound = streamCompressOutputBound(&sc, strlen(payload));
+    uint8_t *compressed = (uint8_t *)zmalloc(bound);
+    ASSERT_TRUE(compressed != NULL);
+    ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
+                                                (const uint8_t *)payload, strlen(payload),
+                                                FLUSH_END);
+    ASSERT_TRUE(compressed_len > 0);
+    streamCompressorDestroy(&sc);
+
+    ASSERT_TRUE(streamDecompressFeed(&sd, out, sizeof(out),
+                                     compressed, (size_t)compressed_len,
+                                     &consumed) == -1)
+        << "errored decompressor should fail even with valid input";
+    zfree(compressed);
+
+    streamDecompressorDestroy(&sd);
+    return;
+}
+
+/* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
+TEST(compression, streamCompressFeedErrorRecovery) {
+    stream_compressor_t sc;
+    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+
+    /* Pre-frame error: compressBegin fails with tiny buffer, but no frame
+     * bytes have been emitted yet — this is recoverable. */
+    uint8_t tiny[1];
+    ssize_t ret = streamCompressFeed(&sc, tiny, 1,
+                                     (const uint8_t *)"test data", 9, FLUSH_END);
+    ASSERT_TRUE(ret == -1) << "should fail with tiny buffer";
+    ASSERT_TRUE(sc.errored == false) << "errored should NOT be set (pre-frame failure)";
+    ASSERT_TRUE(sc.frame_started == false) << "frame_started should still be false";
+
+    /* Retry with a proper buffer — should succeed */
+    size_t bound = streamCompressOutputBound(&sc, 9);
+    uint8_t *buf = (uint8_t *)zmalloc(bound);
+    ssize_t ret2 = streamCompressFeed(&sc, buf, bound,
+                                      (const uint8_t *)"test data", 9, FLUSH_END);
+    ASSERT_TRUE(ret2 > 0) << "retry after pre-frame error should succeed";
+    zfree(buf);
+    streamCompressorDestroy(&sc);
+
+    /* Mid-frame error: start a frame, then force an error — this is permanent. */
+    stream_compressor_t sc2;
+    ASSERT_TRUE(streamCompressorInit(&sc2, ALGO_LZ4, 0) == 0);
+
+    /* First call with enough space to start the frame */
+    size_t bound2 = streamCompressOutputBound(&sc2, 5);
+    uint8_t *buf2 = (uint8_t *)zmalloc(bound2);
+    ssize_t ret3 = streamCompressFeed(&sc2, buf2, bound2,
+                                      (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
+    ASSERT_TRUE(ret3 >= 0) << "first write should succeed";
+    ASSERT_TRUE(sc2.frame_started == true) << "frame should be started";
+
+    /* Now force a mid-frame error with a tiny buffer */
+    uint8_t tiny2[1];
+    ssize_t ret4 = streamCompressFeed(&sc2, tiny2, 1,
+                                      (const uint8_t *)"more data to compress", 21,
+                                      FLUSH_END);
+    ASSERT_TRUE(ret4 == -1) << "mid-frame error should fail";
+    ASSERT_TRUE(sc2.errored == true) << "errored should be set (mid-frame failure)";
+
+    /* Subsequent calls must fail immediately */
+    size_t bound3 = streamCompressOutputBound(&sc2, 5);
+    uint8_t *buf3 = (uint8_t *)zmalloc(bound3);
+    ssize_t ret5 = streamCompressFeed(&sc2, buf3, bound3,
+                                      (const uint8_t *)"hello", 5, FLUSH_END);
+    ASSERT_TRUE(ret5 == -1) << "must fail on errored compressor";
+    zfree(buf3);
+    zfree(buf2);
+    streamCompressorDestroy(&sc2);
+
+    return;
+}
+
+TEST(compression, streamReaderClassifiesProbeInputs) {
+    static const uint8_t plain_input[] = {'H', 'E', 'L', 'L', 'O'};
+    static const uint8_t truncated_vkcs[] = {'V', 'K', 'C'};
+    static const uint8_t invalid_vkcs[VKCS_ENVELOPE_SIZE] = {
+        VKCS_MAGIC_0, VKCS_MAGIC_1, VKCS_MAGIC_2, VKCS_MAGIC_3,
+        0, VKCS_CODEC_LZ4, 0, STREAM_KIND_RDB};
+    static const uint8_t strict_non_vkcs[VKCS_ENVELOPE_SIZE] = {'R', 'E', 'D', 'I', 'S', '0', '0', '1'};
+
+    struct {
+        const char *name;
+        const uint8_t *input;
+        size_t input_len;
+        size_t max_chunk;
+        bool allow_passthrough;
+        bool expect_probe_ok;
+        stream_reader_error_t expected_error;
+        size_t expected_read_len;
+    } cases[] = {
+        {"plain passthrough",
+         plain_input,
+         sizeof(plain_input),
+         2,
+         true,
+         true,
+         STREAM_READER_ERROR_NONE,
+         sizeof(plain_input)},
+        {"truncated VKCS prefix",
+         truncated_vkcs,
+         sizeof(truncated_vkcs),
+         2,
+         true,
+         false,
+         STREAM_READER_ERROR_INCOMPATIBLE,
+         0},
+        {"invalid VKCS envelope",
+         invalid_vkcs,
+         sizeof(invalid_vkcs),
+         0,
+         true,
+         false,
+         STREAM_READER_ERROR_INCOMPATIBLE,
+         0},
+        {"non-VKCS with passthrough disabled",
+         strict_non_vkcs,
+         sizeof(strict_non_vkcs),
+         0,
+         false,
+         false,
+         STREAM_READER_ERROR_INCOMPATIBLE,
+         0},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        mem_reader_t mr = {};
+        mr.data = cases[i].input;
+        mr.len = cases[i].input_len;
+        mr.max_chunk = cases[i].max_chunk;
+        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
+        stream_reader_t *t = stream_reader_create(&cfg, memReaderRead, &mr);
+        ASSERT_TRUE(t != NULL) << cases[i].name;
+
+        stream_reader_info_t info;
+        if (cases[i].expect_probe_ok) {
+            ASSERT_TRUE(stream_reader_probe(t) == 0) << cases[i].name;
+            ASSERT_TRUE(stream_reader_get_info(t, &info) == 0) << cases[i].name;
+            ASSERT_TRUE(info.compressed == 0) << cases[i].name;
+
+            uint8_t out[16] = {0};
+            ASSERT_TRUE(stream_reader_read(t, out, cases[i].expected_read_len) == (ssize_t)cases[i].expected_read_len)
+                << cases[i].name;
+            ASSERT_TRUE(memcmp(out, cases[i].input, cases[i].expected_read_len) == 0) << cases[i].name;
+            ASSERT_TRUE(stream_reader_read(t, out, sizeof(out)) == 0) << cases[i].name;
+        } else {
+            ASSERT_TRUE(stream_reader_probe(t) == -1) << cases[i].name;
+            ASSERT_TRUE(stream_reader_get_info(t, &info) == -1) << cases[i].name;
+            ASSERT_TRUE(stream_reader_get_error(t) == cases[i].expected_error) << cases[i].name;
+
+            uint8_t out[8] = {0};
+            ASSERT_TRUE(stream_reader_read(t, out, sizeof(out)) == -1) << cases[i].name;
+        }
+
+        stream_reader_destroy(t);
+    }
+    return;
+}
+
+TEST(compression, streamReaderRejectsOversizedReadRequest) {
+    const uint8_t input[] = {'H', 'E', 'L', 'L', 'O'};
+    mem_reader_t mr = {};
+    mr.data = input;
+    mr.len = sizeof(input);
+    mr.max_chunk = 2;
+    stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+
+    stream_reader_t *t = stream_reader_create(&cfg, memReaderRead, &mr);
+    ASSERT_TRUE(t != NULL) << "stream_reader_create should succeed";
+
+    uint8_t out[8] = {0};
+    size_t oversized = (size_t)std::numeric_limits<ssize_t>::max() + 1;
+    ASSERT_TRUE(stream_reader_read(t, out, oversized) == -1)
+        << "oversized reads should fail before touching stream state";
+
+    stream_reader_info_t info;
+    ASSERT_TRUE(stream_reader_get_info(t, &info) == 0)
+        << "oversized read failure should not poison the reader";
+    ASSERT_TRUE(info.compressed == 0) << "plain input should still probe as passthrough";
+
+    ASSERT_TRUE(stream_reader_read(t, out, sizeof(input)) == (ssize_t)sizeof(input));
+    ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
+
+    stream_reader_destroy(t);
+    return;
+}
+
+/* ===================================================================
+ * Tests for stream writer API and rio decorators
+ * =================================================================== */
+
+extern "C" {
+void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
+}
+
+/* --- Emit callback that appends to a dynamically growing buffer --- */
+typedef struct {
+    uint8_t *data;
+} dynamic_buf_t;
+
+static void dynamicBufInit(dynamic_buf_t *db) {
+    db->data = (uint8_t *)sdsempty();
+}
+
+static void dynamicBufFree(dynamic_buf_t *db) {
+    if (db->data) sdsfree((sds)db->data);
+    db->data = NULL;
+}
+
+static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
+    dynamic_buf_t *db = (dynamic_buf_t *)ctx;
+    db->data = (uint8_t *)sdscatlen((sds)db->data, data, len);
+    return db->data != NULL ? 0 : -1;
+}
+
+static int initVkcsRdbDecompressRio(decompress_rio_t *dr, rio *inner) {
+    stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    return rioInitWithDecompress(dr, inner, &cfg, NULL) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
+}
+
+TEST(compression, streamReaderValidatesCompressedStreamKinds) {
+    struct {
+        const char *name;
+        const char *payload;
+        uint8_t writer_kind;
+        uint8_t expected_kind;
+        size_t max_chunk;
+        size_t buffer_size;
+        bool expect_ok;
+    } cases[] = {
+        {"incremental RDB stream",
+         "incremental probe payload",
+         STREAM_KIND_RDB,
+         STREAM_KIND_RDB,
+         3,
+         8,
+         true},
+        {"custom stream kind",
+         "custom stream kind",
+         0x7f,
+         0x7f,
+         0,
+         0,
+         true},
+        {"custom stream when RDB expected",
+         "stream-kind mismatch",
+         0x7f,
+         STREAM_KIND_RDB,
+         0,
+         0,
+         false},
+        {"RDB stream when custom expected",
+         "stream-kind mismatch",
+         STREAM_KIND_RDB,
+         0x7f,
+         0,
+         0,
+         false},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        size_t payload_len = strlen(cases[i].payload);
+        dynamic_buf_t db;
+        dynamicBufInit(&db);
+
+        stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
+        stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+        ASSERT_TRUE(w != NULL) << cases[i].name;
+        ASSERT_TRUE(stream_writer_write(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
+        ASSERT_TRUE(stream_writer_finish(w) == 0) << cases[i].name;
+        stream_writer_destroy(w);
+
+        mem_reader_t mr = {};
+        mr.data = db.data;
+        mr.len = sdslen((const char *)db.data);
+        mr.max_chunk = cases[i].max_chunk;
+        stream_reader_config_t rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
+        stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+        ASSERT_TRUE(r != NULL) << cases[i].name;
+
+        stream_reader_info_t info;
+        if (cases[i].expect_ok) {
+            ASSERT_TRUE(stream_reader_probe(r) == 0) << cases[i].name;
+            ASSERT_TRUE(stream_reader_get_info(r, &info) == 0) << cases[i].name;
+            ASSERT_TRUE(info.compressed) << cases[i].name;
+            ASSERT_TRUE(info.algo == ALGO_LZ4) << cases[i].name;
+            ASSERT_TRUE(info.stream_kind == cases[i].expected_kind) << cases[i].name;
+
+            uint8_t out[64] = {0};
+            ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len) << cases[i].name;
+            ASSERT_TRUE(memcmp(out, cases[i].payload, payload_len) == 0) << cases[i].name;
+            ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == 0) << cases[i].name;
+        } else {
+            ASSERT_TRUE(stream_reader_probe(r) == -1) << cases[i].name;
+            ASSERT_TRUE(stream_reader_get_info(r, &info) == -1) << cases[i].name;
+            ASSERT_TRUE(stream_reader_get_error(r) == STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
+
+            uint8_t out[32] = {0};
+            ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == -1) << cases[i].name;
+        }
+
+        stream_reader_destroy(r);
+        dynamicBufFree(&db);
+    }
+    return;
+}
+
+/* --- Test: stream_reader marks errored on partial output + read error.
+ * Regression for direct-path error accounting (partial bytes were returned
+ * without sticky errored state). */
+TEST(compression, streamReaderPartialThenErrorSetsErrored) {
+    const size_t payload_len = 64 * 1024;
+    uint8_t *payload = (uint8_t *)zmalloc(payload_len);
+    uint32_t x = 0x12345678u;
+    for (size_t i = 0; i < payload_len; i++) {
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        payload[i] = (uint8_t)(x & 0xFF);
+    }
+
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL) << "stream_writer_create should succeed";
+    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(stream_writer_finish(w) == 0);
+    stream_writer_destroy(w);
+
+    flaky_reader_t fr = {};
+    fr.data = db.data;
+    fr.len = sdslen((const char *)db.data);
+    fr.max_chunk = 4096;
+    /* One probe read plus two 4 KB payload reads is enough to produce some
+     * output with an 8 KB window, but not enough to satisfy the full request. */
+    fr.fail_after_success_reads = 3;
+    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
+    stream_reader_t *r = stream_reader_create(&rcfg, flakyReaderRead, &fr);
+    ASSERT_TRUE(r != NULL) << "stream_reader_create should succeed";
+
+    const size_t out_len = 16 * 1024;
+    uint8_t *out = (uint8_t *)zmalloc(out_len);
+    ASSERT_TRUE(out != NULL);
+    ssize_t n1 = stream_reader_read(r, out, out_len);
+    ASSERT_TRUE(n1 > 0) << "first read should return partial output";
+    ASSERT_TRUE(stream_reader_read(r, out, out_len) == -1) << "second read should fail immediately";
+
+    stream_reader_destroy(r);
+
+    /* Passthrough mode should also preserve partial bytes when source read
+     * fails after probe/prefix buffering, then latch sticky error state. */
+    const uint8_t plain[] = "NOTVKCS-passthrough-regression";
+    flaky_reader_t fr_passthrough = {};
+    fr_passthrough.data = plain;
+    fr_passthrough.len = sizeof(plain) - 1;
+    fr_passthrough.max_chunk = 0;
+    fr_passthrough.fail_after_success_reads = 1; /* probe succeeds, next read fails */
+    stream_reader_config_t pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    stream_reader_t *rp = stream_reader_create(&pass_cfg, flakyReaderRead, &fr_passthrough);
+    ASSERT_TRUE(rp != NULL) << "passthrough reader create should succeed";
+
+    uint8_t pass_out[64];
+    ssize_t p1 = stream_reader_read(rp, pass_out, sizeof(pass_out));
+    ASSERT_TRUE(p1 > 0) << "passthrough first read should return partial output";
+    ASSERT_TRUE(memcmp(pass_out, plain, (size_t)p1) == 0) << "passthrough partial bytes should match input prefix";
+    ASSERT_TRUE(stream_reader_read(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
+    stream_reader_destroy(rp);
+    zfree(out);
+
+    dynamicBufFree(&db);
+    zfree(payload);
+    return;
+}
+
+/* --- Test: stream_writer_create/destroy --- */
+TEST(compression, streamWriterCreateDestroy) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL) << "create should succeed for LZ4";
+    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored";
+
+    stream_writer_destroy(t);
+    dynamicBufFree(&db);
+
+    /* NULL config should fail */
+    ASSERT_TRUE(stream_writer_create(NULL, emitToDynamicBuf, &db) == NULL) << "NULL config should return NULL";
+
+    /* NULL emit_cb should fail */
+    ASSERT_TRUE(stream_writer_create(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
+
+    /* ALGO_NONE should fail */
+    stream_writer_config_t bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
+    ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
+    bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
+    ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
+
+    /* Concrete stream kinds outside the currently named ones are valid. */
+    stream_writer_config_t future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
+    stream_writer_t *future_t = stream_writer_create(&future_kind_cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(future_t != NULL) << "custom stream_kind should succeed with envelope";
+    stream_writer_destroy(future_t);
+
+    /* destroy NULL should be safe */
+    stream_writer_destroy(NULL);
+
+    return;
+}
+
+/* --- Test: stream_writer write + finish round-trip --- */
+TEST(compression, streamWriterRoundTrip) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    /* Write some data */
+    const char *test_data = "Hello, compression world! This is a test of the stream writer API.";
+    size_t data_len = strlen(test_data);
+    ASSERT_TRUE(stream_writer_write(t, test_data, data_len) >= 0);
+    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored after write";
+    ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "write should emit envelope";
+
+    /* Finalize */
+    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored after finish";
+
+    /* Verify output starts with VKCS envelope */
+    ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "output should have at least envelope size";
+    ASSERT_TRUE(db.data[0] == VKCS_MAGIC_0) << "magic byte 0";
+    ASSERT_TRUE(db.data[1] == VKCS_MAGIC_1) << "magic byte 1";
+    ASSERT_TRUE(db.data[2] == VKCS_MAGIC_2) << "magic byte 2";
+    ASSERT_TRUE(db.data[3] == VKCS_MAGIC_3) << "magic byte 3";
+    ASSERT_TRUE(db.data[4] == VKCS_VERSION) << "version";
+    ASSERT_TRUE(db.data[5] == VKCS_CODEC_LZ4) << "codec_id";
+    ASSERT_TRUE(db.data[6] == 0) << "flags should be clear when checksum is disabled";
+    ASSERT_TRUE(db.data[7] == STREAM_KIND_RDB) << "stream_kind RDB";
+
+    /* Decompress and verify round-trip */
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+
+    uint8_t decompressed[256];
+    size_t total_decompressed = 0;
+    uint8_t *compressed_data = db.data + VKCS_ENVELOPE_SIZE;
+    size_t compressed_len = sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE;
+    size_t src_offset = 0;
+
+    while (src_offset < compressed_len) {
+        size_t consumed = 0;
+        ssize_t produced = streamDecompressFeed(
+            &sd, decompressed + total_decompressed,
+            sizeof(decompressed) - total_decompressed,
+            compressed_data + src_offset,
+            compressed_len - src_offset, &consumed);
+        ASSERT_TRUE(produced >= 0) << "decompression should not fail";
+        total_decompressed += (size_t)produced;
+        src_offset += consumed;
+        if (consumed == 0 && produced == 0) break;
+    }
+
+    ASSERT_TRUE(total_decompressed == data_len) << "decompressed length should match original";
+    ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match original";
+
+    streamDecompressorDestroy(&sd);
+    stream_writer_destroy(t);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* --- Test: a single large write is chunked internally without changing
+ * the logical stream. This exercises the bounded scratch-buffer path. --- */
+TEST(compression, streamWriterLargeSingleWrite) {
+    const size_t payload_len = (1024 * 1024) + 4096;
+    uint8_t *payload = (uint8_t *)zmalloc(payload_len);
+    for (size_t i = 0; i < payload_len; i++) {
+        payload[i] = (uint8_t)((i * 17 + 11) % 251);
+    }
+
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_TRUE(stream_writer_write(t, payload, payload_len) >= 0);
+    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    stream_writer_destroy(t);
+
+    mem_reader_t mr = {};
+    mr.data = db.data;
+    mr.len = sdslen((const char *)db.data);
+    mr.max_chunk = 0;
+    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
+    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    ASSERT_TRUE(r != NULL);
+
+    uint8_t *out = (uint8_t *)zmalloc(payload_len);
+    size_t total = 0;
+    while (total < payload_len) {
+        ssize_t nread = stream_reader_read(r, out + total, payload_len - total);
+        ASSERT_TRUE(nread > 0) << "stream_reader_read should keep making progress";
+        total += (size_t)nread;
+    }
+    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+    ASSERT_TRUE(stream_reader_read(r, out, 1) == 0) << "reader should stop at frame end";
+
+    zfree(out);
+    zfree(payload);
+    stream_reader_destroy(r);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* --- Test: small caller reads should still drain a compressed stream
+ * correctly. This exercises the buffered decompressed window path. --- */
+TEST(compression, streamReaderSmallReadsRoundTrip) {
+    const size_t payload_len = 256 * 1024;
+    uint8_t *payload = (uint8_t *)zmalloc(payload_len);
+    ASSERT_TRUE(payload != NULL);
+    for (size_t i = 0; i < payload_len; i++) {
+        payload[i] = (uint8_t)((i * 29 + 7) % 251);
+    }
+
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
+    stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL);
+    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(stream_writer_finish(w) == 0);
+    stream_writer_destroy(w);
+
+    mem_reader_t mr = {};
+    mr.data = db.data;
+    mr.len = sdslen((const char *)db.data);
+    mr.max_chunk = 4096;
+    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
+    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    ASSERT_TRUE(r != NULL);
+
+    uint8_t *out = (uint8_t *)zmalloc(payload_len);
+    ASSERT_TRUE(out != NULL);
+    size_t total = 0;
+    while (total < payload_len) {
+        size_t step = payload_len - total;
+        if (step > 17) step = 17;
+        ssize_t nread = stream_reader_read(r, out + total, step);
+        ASSERT_TRUE(nread > 0) << "stream_reader_read should keep making progress";
+        total += (size_t)nread;
+    }
+
+    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+    ASSERT_TRUE(stream_reader_read(r, out, 1) == 0) << "reader should stop at frame end";
+
+    zfree(out);
+    zfree(payload);
+    stream_reader_destroy(r);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* --- Test: stream_writer_flush semantics (no-op before writes, valid mid-stream) --- */
+TEST(compression, streamWriterFlushBehavior) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush before write should be no-op success";
+    ASSERT_TRUE(sdslen((const char *)db.data) == 0) << "flush before write should not emit bytes";
+
+    ASSERT_TRUE(stream_writer_write(t, "first chunk", 11) >= 0);
+    ASSERT_TRUE(stream_writer_flush(t) == 0);
+    ASSERT_TRUE(stream_writer_write(t, "second chunk", 12) >= 0);
+    ASSERT_TRUE(stream_writer_finish(t) == 0);
+
+    ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+
+    uint8_t decompressed[256];
+    size_t total_decompressed = 0;
+    uint8_t *comp_data = db.data + VKCS_ENVELOPE_SIZE;
+    size_t comp_len = sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE;
+    size_t src_offset = 0;
+
+    while (src_offset < comp_len) {
+        size_t consumed = 0;
+        ssize_t produced = streamDecompressFeed(
+            &sd, decompressed + total_decompressed,
+            sizeof(decompressed) - total_decompressed,
+            comp_data + src_offset,
+            comp_len - src_offset, &consumed);
+        ASSERT_TRUE(produced >= 0);
+        total_decompressed += (size_t)produced;
+        src_offset += consumed;
+        if (consumed == 0 && produced == 0) break;
+    }
+
+    ASSERT_TRUE(total_decompressed == 23);
+    ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0);
+
+    streamDecompressorDestroy(&sd);
+    stream_writer_destroy(t);
+    dynamicBufFree(&db);
+    return;
+}
+
+TEST(compression, streamWriterFlushAfterFinishIsNoop) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    ASSERT_TRUE(stream_writer_write(t, "payload", 7) >= 0);
+    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    size_t len_after_finish = sdslen((const char *)db.data);
+
+    ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush after finish should be a no-op success";
+    ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "flush after finish should not emit bytes";
+
+    stream_writer_destroy(t);
+    dynamicBufFree(&db);
+    return;
+}
+
+TEST(compression, streamWriterCodecChecksumToggle) {
+    const char *payload = "block checksum payload block checksum payload";
+
+    for (bool codec_checksum : {false, true}) {
+        dynamic_buf_t db;
+        dynamicBufInit(&db);
+
+        stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
+                                                      codec_checksum);
+        stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+        ASSERT_TRUE(t != NULL);
+        ASSERT_TRUE(stream_writer_write(t, payload, strlen(payload)) >= 0);
+        ASSERT_TRUE(stream_writer_finish(t) == 0);
+
+        ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
+        ASSERT_TRUE(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
+                                             sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE) == codec_checksum)
+            << "LZ4 frame should reflect configured codec checksum setting";
+
+        stream_writer_destroy(t);
+        dynamicBufFree(&db);
+    }
+}
+
+/* --- Test: compress_rio_t write + finish round-trip --- */
+TEST(compression, compressRioRoundTrip) {
+    /* Use a buffer rio as the inner rio */
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    const char *test_data = "The quick brown fox jumps over the lazy dog. "
+                            "Pack my box with five dozen liquor jugs.";
+    size_t data_len = strlen(test_data);
+    ASSERT_TRUE(rioWrite((rio *)&cr, test_data, data_len) != 0) << "rioWrite should succeed";
+
+    /* Finalize and destroy */
+    compress_rio_finish(&cr);
+
+    /* Get the compressed output from the buffer rio */
+    sds compressed = buffer_rio.io.buffer.ptr;
+    size_t compressed_len = sdslen(compressed);
+    ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE) << "compressed output should exist";
+
+    /* Verify VKCS envelope */
+    ASSERT_TRUE(compressed[0] == (char)VKCS_MAGIC_0) << "magic V";
+    ASSERT_TRUE(compressed[1] == (char)VKCS_MAGIC_1) << "magic K";
+    ASSERT_TRUE(compressed[2] == (char)VKCS_MAGIC_2) << "magic C";
+    ASSERT_TRUE(compressed[3] == (char)VKCS_MAGIC_3) << "magic S";
+
+    /* Decompress and verify */
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+
+    uint8_t decompressed[512];
+    size_t total_decompressed = 0;
+    uint8_t *comp_data = (uint8_t *)compressed + VKCS_ENVELOPE_SIZE;
+    size_t comp_len = compressed_len - VKCS_ENVELOPE_SIZE;
+    size_t src_offset = 0;
+
+    while (src_offset < comp_len) {
+        size_t consumed = 0;
+        ssize_t produced = streamDecompressFeed(
+            &sd, decompressed + total_decompressed,
+            sizeof(decompressed) - total_decompressed,
+            comp_data + src_offset,
+            comp_len - src_offset, &consumed);
+        ASSERT_TRUE(produced >= 0) << "decompression should not fail";
+        total_decompressed += (size_t)produced;
+        src_offset += consumed;
+        if (consumed == 0 && produced == 0) break;
+    }
+
+    ASSERT_TRUE(total_decompressed == data_len) << "decompressed length should match";
+    ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match";
+
+    streamDecompressorDestroy(&sd);
+    compress_rio_destroy(&cr);
+    sdsfree(compressed);
+    return;
+}
+
+TEST(compression, compressRioTracksUncompressedChecksum) {
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+
+    const char *payload = "checksum-payload-for-compressed-rio";
+    size_t payload_len = strlen(payload);
+    ASSERT_TRUE(rioWrite((rio *)&cr, payload, payload_len) != 0);
+
+    rio expected = {};
+    rioGenericUpdateChecksum(&expected, payload, payload_len);
+    ASSERT_TRUE(cr.base.cksum == expected.cksum) << "compress_rio should track the checksum of uncompressed bytes";
+
+    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
+    compress_rio_destroy(&cr);
+    sdsfree(buffer_rio.io.buffer.ptr);
+    return;
+}
+
+TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+    buffer_rio.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0);
+
+    const char *payload = "skip-checksum-payload";
+    ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
+    ASSERT_TRUE(cr.base.cksum == 0) << "skip-checksum should disable uncompressed RDB checksum tracking";
+
+    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
+    compress_rio_destroy(&cr);
+    sdsfree(buffer_rio.io.buffer.ptr);
+    return;
+}
+
+TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) {
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) != 0);
+
+    const char *payload = "codec-checksum-enabled";
+    ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
+    ASSERT_TRUE(cr.base.cksum == 0)
+        << "codec checksums should disable standard RDB checksum tracking for compressed RDB";
+
+    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
+    compress_rio_destroy(&cr);
+    sdsfree(buffer_rio.io.buffer.ptr);
+    return;
+}
+
+TEST(compression, rioDecoratorsPreserveInnerType) {
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+
+    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &wcfg) == 0);
+    /* Decorators preserve the inner backend type via the type field.
+     * Verify the decorator reports the same type as the wrapped rio. */
+    ASSERT_TRUE(rioCheckType((rio *)&cr) == RIO_TYPE_BUFFER);
+    compress_rio_destroy(&cr);
+    sdsfree(buffer_rio.io.buffer.ptr);
+
+    sds raw = sdsnew("plain-rdb-prefix");
+    rio raw_rio;
+    rioInitWithBuffer(&raw_rio, raw);
+    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    decompress_rio_t dr;
+    ASSERT_TRUE(rioInitWithDecompress(&dr, &raw_rio, &rcfg, NULL) == DECOMPRESS_RIO_INIT_OK);
+    ASSERT_TRUE(rioCheckType((rio *)&dr) == RIO_TYPE_BUFFER);
+    decompress_rio_destroy(&dr);
+    sdsfree(raw_rio.io.buffer.ptr);
+}
+
+/* --- Test: decompress_rio_t read round-trip --- */
+TEST(compression, decompressRioRoundTrip) {
+    /* First, produce compressed data using stream writer */
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    const char *test_data = "Decompression rio test data. "
+                            "This should round-trip through compress then decompress.";
+    size_t data_len = strlen(test_data);
+    stream_writer_write(t, test_data, data_len);
+    stream_writer_finish(t);
+    stream_writer_destroy(t);
+
+    /* Create a buffer rio with the full VKCS-wrapped stream. */
+    sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, comp_sds);
+
+    /* Create decompress rio */
+    decompress_rio_t dr;
+    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+
+    /* Read decompressed data */
+    char result[256];
+    memset(result, 0, sizeof(result));
+    ASSERT_TRUE(rioRead((rio *)&dr, result, data_len) != 0) << "rioRead should succeed";
+    ASSERT_TRUE(memcmp(result, test_data, data_len) == 0) << "decompressed data should match original";
+
+    decompress_rio_destroy(&dr);
+    sdsfree(comp_sds);
+    dynamicBufFree(&db);
+    return;
+}
+
+TEST(compression, decompressRioTellTracksSourceProgress) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    std::string payload(4096, 'A');
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_TRUE(stream_writer_write(t, payload.data(), payload.size()) >= 0);
+    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    stream_writer_destroy(t);
+
+    sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, comp_sds);
+
+    decompress_rio_t dr;
+    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+
+    char out[2048];
+    ASSERT_TRUE(rioRead((rio *)&dr, out, sizeof(out)) != 0);
+    ASSERT_TRUE(rioTell((rio *)&dr) == rioTell(&buffer_rio));
+    ASSERT_TRUE((size_t)rioTell((rio *)&dr) < sizeof(out))
+        << "decompress rio tell should track source bytes, not logical output bytes";
+
+    decompress_rio_destroy(&dr);
+    sdsfree(comp_sds);
+    dynamicBufFree(&db);
+}
+
+TEST(compression, decompressRioClassifiesInput) {
+    {
+        const char *payload = "REDIS001remaining data after prefix";
+        size_t payload_len = strlen(payload);
+        sds buf = sdsnewlen(payload, payload_len);
+        rio buffer_rio;
+        rioInitWithBuffer(&buffer_rio, buf);
+
+        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        decompress_rio_t dr;
+        stream_reader_info_t info;
+        ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info) == DECOMPRESS_RIO_INIT_OK);
+        ASSERT_TRUE(info.compressed == 0) << "passthrough stream should not be compressed";
+
+        char result[64];
+        memset(result, 0, sizeof(result));
+        ASSERT_TRUE(rioRead((rio *)&dr, result, payload_len) != 0) << "rioRead should succeed";
+        ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "payload should be replayed exactly";
+
+        decompress_rio_destroy(&dr);
+        sdsfree(buf);
+    }
+
+    {
+        const uint8_t malformed[VKCS_ENVELOPE_SIZE] = {
+            VKCS_MAGIC_0, VKCS_MAGIC_1, VKCS_MAGIC_2, VKCS_MAGIC_3,
+            0, VKCS_CODEC_LZ4, 0, STREAM_KIND_RDB};
+        sds buf = sdsnewlen(malformed, sizeof(malformed));
+        rio buffer_rio;
+        rioInitWithBuffer(&buffer_rio, buf);
+
+        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        decompress_rio_t dr;
+        ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, NULL) ==
+                    DECOMPRESS_RIO_INIT_INCOMPATIBLE);
+
+        sdsfree(buf);
+    }
+    return;
+}
+
+/* --- Test: compress_rio_finish is idempotent --- */
+TEST(compression, compressRioFinishIdempotent) {
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+
+    rioWrite((rio *)&cr, "test", 4);
+    compress_rio_finish(&cr);
+    size_t len_after_first = sdslen(buffer_rio.io.buffer.ptr);
+
+    /* Second finish should be a no-op */
+    compress_rio_finish(&cr);
+    size_t len_after_second = sdslen(buffer_rio.io.buffer.ptr);
+    ASSERT_TRUE(len_after_first == len_after_second) << "second finish should not produce more output";
+
+    compress_rio_destroy(&cr);
+    sdsfree(buffer_rio.io.buffer.ptr);
+    return;
+}
+
+/* --- Test: compress_rio flush mid-stream does not end frame --- */
+TEST(compression, compressRioFlushMidStream) {
+    sds buf = sdsempty();
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, buf);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+
+    /* Write some data */
+    ASSERT_TRUE(rioWrite((rio *)&cr, "first chunk", 11) != 0);
+
+    /* Flush mid-stream — should NOT end the frame */
+    ASSERT_TRUE(rioFlush((rio *)&cr) != 0) << "flush should succeed";
+
+    /* Write more data — should succeed because frame is still open */
+    ASSERT_TRUE(rioWrite((rio *)&cr, "second chunk", 12) != 0) << "write after flush should succeed";
+
+    /* Now finalize */
+    compress_rio_finish(&cr);
+
+    /* Verify the entire stream decompresses correctly */
+    sds compressed = buffer_rio.io.buffer.ptr;
+    size_t compressed_len = sdslen(compressed);
+    ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE);
+
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+
+    uint8_t decompressed[256];
+    size_t total_decompressed = 0;
+    uint8_t *comp_data = (uint8_t *)compressed + VKCS_ENVELOPE_SIZE;
+    size_t comp_len = compressed_len - VKCS_ENVELOPE_SIZE;
+    size_t src_offset = 0;
+
+    while (src_offset < comp_len) {
+        size_t consumed = 0;
+        ssize_t produced = streamDecompressFeed(
+            &sd, decompressed + total_decompressed,
+            sizeof(decompressed) - total_decompressed,
+            comp_data + src_offset,
+            comp_len - src_offset, &consumed);
+        ASSERT_TRUE(produced >= 0) << "decompression should not fail";
+        total_decompressed += (size_t)produced;
+        src_offset += consumed;
+        if (consumed == 0 && produced == 0) break;
+    }
+
+    ASSERT_TRUE(total_decompressed == 23) << "total decompressed should be 23 bytes";
+    ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0) << "decompressed should match concatenated input";
+
+    streamDecompressorDestroy(&sd);
+    compress_rio_destroy(&cr);
+    sdsfree(compressed);
+    return;
+}
+
+/* --- Test: rdbLoadProgressCallback does not cast write-side streaming rios
+ * to decompress_rio_t. This protects save/async paths that also use
+ * RIO_FLAG_STREAMING_COMPRESSION. --- */
+TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
+    sds buf = sdsempty();
+    rio inner;
+    rioInitWithBuffer(&inner, buf);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compress_rio_t cr;
+    ASSERT_TRUE(rioInitWithCompress(&cr, &inner, &cfg) == 0);
+
+    const char sample[] = "progress-guard";
+    rdbLoadProgressCallback((rio *)&cr, sample, sizeof(sample) - 1);
+
+    ASSERT_TRUE((cr.base.flags & RIO_FLAG_READ_ERROR) == 0) << "write-side streaming rio must not set read error";
+
+    compress_rio_destroy(&cr);
+    sdsfree(inner.io.buffer.ptr);
+    return;
+}
+
+/* --- Test: decompress_rio with large payload (>64KB) exercises partial
+ * consume in the large-chunk read path. Before the fix, unconsumed
+ * compressed bytes were dropped between iterations, causing false EOF
+ * or data corruption. --- */
+TEST(compression, decompressRioLargePayload) {
+    /* Generate a large payload (256KB) with a repeating pattern so
+     * it's compressible but large enough to require multiple
+     * decompression iterations. */
+    const size_t payload_len = 256 * 1024;
+    uint8_t *payload = (uint8_t *)zmalloc(payload_len);
+    for (size_t i = 0; i < payload_len; i++) {
+        payload[i] = (uint8_t)(i % 251); /* prime modulus for variety */
+    }
+
+    /* Compress via stream_writer */
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    stream_writer_write(t, payload, payload_len);
+    stream_writer_finish(t);
+    stream_writer_destroy(t);
+
+    /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
+    sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, comp_sds);
+
+    decompress_rio_t dr;
+    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+
+    /* Read in small chunks (4KB) to force multiple iterations through
+     * the decompression state machine. */
+    uint8_t *result = (uint8_t *)zmalloc(payload_len);
+    size_t total_read = 0;
+    while (total_read < payload_len) {
+        size_t chunk = 4096;
+        if (chunk > payload_len - total_read) chunk = payload_len - total_read;
+        size_t ret = rioRead((rio *)&dr, result + total_read, chunk);
+        ASSERT_TRUE(ret != 0) << "rioRead should succeed for large payload";
+        total_read += chunk;
+    }
+
+    ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
+
+    decompress_rio_destroy(&dr);
+    sdsfree(comp_sds);
+    zfree(result);
+    zfree(payload);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* --- Test: decompressRioRead handles a large single rioRead request.
+ * Verifies correctness for a single 128KB read through the buffered path. --- */
+TEST(compression, decompressRioDirectPath) {
+    /* Generate a large payload (128KB). */
+    const size_t payload_len = 128 * 1024;
+    uint8_t *payload = (uint8_t *)zmalloc(payload_len);
+    for (size_t i = 0; i < payload_len; i++) {
+        payload[i] = (uint8_t)((i * 7 + 13) % 256);
+    }
+
+    /* Compress */
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    stream_writer_write(t, payload, payload_len);
+    stream_writer_finish(t);
+    stream_writer_destroy(t);
+
+    /* Decompress via decompress_rio with a single large read. */
+    sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
+    rio buffer_rio;
+    rioInitWithBuffer(&buffer_rio, comp_sds);
+
+    decompress_rio_t dr;
+    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+
+    uint8_t *result = (uint8_t *)zmalloc(payload_len);
+    size_t ret = rioRead((rio *)&dr, result, payload_len);
+    ASSERT_TRUE(ret != 0) << "single large rioRead should succeed";
+    ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
+
+    decompress_rio_destroy(&dr);
+    sdsfree(comp_sds);
+    zfree(result);
+    zfree(payload);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* --- Test: stream_reader stops at the end of the compressed frame even if
+ * the underlying source still has trailing bytes. This keeps caller-managed
+ * framing viable on long-lived streams. --- */
+TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
+    const char *payload = "stream-reader-frame-end";
+    const size_t payload_len = strlen(payload);
+    const char *trailer = "TRAILER-BYTES-AFTER-FRAME";
+    const size_t trailer_len = strlen(trailer);
+
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL);
+    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(stream_writer_finish(w) == 0);
+    stream_writer_destroy(w);
+
+    sds input = sdsnewlen(db.data, sdslen((const char *)db.data));
+    input = sdscatlen(input, trailer, trailer_len);
+
+    mem_reader_t mr = {};
+    mr.data = (const uint8_t *)input;
+    mr.len = sdslen(input);
+    mr.max_chunk = 3;
+    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
+    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    ASSERT_TRUE(r != NULL);
+
+    char out[128];
+    memset(out, 0, sizeof(out));
+    ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+
+    /* The reader must stop cleanly at frame end instead of trying to decode
+     * trailing bytes as part of the same compressed frame. */
+    ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == 0);
+
+    stream_reader_destroy(r);
+    sdsfree(input);
+    dynamicBufFree(&db);
+    return;
+}
+
+TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
+    const size_t payload_len = 256;
+    uint8_t payload[payload_len];
+    for (size_t i = 0; i < payload_len; i++) {
+        payload[i] = (uint8_t)(i & 0xFF);
+    }
+
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL);
+    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(stream_writer_finish(w) == 0);
+    stream_writer_destroy(w);
+
+    ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE + 1);
+    mem_reader_t mr = {};
+    mr.data = db.data;
+    mr.len = sdslen((const char *)db.data) - 1;
+    mr.max_chunk = 7;
+    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
+    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    ASSERT_TRUE(r != NULL);
+
+    uint8_t out[payload_len];
+    ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+    ASSERT_TRUE(stream_reader_read(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
+    ASSERT_TRUE(stream_reader_get_error(r) == STREAM_READER_ERROR_CORRUPT)
+        << "truncated compressed frame should latch corruption, not I/O";
+
+    stream_reader_destroy(r);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* --- Test: stream_writer_write after finish is rejected.
+ * Writes after finish must fail and must not emit bytes. --- */
+TEST(compression, streamWriterWriteAfterFinish) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    stream_writer_write(t, "hello", 5);
+    stream_writer_finish(t);
+    size_t len_after_finish = sdslen((const char *)db.data);
+
+    /* Write after finish must fail and emit no output. */
+    ASSERT_TRUE(stream_writer_write(t, "world", 5) < 0);
+    ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "write after finish should not produce output";
+
+    /* Second finish — should also be a no-op */
+    stream_writer_finish(t);
+    ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "second finish should not produce output";
+
+    /* Verify the stream is still valid: one envelope + one frame */
+    ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
+    stream_decompressor_t sd;
+    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+
+    uint8_t decompressed[64];
+    size_t total = 0;
+    uint8_t *cdata = db.data + VKCS_ENVELOPE_SIZE;
+    size_t comp_len = sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE;
+    size_t off = 0;
+    while (off < comp_len) {
+        size_t consumed = 0;
+        ssize_t produced = streamDecompressFeed(
+            &sd, decompressed + total, sizeof(decompressed) - total,
+            cdata + off, comp_len - off, &consumed);
+        ASSERT_TRUE(produced >= 0);
+        total += (size_t)produced;
+        off += consumed;
+        if (consumed == 0 && produced == 0) break;
+    }
+
+    ASSERT_TRUE(total == 5 && memcmp(decompressed, "hello", 5) == 0) << "should decompress to 'hello' only";
+
+    streamDecompressorDestroy(&sd);
+    stream_writer_destroy(t);
+    dynamicBufFree(&db);
+    return;
+}
+
+/* Test that two independent compress/decompress streams can coexist
+ * without interfering with each other. Verifies no shared mutable state. */
+TEST(compression, independentStreamsCoexist) {
+    /* Create two independent compress streams with different data */
+    dynamic_buf_t db1, db2;
+    dynamicBufInit(&db1);
+    dynamicBufInit(&db2);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t1 = stream_writer_create(&cfg, emitToDynamicBuf, &db1);
+    stream_writer_t *t2 = stream_writer_create(&cfg, emitToDynamicBuf, &db2);
+    ASSERT_TRUE(t1 != NULL && t2 != NULL);
+
+    const char *data1 = "Stream one data - unique content for first stream AAAA";
+    const char *data2 = "Stream two data - different content for second stream BBBB";
+
+    /* Interleave writes to both streams */
+    stream_writer_write(t1, data1, strlen(data1));
+    stream_writer_write(t2, data2, strlen(data2));
+    stream_writer_write(t1, data1, strlen(data1)); /* write again to stream 1 */
+    stream_writer_write(t2, data2, strlen(data2)); /* write again to stream 2 */
+
+    stream_writer_finish(t1);
+    stream_writer_finish(t2);
+
+    /* Decompress both and verify independently */
+    for (int i = 0; i < 2; i++) {
+        dynamic_buf_t *db = (i == 0) ? &db1 : &db2;
+        const char *expected = (i == 0) ? data1 : data2;
+        size_t expected_len = strlen(expected) * 2; /* written twice */
+
+        sds comp = sdsnewlen(db->data, sdslen((const char *)db->data));
+        rio buf_rio;
+        rioInitWithBuffer(&buf_rio, comp);
+
+        decompress_rio_t dr;
+        ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
+
+        char result[256];
+        memset(result, 0, sizeof(result));
+        ASSERT_TRUE(rioRead((rio *)&dr, result, expected_len) != 0) << "rioRead should succeed for coexisting stream";
+        ASSERT_TRUE(memcmp(result, expected, strlen(expected)) == 0) << "first half should match";
+        ASSERT_TRUE(memcmp(result + strlen(expected), expected, strlen(expected)) == 0) << "second half should match";
+
+        decompress_rio_destroy(&dr);
+        sdsfree(comp);
+    }
+
+    stream_writer_destroy(t1);
+    stream_writer_destroy(t2);
+    dynamicBufFree(&db1);
+    dynamicBufFree(&db2);
+    return;
+}
+
+TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
+    /* Default block mode is independent.
+     * Verify repetitive data still round-trips correctly. */
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(t != NULL);
+
+    /* Write repetitive data to a single stream */
+    char pattern[4096];
+    memset(pattern, 'X', sizeof(pattern));
+    for (int i = 0; i < 32; i++) {
+        ASSERT_TRUE(stream_writer_write(t, pattern, sizeof(pattern)) >= 0);
+    }
+    ASSERT_TRUE(stream_writer_finish(t) == 0);
+
+    sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
+    rio buf_rio;
+    rioInitWithBuffer(&buf_rio, comp);
+
+    decompress_rio_t dr;
+    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
+
+    size_t total_len = sizeof(pattern) * 32;
+    char *result = (char *)zmalloc(total_len);
+    ASSERT_TRUE(rioRead((rio *)&dr, result, total_len) != 0) << "repetitive payload decompression should succeed";
+
+    /* Verify all bytes match */
+    for (size_t i = 0; i < total_len; i++) {
+        ASSERT_TRUE(result[i] == 'X');
+    }
+
+    decompress_rio_destroy(&dr);
+    sdsfree(comp);
+    zfree(result);
+    stream_writer_destroy(t);
+    dynamicBufFree(&db);
+    return;
+}

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -46,21 +46,21 @@ typedef struct {
     int success_reads;
 } flaky_reader_t;
 
-static stream_reader_config_t makeReaderConfig(uint8_t expected_stream_kind,
-                                               bool allow_passthrough,
-                                               size_t buffer_size) {
-    stream_reader_config_t cfg = {};
+static streamReaderConfig makeReaderConfig(uint8_t expected_stream_kind,
+                                           bool allow_passthrough,
+                                           size_t buffer_size) {
+    streamReaderConfig cfg = {};
     cfg.expected_stream_kind = expected_stream_kind;
     cfg.allow_passthrough = allow_passthrough;
     cfg.buffer_size = buffer_size;
     return cfg;
 }
 
-static stream_writer_config_t makeWriterConfig(compression_algo_t algo,
-                                               int level,
-                                               uint8_t stream_kind,
-                                               bool codec_checksum_enabled = false) {
-    stream_writer_config_t cfg = {};
+static streamWriterConfig makeWriterConfig(compressionAlgo algo,
+                                           int level,
+                                           uint8_t stream_kind,
+                                           bool codec_checksum_enabled = false) {
+    streamWriterConfig cfg = {};
     cfg.algo = algo;
     cfg.level = level;
     cfg.stream_kind = stream_kind;
@@ -118,7 +118,7 @@ static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
 
 /* --- Test: LZ4 compressor init/destroy lifecycle --- */
 TEST(compression, streamCompressorInitDestroy) {
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
     ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
     ASSERT_TRUE(sc.stream_started == false) << "stream_started should be false";
@@ -128,7 +128,7 @@ TEST(compression, streamCompressorInitDestroy) {
     ASSERT_TRUE(sc.algo == ALGO_NONE) << "algo should be NONE after destroy";
 
     /* ALGO_NONE should fail */
-    stream_compressor_t sc3;
+    streamCompressor sc3;
     ASSERT_TRUE(streamCompressorInit(&sc3, ALGO_NONE, 0) == -1) << "NONE init should fail";
 
     /* NULL should fail */
@@ -137,7 +137,7 @@ TEST(compression, streamCompressorInitDestroy) {
 
 /* --- Test: LZ4 decompressor init/destroy lifecycle --- */
 TEST(compression, streamDecompressorInitDestroy) {
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0) << "LZ4 decomp init should succeed";
     ASSERT_TRUE(sd.algo == ALGO_LZ4) << "algo should be LZ4";
     ASSERT_TRUE(sd.ctx != NULL) << "ctx should be non-NULL";
@@ -154,7 +154,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
     size_t input_len = strlen(input);
 
     /* Compress */
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
 
     size_t bound = streamCompressOutputBound(&sc, input_len);
@@ -170,7 +170,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
     streamCompressorDestroy(&sc);
 
     /* Decompress */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -190,7 +190,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
 
 /* --- Test: streamCompressOutputBound returns sane values --- */
 TEST(compression, streamCompressOutputBound) {
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
 
     /* Basic: bound for 1KB input should be > 0 */
@@ -226,7 +226,7 @@ TEST(compression, streamCompressFeedErrors) {
         << "NULL sc should return -1";
 
     /* NULL output buffer */
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
     ASSERT_TRUE(streamCompressFeed(&sc, NULL, sizeof(buf),
                                    (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
@@ -249,7 +249,7 @@ TEST(compression, streamDecompressFeedErrors) {
         << "NULL sd should return -1";
 
     /* NULL input_consumed */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
     ASSERT_TRUE(streamDecompressFeed(&sd, buf, sizeof(buf),
                                      (const uint8_t *)"x", 1, NULL) == -1)
@@ -263,7 +263,7 @@ TEST(compression, streamDecompressFeedErrors) {
     ASSERT_TRUE(sd.errored == true) << "decompressor should enter sticky errored state";
 
     /* Once errored, all subsequent feeds fail immediately. */
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
     size_t bound = streamCompressOutputBound(&sc, strlen(payload));
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
@@ -286,7 +286,7 @@ TEST(compression, streamDecompressFeedErrors) {
 
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
 TEST(compression, streamCompressFeedErrorRecovery) {
-    stream_compressor_t sc;
+    streamCompressor sc;
     ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
 
     /* Pre-frame error: compressBegin fails with tiny buffer, but no frame
@@ -308,7 +308,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     streamCompressorDestroy(&sc);
 
     /* Mid-frame error: start a frame, then force an error — this is permanent. */
-    stream_compressor_t sc2;
+    streamCompressor sc2;
     ASSERT_TRUE(streamCompressorInit(&sc2, ALGO_LZ4, 0) == 0);
 
     /* First call with enough space to start the frame */
@@ -355,7 +355,7 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
         size_t max_chunk;
         bool allow_passthrough;
         bool expect_probe_ok;
-        stream_reader_error_t expected_error;
+        streamReaderError expected_error;
         size_t expected_read_len;
     } cases[] = {
         {"plain passthrough",
@@ -397,31 +397,31 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
         mr.data = cases[i].input;
         mr.len = cases[i].input_len;
         mr.max_chunk = cases[i].max_chunk;
-        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
-        stream_reader_t *t = stream_reader_create(&cfg, memReaderRead, &mr);
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
+        streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
         ASSERT_TRUE(t != NULL) << cases[i].name;
 
-        stream_reader_info_t info;
+        streamReaderInfo info;
         if (cases[i].expect_probe_ok) {
-            ASSERT_TRUE(stream_reader_probe(t) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(t, &info) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(t) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(t, &info) == 0) << cases[i].name;
             ASSERT_TRUE(info.compressed == 0) << cases[i].name;
 
             uint8_t out[16] = {0};
-            ASSERT_TRUE(stream_reader_read(t, out, cases[i].expected_read_len) == (ssize_t)cases[i].expected_read_len)
+            ASSERT_TRUE(streamReaderRead(t, out, cases[i].expected_read_len) == (ssize_t)cases[i].expected_read_len)
                 << cases[i].name;
             ASSERT_TRUE(memcmp(out, cases[i].input, cases[i].expected_read_len) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_read(t, out, sizeof(out)) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == 0) << cases[i].name;
         } else {
-            ASSERT_TRUE(stream_reader_probe(t) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(t, &info) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_error(t) == cases[i].expected_error) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(t) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(t, &info) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetError(t) == cases[i].expected_error) << cases[i].name;
 
             uint8_t out[8] = {0};
-            ASSERT_TRUE(stream_reader_read(t, out, sizeof(out)) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == -1) << cases[i].name;
         }
 
-        stream_reader_destroy(t);
+        streamReaderDestroy(t);
     }
     return;
 }
@@ -432,25 +432,25 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
     mr.data = input;
     mr.len = sizeof(input);
     mr.max_chunk = 2;
-    stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
 
-    stream_reader_t *t = stream_reader_create(&cfg, memReaderRead, &mr);
-    ASSERT_TRUE(t != NULL) << "stream_reader_create should succeed";
+    streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
+    ASSERT_TRUE(t != NULL) << "streamReaderCreate should succeed";
 
     uint8_t out[8] = {0};
     size_t oversized = (size_t)std::numeric_limits<ssize_t>::max() + 1;
-    ASSERT_TRUE(stream_reader_read(t, out, oversized) == -1)
+    ASSERT_TRUE(streamReaderRead(t, out, oversized) == -1)
         << "oversized reads should fail before touching stream state";
 
-    stream_reader_info_t info;
-    ASSERT_TRUE(stream_reader_get_info(t, &info) == 0)
+    streamReaderInfo info;
+    ASSERT_TRUE(streamReaderGetInfo(t, &info) == 0)
         << "oversized read failure should not poison the reader";
     ASSERT_TRUE(info.compressed == 0) << "plain input should still probe as passthrough";
 
-    ASSERT_TRUE(stream_reader_read(t, out, sizeof(input)) == (ssize_t)sizeof(input));
+    ASSERT_TRUE(streamReaderRead(t, out, sizeof(input)) == (ssize_t)sizeof(input));
     ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
 
-    stream_reader_destroy(t);
+    streamReaderDestroy(t);
     return;
 }
 
@@ -482,8 +482,8 @@ static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
     return db->data != NULL ? 0 : -1;
 }
 
-static int initVkcsRdbDecompressRio(decompress_rio_t *dr, rio *inner) {
-    stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+static int initVkcsRdbDecompressRio(decompressRio *dr, rio *inner) {
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
     return rioInitWithDecompress(dr, inner, &cfg, NULL) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
 
@@ -532,43 +532,43 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
         dynamic_buf_t db;
         dynamicBufInit(&db);
 
-        stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
-        stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+        streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
+        streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(w != NULL) << cases[i].name;
-        ASSERT_TRUE(stream_writer_write(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
-        ASSERT_TRUE(stream_writer_finish(w) == 0) << cases[i].name;
-        stream_writer_destroy(w);
+        ASSERT_TRUE(streamWriterWrite(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
+        ASSERT_TRUE(streamWriterFinish(w) == 0) << cases[i].name;
+        streamWriterDestroy(w);
 
         mem_reader_t mr = {};
         mr.data = db.data;
         mr.len = sdslen((const char *)db.data);
         mr.max_chunk = cases[i].max_chunk;
-        stream_reader_config_t rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
-        stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+        streamReaderConfig rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
+        streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
         ASSERT_TRUE(r != NULL) << cases[i].name;
 
-        stream_reader_info_t info;
+        streamReaderInfo info;
         if (cases[i].expect_ok) {
-            ASSERT_TRUE(stream_reader_probe(r) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(r, &info) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(r) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(r, &info) == 0) << cases[i].name;
             ASSERT_TRUE(info.compressed) << cases[i].name;
             ASSERT_TRUE(info.algo == ALGO_LZ4) << cases[i].name;
             ASSERT_TRUE(info.stream_kind == cases[i].expected_kind) << cases[i].name;
 
             uint8_t out[64] = {0};
-            ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len) << cases[i].name;
             ASSERT_TRUE(memcmp(out, cases[i].payload, payload_len) == 0) << cases[i].name;
-            ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == 0) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0) << cases[i].name;
         } else {
-            ASSERT_TRUE(stream_reader_probe(r) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_info(r, &info) == -1) << cases[i].name;
-            ASSERT_TRUE(stream_reader_get_error(r) == STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
+            ASSERT_TRUE(streamReaderProbe(r) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetInfo(r, &info) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderGetError(r) == STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
 
             uint8_t out[32] = {0};
-            ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == -1) << cases[i].name;
+            ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == -1) << cases[i].name;
         }
 
-        stream_reader_destroy(r);
+        streamReaderDestroy(r);
         dynamicBufFree(&db);
     }
     return;
@@ -590,12 +590,12 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
 
     dynamic_buf_t db;
     dynamicBufInit(&db);
-    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL) << "stream_writer_create should succeed";
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL) << "streamWriterCreate should succeed";
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     flaky_reader_t fr = {};
     fr.data = db.data;
@@ -604,18 +604,18 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     /* One probe read plus two 4 KB payload reads is enough to produce some
      * output with an 8 KB window, but not enough to satisfy the full request. */
     fr.fail_after_success_reads = 3;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
-    stream_reader_t *r = stream_reader_create(&rcfg, flakyReaderRead, &fr);
-    ASSERT_TRUE(r != NULL) << "stream_reader_create should succeed";
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
+    streamReader *r = streamReaderCreate(&rcfg, flakyReaderRead, &fr);
+    ASSERT_TRUE(r != NULL) << "streamReaderCreate should succeed";
 
     const size_t out_len = 16 * 1024;
     uint8_t *out = (uint8_t *)zmalloc(out_len);
     ASSERT_TRUE(out != NULL);
-    ssize_t n1 = stream_reader_read(r, out, out_len);
+    ssize_t n1 = streamReaderRead(r, out, out_len);
     ASSERT_TRUE(n1 > 0) << "first read should return partial output";
-    ASSERT_TRUE(stream_reader_read(r, out, out_len) == -1) << "second read should fail immediately";
+    ASSERT_TRUE(streamReaderRead(r, out, out_len) == -1) << "second read should fail immediately";
 
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
 
     /* Passthrough mode should also preserve partial bytes when source read
      * fails after probe/prefix buffering, then latch sticky error state. */
@@ -625,16 +625,16 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     fr_passthrough.len = sizeof(plain) - 1;
     fr_passthrough.max_chunk = 0;
     fr_passthrough.fail_after_success_reads = 1; /* probe succeeds, next read fails */
-    stream_reader_config_t pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-    stream_reader_t *rp = stream_reader_create(&pass_cfg, flakyReaderRead, &fr_passthrough);
+    streamReaderConfig pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReader *rp = streamReaderCreate(&pass_cfg, flakyReaderRead, &fr_passthrough);
     ASSERT_TRUE(rp != NULL) << "passthrough reader create should succeed";
 
     uint8_t pass_out[64];
-    ssize_t p1 = stream_reader_read(rp, pass_out, sizeof(pass_out));
+    ssize_t p1 = streamReaderRead(rp, pass_out, sizeof(pass_out));
     ASSERT_TRUE(p1 > 0) << "passthrough first read should return partial output";
     ASSERT_TRUE(memcmp(pass_out, plain, (size_t)p1) == 0) << "passthrough partial bytes should match input prefix";
-    ASSERT_TRUE(stream_reader_read(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
-    stream_reader_destroy(rp);
+    ASSERT_TRUE(streamReaderRead(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
+    streamReaderDestroy(rp);
     zfree(out);
 
     dynamicBufFree(&db);
@@ -642,39 +642,39 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     return;
 }
 
-/* --- Test: stream_writer_create/destroy --- */
+/* --- Test: streamWriterCreate/destroy --- */
 TEST(compression, streamWriterCreateDestroy) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL) << "create should succeed for LZ4";
-    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored";
+    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored";
 
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
 
     /* NULL config should fail */
-    ASSERT_TRUE(stream_writer_create(NULL, emitToDynamicBuf, &db) == NULL) << "NULL config should return NULL";
+    ASSERT_TRUE(streamWriterCreate(NULL, emitToDynamicBuf, &db) == NULL) << "NULL config should return NULL";
 
     /* NULL emit_cb should fail */
-    ASSERT_TRUE(stream_writer_create(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
 
     /* ALGO_NONE should fail */
-    stream_writer_config_t bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
+    streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
     bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(stream_writer_create(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
 
     /* Concrete stream kinds outside the currently named ones are valid. */
-    stream_writer_config_t future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
-    stream_writer_t *future_t = stream_writer_create(&future_kind_cfg, emitToDynamicBuf, &db);
+    streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
+    streamWriter *future_t = streamWriterCreate(&future_kind_cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(future_t != NULL) << "custom stream_kind should succeed with envelope";
-    stream_writer_destroy(future_t);
+    streamWriterDestroy(future_t);
 
     /* destroy NULL should be safe */
-    stream_writer_destroy(NULL);
+    streamWriterDestroy(NULL);
 
     return;
 }
@@ -684,20 +684,20 @@ TEST(compression, streamWriterRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     /* Write some data */
     const char *test_data = "Hello, compression world! This is a test of the stream writer API.";
     size_t data_len = strlen(test_data);
-    ASSERT_TRUE(stream_writer_write(t, test_data, data_len) >= 0);
-    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored after write";
+    ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
+    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored after write";
     ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "write should emit envelope";
 
     /* Finalize */
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
-    ASSERT_TRUE(stream_writer_is_errored(t) == 0) << "should not be errored after finish";
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored after finish";
 
     /* Verify output starts with VKCS envelope */
     ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "output should have at least envelope size";
@@ -711,7 +711,7 @@ TEST(compression, streamWriterRoundTrip) {
     ASSERT_TRUE(db.data[7] == STREAM_KIND_RDB) << "stream_kind RDB";
 
     /* Decompress and verify round-trip */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -737,7 +737,7 @@ TEST(compression, streamWriterRoundTrip) {
     ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match original";
 
     streamDecompressorDestroy(&sd);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -754,34 +754,34 @@ TEST(compression, streamWriterLargeSingleWrite) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
-    ASSERT_TRUE(stream_writer_write(t, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
-    stream_writer_destroy(t);
+    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    streamWriterDestroy(t);
 
     mem_reader_t mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 0;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
     size_t total = 0;
     while (total < payload_len) {
-        ssize_t nread = stream_reader_read(r, out + total, payload_len - total);
-        ASSERT_TRUE(nread > 0) << "stream_reader_read should keep making progress";
+        ssize_t nread = streamReaderRead(r, out + total, payload_len - total);
+        ASSERT_TRUE(nread > 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(stream_reader_read(r, out, 1) == 0) << "reader should stop at frame end";
+    ASSERT_TRUE(streamReaderRead(r, out, 1) == 0) << "reader should stop at frame end";
 
     zfree(out);
     zfree(payload);
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     dynamicBufFree(&db);
     return;
 }
@@ -799,19 +799,19 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&wcfg, emitToDynamicBuf, &db);
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     mem_reader_t mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 4096;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
@@ -820,40 +820,40 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     while (total < payload_len) {
         size_t step = payload_len - total;
         if (step > 17) step = 17;
-        ssize_t nread = stream_reader_read(r, out + total, step);
-        ASSERT_TRUE(nread > 0) << "stream_reader_read should keep making progress";
+        ssize_t nread = streamReaderRead(r, out + total, step);
+        ASSERT_TRUE(nread > 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
 
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(stream_reader_read(r, out, 1) == 0) << "reader should stop at frame end";
+    ASSERT_TRUE(streamReaderRead(r, out, 1) == 0) << "reader should stop at frame end";
 
     zfree(out);
     zfree(payload);
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     dynamicBufFree(&db);
     return;
 }
 
-/* --- Test: stream_writer_flush semantics (no-op before writes, valid mid-stream) --- */
+/* --- Test: streamWriterFlush semantics (no-op before writes, valid mid-stream) --- */
 TEST(compression, streamWriterFlushBehavior) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush before write should be no-op success";
+    ASSERT_TRUE(streamWriterFlush(t) == 0) << "flush before write should be no-op success";
     ASSERT_TRUE(sdslen((const char *)db.data) == 0) << "flush before write should not emit bytes";
 
-    ASSERT_TRUE(stream_writer_write(t, "first chunk", 11) >= 0);
-    ASSERT_TRUE(stream_writer_flush(t) == 0);
-    ASSERT_TRUE(stream_writer_write(t, "second chunk", 12) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(streamWriterWrite(t, "first chunk", 11) >= 0);
+    ASSERT_TRUE(streamWriterFlush(t) == 0);
+    ASSERT_TRUE(streamWriterWrite(t, "second chunk", 12) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -879,7 +879,7 @@ TEST(compression, streamWriterFlushBehavior) {
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0);
 
     streamDecompressorDestroy(&sd);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -888,18 +888,18 @@ TEST(compression, streamWriterFlushAfterFinishIsNoop) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    ASSERT_TRUE(stream_writer_write(t, "payload", 7) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(streamWriterWrite(t, "payload", 7) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
-    ASSERT_TRUE(stream_writer_flush(t) == 0) << "flush after finish should be a no-op success";
+    ASSERT_TRUE(streamWriterFlush(t) == 0) << "flush after finish should be a no-op success";
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "flush after finish should not emit bytes";
 
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -911,32 +911,32 @@ TEST(compression, streamWriterCodecChecksumToggle) {
         dynamic_buf_t db;
         dynamicBufInit(&db);
 
-        stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
-                                                      codec_checksum);
-        stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+        streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
+                                                  codec_checksum);
+        streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(t != NULL);
-        ASSERT_TRUE(stream_writer_write(t, payload, strlen(payload)) >= 0);
-        ASSERT_TRUE(stream_writer_finish(t) == 0);
+        ASSERT_TRUE(streamWriterWrite(t, payload, strlen(payload)) >= 0);
+        ASSERT_TRUE(streamWriterFinish(t) == 0);
 
         ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
         ASSERT_TRUE(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
                                              sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE) == codec_checksum)
             << "LZ4 frame should reflect configured codec checksum setting";
 
-        stream_writer_destroy(t);
+        streamWriterDestroy(t);
         dynamicBufFree(&db);
     }
 }
 
-/* --- Test: compress_rio_t write + finish round-trip --- */
+/* --- Test: compressRio write + finish round-trip --- */
 TEST(compression, compressRioRoundTrip) {
     /* Use a buffer rio as the inner rio */
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
                             "Pack my box with five dozen liquor jugs.";
@@ -944,7 +944,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(rioWrite((rio *)&cr, test_data, data_len) != 0) << "rioWrite should succeed";
 
     /* Finalize and destroy */
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
 
     /* Get the compressed output from the buffer rio */
     sds compressed = buffer_rio.io.buffer.ptr;
@@ -958,7 +958,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(compressed[3] == (char)VKCS_MAGIC_3) << "magic S";
 
     /* Decompress and verify */
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[512];
@@ -984,7 +984,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match";
 
     streamDecompressorDestroy(&sd);
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(compressed);
     return;
 }
@@ -994,8 +994,8 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     const char *payload = "checksum-payload-for-compressed-rio";
@@ -1006,8 +1006,8 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     rioGenericUpdateChecksum(&expected, payload, payload_len);
     ASSERT_TRUE(cr.base.cksum == expected.cksum) << "compress_rio should track the checksum of uncompressed bytes";
 
-    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
-    compress_rio_destroy(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1018,8 +1018,8 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     rioInitWithBuffer(&buffer_rio, buf);
     buffer_rio.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0);
 
@@ -1027,8 +1027,8 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
     ASSERT_TRUE(cr.base.cksum == 0) << "skip-checksum should disable uncompressed RDB checksum tracking";
 
-    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
-    compress_rio_destroy(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1038,8 +1038,8 @@ TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) 
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) != 0);
 
@@ -1048,8 +1048,8 @@ TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) 
     ASSERT_TRUE(cr.base.cksum == 0)
         << "codec checksums should disable standard RDB checksum tracking for compressed RDB";
 
-    ASSERT_TRUE(compress_rio_finish(&cr) == 0);
-    compress_rio_destroy(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1059,42 +1059,42 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &wcfg) == 0);
     /* Decorators preserve the inner backend type via the type field.
      * Verify the decorator reports the same type as the wrapped rio. */
     ASSERT_TRUE(rioCheckType((rio *)&cr) == RIO_TYPE_BUFFER);
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 
     sds raw = sdsnew("plain-rdb-prefix");
     rio raw_rio;
     rioInitWithBuffer(&raw_rio, raw);
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-    decompress_rio_t dr;
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    decompressRio dr;
     ASSERT_TRUE(rioInitWithDecompress(&dr, &raw_rio, &rcfg, NULL) == DECOMPRESS_RIO_INIT_OK);
     ASSERT_TRUE(rioCheckType((rio *)&dr) == RIO_TYPE_BUFFER);
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
 }
 
-/* --- Test: decompress_rio_t read round-trip --- */
+/* --- Test: decompressRio read round-trip --- */
 TEST(compression, decompressRioRoundTrip) {
     /* First, produce compressed data using stream writer */
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     const char *test_data = "Decompression rio test data. "
                             "This should round-trip through compress then decompress.";
     size_t data_len = strlen(test_data);
-    stream_writer_write(t, test_data, data_len);
-    stream_writer_finish(t);
-    stream_writer_destroy(t);
+    streamWriterWrite(t, test_data, data_len);
+    streamWriterFinish(t);
+    streamWriterDestroy(t);
 
     /* Create a buffer rio with the full VKCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1102,7 +1102,7 @@ TEST(compression, decompressRioRoundTrip) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     /* Create decompress rio */
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     /* Read decompressed data */
@@ -1111,7 +1111,7 @@ TEST(compression, decompressRioRoundTrip) {
     ASSERT_TRUE(rioRead((rio *)&dr, result, data_len) != 0) << "rioRead should succeed";
     ASSERT_TRUE(memcmp(result, test_data, data_len) == 0) << "decompressed data should match original";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
     return;
@@ -1122,18 +1122,18 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     dynamicBufInit(&db);
 
     std::string payload(4096, 'A');
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
-    ASSERT_TRUE(stream_writer_write(t, payload.data(), payload.size()) >= 0);
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
-    stream_writer_destroy(t);
+    ASSERT_TRUE(streamWriterWrite(t, payload.data(), payload.size()) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    streamWriterDestroy(t);
 
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     char out[2048];
@@ -1142,7 +1142,7 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     ASSERT_TRUE((size_t)rioTell((rio *)&dr) < sizeof(out))
         << "decompress rio tell should track source bytes, not logical output bytes";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
 }
@@ -1155,9 +1155,9 @@ TEST(compression, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-        decompress_rio_t dr;
-        stream_reader_info_t info;
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        decompressRio dr;
+        streamReaderInfo info;
         ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info) == DECOMPRESS_RIO_INIT_OK);
         ASSERT_TRUE(info.compressed == 0) << "passthrough stream should not be compressed";
 
@@ -1166,7 +1166,7 @@ TEST(compression, decompressRioClassifiesInput) {
         ASSERT_TRUE(rioRead((rio *)&dr, result, payload_len) != 0) << "rioRead should succeed";
         ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "payload should be replayed exactly";
 
-        decompress_rio_destroy(&dr);
+        decompressRioDestroy(&dr);
         sdsfree(buf);
     }
 
@@ -1178,8 +1178,8 @@ TEST(compression, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        stream_reader_config_t cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
-        decompress_rio_t dr;
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        decompressRio dr;
         ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, NULL) ==
                     DECOMPRESS_RIO_INIT_INCOMPATIBLE);
 
@@ -1188,26 +1188,26 @@ TEST(compression, decompressRioClassifiesInput) {
     return;
 }
 
-/* --- Test: compress_rio_finish is idempotent --- */
+/* --- Test: compressRioFinish is idempotent --- */
 TEST(compression, compressRioFinishIdempotent) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     rioWrite((rio *)&cr, "test", 4);
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
     size_t len_after_first = sdslen(buffer_rio.io.buffer.ptr);
 
     /* Second finish should be a no-op */
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
     size_t len_after_second = sdslen(buffer_rio.io.buffer.ptr);
     ASSERT_TRUE(len_after_first == len_after_second) << "second finish should not produce more output";
 
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
     return;
 }
@@ -1218,8 +1218,8 @@ TEST(compression, compressRioFlushMidStream) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
     /* Write some data */
@@ -1232,14 +1232,14 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(rioWrite((rio *)&cr, "second chunk", 12) != 0) << "write after flush should succeed";
 
     /* Now finalize */
-    compress_rio_finish(&cr);
+    compressRioFinish(&cr);
 
     /* Verify the entire stream decompresses correctly */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
     ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE);
 
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
@@ -1265,21 +1265,21 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0) << "decompressed should match concatenated input";
 
     streamDecompressorDestroy(&sd);
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(compressed);
     return;
 }
 
 /* --- Test: rdbLoadProgressCallback does not cast write-side streaming rios
- * to decompress_rio_t. This protects save/async paths that also use
+ * to decompressRio. This protects save/async paths that also use
  * RIO_FLAG_STREAMING_COMPRESSION. --- */
 TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
     sds buf = sdsempty();
     rio inner;
     rioInitWithBuffer(&inner, buf);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    compress_rio_t cr;
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &inner, &cfg) == 0);
 
     const char sample[] = "progress-guard";
@@ -1287,7 +1287,7 @@ TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
 
     ASSERT_TRUE((cr.base.flags & RIO_FLAG_READ_ERROR) == 0) << "write-side streaming rio must not set read error";
 
-    compress_rio_destroy(&cr);
+    compressRioDestroy(&cr);
     sdsfree(inner.io.buffer.ptr);
     return;
 }
@@ -1310,20 +1310,20 @@ TEST(compression, decompressRioLargePayload) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    stream_writer_write(t, payload, payload_len);
-    stream_writer_finish(t);
-    stream_writer_destroy(t);
+    streamWriterWrite(t, payload, payload_len);
+    streamWriterFinish(t);
+    streamWriterDestroy(t);
 
     /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     /* Read in small chunks (4KB) to force multiple iterations through
@@ -1340,7 +1340,7 @@ TEST(compression, decompressRioLargePayload) {
 
     ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     zfree(result);
     zfree(payload);
@@ -1362,20 +1362,20 @@ TEST(compression, decompressRioDirectPath) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    stream_writer_write(t, payload, payload_len);
-    stream_writer_finish(t);
-    stream_writer_destroy(t);
+    streamWriterWrite(t, payload, payload_len);
+    streamWriterFinish(t);
+    streamWriterDestroy(t);
 
     /* Decompress via decompress_rio with a single large read. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
 
     uint8_t *result = (uint8_t *)zmalloc(payload_len);
@@ -1383,7 +1383,7 @@ TEST(compression, decompressRioDirectPath) {
     ASSERT_TRUE(ret != 0) << "single large rioRead should succeed";
     ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     zfree(result);
     zfree(payload);
@@ -1403,12 +1403,12 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     sds input = sdsnewlen(db.data, sdslen((const char *)db.data));
     input = sdscatlen(input, trailer, trailer_len);
@@ -1417,20 +1417,20 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     mr.data = (const uint8_t *)input;
     mr.len = sdslen(input);
     mr.max_chunk = 3;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     char out[128];
     memset(out, 0, sizeof(out));
-    ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len);
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
 
     /* The reader must stop cleanly at frame end instead of trying to decode
      * trailing bytes as part of the same compressed frame. */
-    ASSERT_TRUE(stream_reader_read(r, out, sizeof(out)) == 0);
+    ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0);
 
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     sdsfree(input);
     dynamicBufFree(&db);
     return;
@@ -1446,59 +1446,59 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *w = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
-    ASSERT_TRUE(stream_writer_write(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(stream_writer_finish(w) == 0);
-    stream_writer_destroy(w);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    streamWriterDestroy(w);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE + 1);
     mem_reader_t mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data) - 1;
     mr.max_chunk = 7;
-    stream_reader_config_t rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
-    stream_reader_t *r = stream_reader_create(&rcfg, memReaderRead, &mr);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
+    streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
     ASSERT_TRUE(r != NULL);
 
     uint8_t out[payload_len];
-    ASSERT_TRUE(stream_reader_read(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len);
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(stream_reader_read(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
-    ASSERT_TRUE(stream_reader_get_error(r) == STREAM_READER_ERROR_CORRUPT)
+    ASSERT_TRUE(streamReaderRead(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
+    ASSERT_TRUE(streamReaderGetError(r) == STREAM_READER_ERROR_CORRUPT)
         << "truncated compressed frame should latch corruption, not I/O";
 
-    stream_reader_destroy(r);
+    streamReaderDestroy(r);
     dynamicBufFree(&db);
     return;
 }
 
-/* --- Test: stream_writer_write after finish is rejected.
+/* --- Test: streamWriterWrite after finish is rejected.
  * Writes after finish must fail and must not emit bytes. --- */
 TEST(compression, streamWriterWriteAfterFinish) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    stream_writer_write(t, "hello", 5);
-    stream_writer_finish(t);
+    streamWriterWrite(t, "hello", 5);
+    streamWriterFinish(t);
     size_t len_after_finish = sdslen((const char *)db.data);
 
     /* Write after finish must fail and emit no output. */
-    ASSERT_TRUE(stream_writer_write(t, "world", 5) < 0);
+    ASSERT_TRUE(streamWriterWrite(t, "world", 5) < 0);
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "write after finish should not produce output";
 
     /* Second finish — should also be a no-op */
-    stream_writer_finish(t);
+    streamWriterFinish(t);
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "second finish should not produce output";
 
     /* Verify the stream is still valid: one envelope + one frame */
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
-    stream_decompressor_t sd;
+    streamDecompressor sd;
     ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
 
     uint8_t decompressed[64];
@@ -1520,7 +1520,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
     ASSERT_TRUE(total == 5 && memcmp(decompressed, "hello", 5) == 0) << "should decompress to 'hello' only";
 
     streamDecompressorDestroy(&sd);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }
@@ -1533,22 +1533,22 @@ TEST(compression, independentStreamsCoexist) {
     dynamicBufInit(&db1);
     dynamicBufInit(&db2);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t1 = stream_writer_create(&cfg, emitToDynamicBuf, &db1);
-    stream_writer_t *t2 = stream_writer_create(&cfg, emitToDynamicBuf, &db2);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t1 = streamWriterCreate(&cfg, emitToDynamicBuf, &db1);
+    streamWriter *t2 = streamWriterCreate(&cfg, emitToDynamicBuf, &db2);
     ASSERT_TRUE(t1 != NULL && t2 != NULL);
 
     const char *data1 = "Stream one data - unique content for first stream AAAA";
     const char *data2 = "Stream two data - different content for second stream BBBB";
 
     /* Interleave writes to both streams */
-    stream_writer_write(t1, data1, strlen(data1));
-    stream_writer_write(t2, data2, strlen(data2));
-    stream_writer_write(t1, data1, strlen(data1)); /* write again to stream 1 */
-    stream_writer_write(t2, data2, strlen(data2)); /* write again to stream 2 */
+    streamWriterWrite(t1, data1, strlen(data1));
+    streamWriterWrite(t2, data2, strlen(data2));
+    streamWriterWrite(t1, data1, strlen(data1)); /* write again to stream 1 */
+    streamWriterWrite(t2, data2, strlen(data2)); /* write again to stream 2 */
 
-    stream_writer_finish(t1);
-    stream_writer_finish(t2);
+    streamWriterFinish(t1);
+    streamWriterFinish(t2);
 
     /* Decompress both and verify independently */
     for (int i = 0; i < 2; i++) {
@@ -1560,7 +1560,7 @@ TEST(compression, independentStreamsCoexist) {
         rio buf_rio;
         rioInitWithBuffer(&buf_rio, comp);
 
-        decompress_rio_t dr;
+        decompressRio dr;
         ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
 
         char result[256];
@@ -1569,12 +1569,12 @@ TEST(compression, independentStreamsCoexist) {
         ASSERT_TRUE(memcmp(result, expected, strlen(expected)) == 0) << "first half should match";
         ASSERT_TRUE(memcmp(result + strlen(expected), expected, strlen(expected)) == 0) << "second half should match";
 
-        decompress_rio_destroy(&dr);
+        decompressRioDestroy(&dr);
         sdsfree(comp);
     }
 
-    stream_writer_destroy(t1);
-    stream_writer_destroy(t2);
+    streamWriterDestroy(t1);
+    streamWriterDestroy(t2);
     dynamicBufFree(&db1);
     dynamicBufFree(&db2);
     return;
@@ -1586,23 +1586,23 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    stream_writer_config_t cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
-    stream_writer_t *t = stream_writer_create(&cfg, emitToDynamicBuf, &db);
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
     /* Write repetitive data to a single stream */
     char pattern[4096];
     memset(pattern, 'X', sizeof(pattern));
     for (int i = 0; i < 32; i++) {
-        ASSERT_TRUE(stream_writer_write(t, pattern, sizeof(pattern)) >= 0);
+        ASSERT_TRUE(streamWriterWrite(t, pattern, sizeof(pattern)) >= 0);
     }
-    ASSERT_TRUE(stream_writer_finish(t) == 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
 
     sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buf_rio;
     rioInitWithBuffer(&buf_rio, comp);
 
-    decompress_rio_t dr;
+    decompressRio dr;
     ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
 
     size_t total_len = sizeof(pattern) * 32;
@@ -1614,10 +1614,10 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
         ASSERT_TRUE(result[i] == 'X');
     }
 
-    decompress_rio_destroy(&dr);
+    decompressRioDestroy(&dr);
     sdsfree(comp);
     zfree(result);
-    stream_writer_destroy(t);
+    streamWriterDestroy(t);
     dynamicBufFree(&db);
     return;
 }

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -119,31 +119,31 @@ static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
 /* --- Test: LZ4 compressor init/destroy lifecycle --- */
 TEST(compression, streamCompressorInitDestroy) {
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
-    ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
+    ASSERT_TRUE(streamCompressorInit(&sc, COMPRESSION_ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
+    ASSERT_TRUE(sc.algo == COMPRESSION_ALGO_LZ4) << "algo should be LZ4";
     ASSERT_TRUE(sc.stream_started == false) << "stream_started should be false";
     ASSERT_TRUE(sc.ctx != NULL) << "ctx should be non-NULL";
     streamCompressorDestroy(&sc);
     ASSERT_TRUE(sc.ctx == NULL) << "ctx should be NULL after destroy";
-    ASSERT_TRUE(sc.algo == ALGO_NONE) << "algo should be NONE after destroy";
+    ASSERT_TRUE(sc.algo == COMPRESSION_ALGO_NONE) << "algo should be NONE after destroy";
 
-    /* ALGO_NONE should fail */
+    /* COMPRESSION_ALGO_NONE should fail */
     streamCompressor sc3;
-    ASSERT_TRUE(streamCompressorInit(&sc3, ALGO_NONE, 0) == -1) << "NONE init should fail";
+    ASSERT_TRUE(streamCompressorInit(&sc3, COMPRESSION_ALGO_NONE, 0) == -1) << "NONE init should fail";
 
     /* NULL should fail */
-    ASSERT_TRUE(streamCompressorInit(NULL, ALGO_LZ4, 0) == -1) << "NULL init should fail";
+    ASSERT_TRUE(streamCompressorInit(NULL, COMPRESSION_ALGO_LZ4, 0) == -1) << "NULL init should fail";
 }
 
 /* --- Test: LZ4 decompressor init/destroy lifecycle --- */
 TEST(compression, streamDecompressorInitDestroy) {
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0) << "LZ4 decomp init should succeed";
-    ASSERT_TRUE(sd.algo == ALGO_LZ4) << "algo should be LZ4";
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0) << "LZ4 decomp init should succeed";
+    ASSERT_TRUE(sd.algo == COMPRESSION_ALGO_LZ4) << "algo should be LZ4";
     ASSERT_TRUE(sd.ctx != NULL) << "ctx should be non-NULL";
     streamDecompressorDestroy(&sd);
     ASSERT_TRUE(sd.ctx == NULL) << "ctx should be NULL after destroy";
-    ASSERT_TRUE(sd.algo == ALGO_NONE) << "algo should be NONE after destroy";
+    ASSERT_TRUE(sd.algo == COMPRESSION_ALGO_NONE) << "algo should be NONE after destroy";
 
     return;
 }
@@ -155,7 +155,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
 
     /* Compress */
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressorInit(&sc, COMPRESSION_ALGO_LZ4, 0) == 0);
 
     size_t bound = streamCompressOutputBound(&sc, input_len);
     ASSERT_TRUE(bound > 0) << "bound should be > 0";
@@ -164,14 +164,14 @@ TEST(compression, streamCompressDecompressRoundTrip) {
     ASSERT_TRUE(compressed != NULL);
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)input, input_len,
-                                                FLUSH_END);
+                                                COMPRESS_FLUSH_END);
     ASSERT_TRUE(compressed_len > 0) << "compress should succeed";
-    ASSERT_TRUE(sc.stream_started == false) << "frame should be closed after FLUSH_END";
+    ASSERT_TRUE(sc.stream_started == false) << "frame should be closed after COMPRESS_FLUSH_END";
     streamCompressorDestroy(&sc);
 
     /* Decompress */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
     size_t input_consumed = 0;
@@ -191,7 +191,7 @@ TEST(compression, streamCompressDecompressRoundTrip) {
 /* --- Test: streamCompressOutputBound returns sane values --- */
 TEST(compression, streamCompressOutputBound) {
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressorInit(&sc, COMPRESSION_ALGO_LZ4, 0) == 0);
 
     /* Basic: bound for 1KB input should be > 0 */
     size_t b1 = streamCompressOutputBound(&sc, 1024);
@@ -203,7 +203,7 @@ TEST(compression, streamCompressOutputBound) {
     uint8_t *seed_buf = (uint8_t *)zmalloc(b_before);
     ASSERT_TRUE(seed_buf != NULL);
     ASSERT_TRUE(streamCompressFeed(&sc, seed_buf, b_before,
-                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) >= 0)
+                                   (const uint8_t *)"x", 1, COMPRESS_FLUSH_CONTINUE) >= 0)
         << "seed write should start the frame";
     size_t b_after = streamCompressOutputBound(&sc, 1024);
     ASSERT_TRUE(b_before == b_after) << "bound should be the same before and after frame start";
@@ -222,14 +222,14 @@ TEST(compression, streamCompressFeedErrors) {
     uint8_t buf[64];
     /* NULL compressor */
     ASSERT_TRUE(streamCompressFeed(NULL, buf, sizeof(buf),
-                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
+                                   (const uint8_t *)"x", 1, COMPRESS_FLUSH_CONTINUE) == -1)
         << "NULL sc should return -1";
 
     /* NULL output buffer */
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressorInit(&sc, COMPRESSION_ALGO_LZ4, 0) == 0);
     ASSERT_TRUE(streamCompressFeed(&sc, NULL, sizeof(buf),
-                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
+                                   (const uint8_t *)"x", 1, COMPRESS_FLUSH_CONTINUE) == -1)
         << "NULL output should return -1";
     streamCompressorDestroy(&sc);
 
@@ -250,7 +250,7 @@ TEST(compression, streamDecompressFeedErrors) {
 
     /* NULL input_consumed */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
     ASSERT_TRUE(streamDecompressFeed(&sd, buf, sizeof(buf),
                                      (const uint8_t *)"x", 1, NULL) == -1)
         << "NULL input_consumed should return -1";
@@ -264,13 +264,13 @@ TEST(compression, streamDecompressFeedErrors) {
 
     /* Once errored, all subsequent feeds fail immediately. */
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressorInit(&sc, COMPRESSION_ALGO_LZ4, 0) == 0);
     size_t bound = streamCompressOutputBound(&sc, strlen(payload));
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
     ASSERT_TRUE(compressed != NULL);
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)payload, strlen(payload),
-                                                FLUSH_END);
+                                                COMPRESS_FLUSH_END);
     ASSERT_TRUE(compressed_len > 0);
     streamCompressorDestroy(&sc);
 
@@ -287,13 +287,13 @@ TEST(compression, streamDecompressFeedErrors) {
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
 TEST(compression, streamCompressFeedErrorRecovery) {
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressorInit(&sc, COMPRESSION_ALGO_LZ4, 0) == 0);
 
     /* Pre-frame error: compressBegin fails with tiny buffer, but no frame
      * bytes have been emitted yet — this is recoverable. */
     uint8_t tiny[1];
     ssize_t ret = streamCompressFeed(&sc, tiny, 1,
-                                     (const uint8_t *)"test data", 9, FLUSH_END);
+                                     (const uint8_t *)"test data", 9, COMPRESS_FLUSH_END);
     ASSERT_TRUE(ret == -1) << "should fail with tiny buffer";
     ASSERT_TRUE(sc.errored == false) << "errored should NOT be set (pre-frame failure)";
     ASSERT_TRUE(sc.stream_started == false) << "stream_started should still be false";
@@ -302,20 +302,20 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     size_t bound = streamCompressOutputBound(&sc, 9);
     uint8_t *buf = (uint8_t *)zmalloc(bound);
     ssize_t ret2 = streamCompressFeed(&sc, buf, bound,
-                                      (const uint8_t *)"test data", 9, FLUSH_END);
+                                      (const uint8_t *)"test data", 9, COMPRESS_FLUSH_END);
     ASSERT_TRUE(ret2 > 0) << "retry after pre-frame error should succeed";
     zfree(buf);
     streamCompressorDestroy(&sc);
 
     /* Mid-frame error: start a frame, then force an error — this is permanent. */
     streamCompressor sc2;
-    ASSERT_TRUE(streamCompressorInit(&sc2, ALGO_LZ4, 0) == 0);
+    ASSERT_TRUE(streamCompressorInit(&sc2, COMPRESSION_ALGO_LZ4, 0) == 0);
 
     /* First call with enough space to start the frame */
     size_t bound2 = streamCompressOutputBound(&sc2, 5);
     uint8_t *buf2 = (uint8_t *)zmalloc(bound2);
     ssize_t ret3 = streamCompressFeed(&sc2, buf2, bound2,
-                                      (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
+                                      (const uint8_t *)"hello", 5, COMPRESS_FLUSH_CONTINUE);
     ASSERT_TRUE(ret3 >= 0) << "first write should succeed";
     ASSERT_TRUE(sc2.stream_started == true) << "stream should be started";
 
@@ -323,7 +323,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     uint8_t tiny2[1];
     ssize_t ret4 = streamCompressFeed(&sc2, tiny2, 1,
                                       (const uint8_t *)"more data to compress", 21,
-                                      FLUSH_END);
+                                      COMPRESS_FLUSH_END);
     ASSERT_TRUE(ret4 == -1) << "mid-frame error should fail";
     ASSERT_TRUE(sc2.errored == true) << "errored should be set (mid-frame failure)";
 
@@ -331,7 +331,7 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     size_t bound3 = streamCompressOutputBound(&sc2, 5);
     uint8_t *buf3 = (uint8_t *)zmalloc(bound3);
     ssize_t ret5 = streamCompressFeed(&sc2, buf3, bound3,
-                                      (const uint8_t *)"hello", 5, FLUSH_END);
+                                      (const uint8_t *)"hello", 5, COMPRESS_FLUSH_END);
     ASSERT_TRUE(ret5 == -1) << "must fail on errored compressor";
     zfree(buf3);
     zfree(buf2);
@@ -532,7 +532,7 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
         dynamic_buf_t db;
         dynamicBufInit(&db);
 
-        streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
+        streamWriterConfig wcfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, cases[i].writer_kind);
         streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(w != NULL) << cases[i].name;
         ASSERT_TRUE(streamWriterWrite(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
@@ -552,7 +552,7 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
             ASSERT_TRUE(streamReaderProbe(r) == 0) << cases[i].name;
             ASSERT_TRUE(streamReaderGetInfo(r, &info) == 0) << cases[i].name;
             ASSERT_TRUE(info.compressed) << cases[i].name;
-            ASSERT_TRUE(info.algo == ALGO_LZ4) << cases[i].name;
+            ASSERT_TRUE(info.algo == COMPRESSION_ALGO_LZ4) << cases[i].name;
             ASSERT_TRUE(info.stream_kind == cases[i].expected_kind) << cases[i].name;
 
             uint8_t out[64] = {0};
@@ -590,7 +590,7 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
 
     dynamic_buf_t db;
     dynamicBufInit(&db);
-    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig wcfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL) << "streamWriterCreate should succeed";
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
@@ -647,7 +647,7 @@ TEST(compression, streamWriterCreateDestroy) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL) << "create should succeed for LZ4";
     ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored";
@@ -661,14 +661,14 @@ TEST(compression, streamWriterCreateDestroy) {
     /* NULL emit_cb should fail */
     ASSERT_TRUE(streamWriterCreate(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
 
-    /* ALGO_NONE should fail */
-    streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
-    bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
+    /* COMPRESSION_ALGO_NONE should fail */
+    streamWriterConfig bad_cfg = makeWriterConfig(COMPRESSION_ALGO_NONE, 0, STREAM_KIND_RDB);
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "COMPRESSION_ALGO_NONE should return NULL";
+    bad_cfg = makeWriterConfig(COMPRESSION_ALGO_LZF, 0, STREAM_KIND_RDB);
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "COMPRESSION_ALGO_LZF should return NULL";
 
     /* Concrete stream kinds outside the currently named ones are valid. */
-    streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
+    streamWriterConfig future_kind_cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, 0x7f);
     streamWriter *future_t = streamWriterCreate(&future_kind_cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(future_t != NULL) << "custom stream_kind should succeed with envelope";
     streamWriterDestroy(future_t);
@@ -684,7 +684,7 @@ TEST(compression, streamWriterRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -712,7 +712,7 @@ TEST(compression, streamWriterRoundTrip) {
 
     /* Decompress and verify round-trip */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
@@ -754,7 +754,7 @@ TEST(compression, streamWriterLargeSingleWrite) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
     ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
@@ -799,7 +799,7 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
+    streamWriterConfig wcfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, -5, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
@@ -840,7 +840,7 @@ TEST(compression, streamWriterFlushBehavior) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -854,7 +854,7 @@ TEST(compression, streamWriterFlushBehavior) {
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
@@ -888,7 +888,7 @@ TEST(compression, streamWriterFlushAfterFinishIsNoop) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -911,7 +911,7 @@ TEST(compression, streamWriterCodecChecksumToggle) {
         dynamic_buf_t db;
         dynamicBufInit(&db);
 
-        streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
+        streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB,
                                                   codec_checksum);
         streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
         ASSERT_TRUE(t != NULL);
@@ -935,7 +935,7 @@ TEST(compression, compressRioRoundTrip) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
@@ -959,7 +959,7 @@ TEST(compression, compressRioRoundTrip) {
 
     /* Decompress and verify */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
 
     uint8_t decompressed[512];
     size_t total_decompressed = 0;
@@ -994,7 +994,7 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
@@ -1018,7 +1018,7 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     rioInitWithBuffer(&buffer_rio, buf);
     buffer_rio.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0);
@@ -1038,7 +1038,7 @@ TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) 
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) != 0);
@@ -1059,7 +1059,7 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig wcfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &wcfg) == 0);
     /* Decorators preserve the inner backend type via the type field.
@@ -1085,7 +1085,7 @@ TEST(compression, decompressRioRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -1122,7 +1122,7 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     dynamicBufInit(&db);
 
     std::string payload(4096, 'A');
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
     ASSERT_TRUE(streamWriterWrite(t, payload.data(), payload.size()) >= 0);
@@ -1194,7 +1194,7 @@ TEST(compression, compressRioFinishIdempotent) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
@@ -1218,7 +1218,7 @@ TEST(compression, compressRioFlushMidStream) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
@@ -1240,7 +1240,7 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE);
 
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
@@ -1278,7 +1278,7 @@ TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
     rio inner;
     rioInitWithBuffer(&inner, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &inner, &cfg) == 0);
 
@@ -1310,7 +1310,7 @@ TEST(compression, decompressRioLargePayload) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -1362,7 +1362,7 @@ TEST(compression, decompressRioDirectPath) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -1403,7 +1403,7 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
@@ -1446,7 +1446,7 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
@@ -1480,7 +1480,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
@@ -1499,7 +1499,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
     /* Verify the stream is still valid: one envelope + one frame */
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressorInit(&sd, COMPRESSION_ALGO_LZ4) == 0);
 
     uint8_t decompressed[64];
     size_t total = 0;
@@ -1533,7 +1533,7 @@ TEST(compression, independentStreamsCoexist) {
     dynamicBufInit(&db1);
     dynamicBufInit(&db2);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t1 = streamWriterCreate(&cfg, emitToDynamicBuf, &db1);
     streamWriter *t2 = streamWriterCreate(&cfg, emitToDynamicBuf, &db2);
     ASSERT_TRUE(t1 != NULL && t2 != NULL);
@@ -1586,7 +1586,7 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     dynamic_buf_t db;
     dynamicBufInit(&db);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriterConfig cfg = makeWriterConfig(COMPRESSION_ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -94,6 +94,15 @@ struct {
     char *stats_output;
 } rdbstate;
 
+static unsigned long long rdbCheckOffset(void) {
+    if (!rdbstate.rio) return 0;
+
+    off_t pos = rioTell(rdbstate.rio);
+    if (pos >= 0) return (unsigned long long)pos;
+
+    return (unsigned long long)rdbstate.rio->processed_bytes;
+}
+
 /* At every loading step try to remember what we were about to do, so that
  * we can log this information when an error is encountered. */
 #define RDB_CHECK_DOING_START 0
@@ -522,7 +531,7 @@ void rdbCheckError(const char *fmt, ...) {
     va_end(ap);
 
     printf("--- RDB ERROR DETECTED ---\n");
-    printf("[offset %llu] %s\n", (unsigned long long)(rdbstate.rio ? rdbstate.rio->processed_bytes : 0), msg);
+    printf("[offset %llu] %s\n", rdbCheckOffset(), msg);
     printf("[additional info] While doing: %s\n", rdb_check_doing_string[rdbstate.doing]);
     if (rdbstate.key) printf("[additional info] Reading key '%s'\n", (char *)objectGetVal(rdbstate.key));
     if (rdbstate.key_type != -1)
@@ -551,7 +560,7 @@ void rdbCheckInfo(const char *fmt, ...) {
         va_end(ap);
     }
 
-    printf("[offset %llu] %s\n", (unsigned long long)(rdbstate.rio ? rdbstate.rio->processed_bytes : 0), msgbuf);
+    printf("[offset %llu] %s\n", rdbCheckOffset(), msgbuf);
 
     if (msgbuf != msg) sdsfree(msgbuf);
 }
@@ -602,7 +611,9 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     int type, rdbver;
     char buf[1024];
     long long expiretime;
-    static rio rdb; /* Pointed by global struct riostate. */
+    static rio file_rdb;
+    rio *rdb = &file_rdb; /* Pointed by global struct riostate. */
+    rdbInputStream input;
     struct stat sb;
 
     now = mstime();
@@ -612,10 +623,24 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     if (fstat(fileno(fp), &sb) == -1) sb.st_size = 0;
 
     startLoadingFile(sb.st_size, rdbfilename, RDBFLAGS_NONE);
-    rioInitWithFile(&rdb, fp);
-    rdbstate.rio = &rdb;
-    rdb.update_cksum = rdbLoadProgressCallback;
-    if (rioRead(&rdb, buf, 9) == 0) goto eoferr;
+    rioInitWithFile(&file_rdb, fp);
+    rdbInputStreamInit(&input, &file_rdb);
+
+    /* Support both plain RDB files and VKCS-wrapped streaming-compressed RDBs. */
+    decompress_rio_init_result_t init_rc = rdbInputStreamPrepare(&input);
+    if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
+        rdbCheckError("Invalid RDB stream envelope");
+        goto err;
+    }
+    if (init_rc != DECOMPRESS_RIO_INIT_OK) {
+        rdbCheckError("Failed to inspect RDB stream metadata");
+        goto err;
+    }
+    rdb = input.rdb_rio;
+
+    rdbstate.rio = rdb;
+    rdb->update_cksum = rdbLoadProgressCallback;
+    if (rioRead(rdb, buf, 9) == 0) goto eoferr;
     buf[9] = '\0';
     bool is_valkey_magic = false, is_redis_magic = false;
     if (memcmp(buf, "REDIS0", 6) == 0) {
@@ -645,7 +670,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
 
         /* Read type. */
         rdbstate.doing = RDB_CHECK_DOING_READ_TYPE;
-        if ((type = rdbLoadType(&rdb)) == -1) goto eoferr;
+        if ((type = rdbLoadType(rdb)) == -1) goto eoferr;
 
         /* Handle special types. */
         if (type == RDB_OPCODE_EXPIRETIME) {
@@ -653,25 +678,25 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             /* EXPIRETIME: load an expire associated with the next key
              * to load. Note that after loading an expire we need to
              * load the actual type, and continue. */
-            expiretime = rdbLoadTime(&rdb);
+            expiretime = rdbLoadTime(rdb);
             expiretime *= 1000;
-            if (rioGetReadError(&rdb)) goto eoferr;
+            if (rioGetReadError(rdb)) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_EXPIRETIME_MS) {
             /* EXPIRETIME_MS: milliseconds precision expire times introduced
              * with RDB v3. Like EXPIRETIME but no with more precision. */
             rdbstate.doing = RDB_CHECK_DOING_READ_EXPIRE;
-            expiretime = rdbLoadMillisecondTime(&rdb, rdbver);
-            if (rioGetReadError(&rdb)) goto eoferr;
+            expiretime = rdbLoadMillisecondTime(rdb, rdbver);
+            if (rioGetReadError(rdb)) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_FREQ) {
             /* FREQ: LFU frequency. */
             uint8_t byte;
-            if (rioRead(&rdb, &byte, 1) == 0) goto eoferr;
+            if (rioRead(rdb, &byte, 1) == 0) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_IDLE) {
             /* IDLE: LRU idle time. */
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_EOF) {
             /* EOF: End of file, exit the main loop. */
@@ -679,7 +704,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         } else if (type == RDB_OPCODE_SELECTDB) {
             /* SELECTDB: Select the specified database. */
             rdbstate.doing = RDB_CHECK_DOING_READ_LEN;
-            if ((dbid = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((dbid = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             rdbCheckInfo("Selecting DB ID %llu", (unsigned long long)dbid);
             selected_dbid = dbid;
             if (selected_dbid > rdbstate.databases) {
@@ -692,24 +717,24 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
              * selected data base, in order to avoid useless rehashing. */
             uint64_t db_size, expires_size;
             rdbstate.doing = RDB_CHECK_DOING_READ_LEN;
-            if ((db_size = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
-            if ((expires_size = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((db_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((expires_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_SLOT_INFO) {
             /* Hint used in foreign RDB versions. */
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
-            if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
+            if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_SLOT_IMPORT) {
             robj *job_name;
-            if ((job_name = rdbLoadStringObject(&rdb)) == NULL) goto eoferr;
+            if ((job_name = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
             decrRefCount(job_name);
             uint64_t num_slot_ranges;
-            if ((num_slot_ranges = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((num_slot_ranges = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             for (uint64_t i = 0; i < num_slot_ranges; i++) {
-                if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
-                if (rdbLoadLen(&rdb, NULL) == RDB_LENERR) goto eoferr;
+                if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
+                if (rdbLoadLen(rdb, NULL) == RDB_LENERR) goto eoferr;
             }
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_AUX) {
@@ -720,8 +745,8 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
              * An AUX field is composed of two strings: key and value. */
             robj *auxkey, *auxval;
             rdbstate.doing = RDB_CHECK_DOING_READ_AUX;
-            if ((auxkey = rdbLoadStringObject(&rdb)) == NULL) goto eoferr;
-            if ((auxval = rdbLoadStringObject(&rdb)) == NULL) {
+            if ((auxkey = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
+            if ((auxval = rdbLoadStringObject(rdb)) == NULL) {
                 decrRefCount(auxkey);
                 goto eoferr;
             }
@@ -737,9 +762,9 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             /* AUX: Auxiliary data for modules. */
             uint64_t moduleid, when_opcode, when;
             rdbstate.doing = RDB_CHECK_DOING_READ_MODULE_AUX;
-            if ((moduleid = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
-            if ((when_opcode = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
-            if ((when = rdbLoadLen(&rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((moduleid = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((when_opcode = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
+            if ((when = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             if (when_opcode != RDB_MODULE_OPCODE_UINT) {
                 rdbCheckError("bad when_opcode");
                 goto err;
@@ -749,7 +774,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             moduleTypeNameByID(name, moduleid);
             rdbCheckInfo("MODULE AUX for: %s", name);
 
-            robj *o = rdbLoadCheckModuleValue(&rdb, name);
+            robj *o = rdbLoadCheckModuleValue(rdb, name);
             decrRefCount(o);
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {
@@ -758,7 +783,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         } else if (type == RDB_OPCODE_FUNCTION2) {
             sds err = NULL;
             rdbstate.doing = RDB_CHECK_DOING_READ_FUNCTIONS;
-            if (rdbFunctionLoad(&rdb, rdbver, NULL, 0, &err) != C_OK) {
+            if (rdbFunctionLoad(rdb, rdbver, NULL, 0, &err) != C_OK) {
                 rdbCheckError("Failed loading library, %s", err);
                 sdsfree(err);
                 goto err;
@@ -783,12 +808,12 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
 
         /* Read key */
         rdbstate.doing = RDB_CHECK_DOING_READ_KEY;
-        if ((key = rdbLoadStringObject(&rdb)) == NULL) goto eoferr;
+        if ((key = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
         rdbstate.key = key;
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type, &rdb, objectGetVal(key), selected_dbid, NULL, RDBFLAGS_NONE, 0)) == NULL) goto eoferr;
+        if ((val = rdbLoadObject(type, rdb, objectGetVal(key), selected_dbid, NULL, RDBFLAGS_NONE, 0)) == NULL) goto eoferr;
         if (rdbCheckStats) {
             int max_stats_num = (rdbstate.databases + 1) * OBJ_TYPE_MAX;
             if (max_stats_num > rdbstate.stats_num) {
@@ -809,12 +834,16 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     }
     /* Verify the checksum if RDB version is >= 5 */
     if (rdbver >= 5 && server.rdb_checksum) {
-        uint64_t cksum, expected = rdb.cksum;
+        uint64_t cksum, expected = rdb->cksum;
 
         rdbstate.doing = RDB_CHECK_DOING_CHECK_SUM;
-        if (rioRead(&rdb, &cksum, 8) == 0) goto eoferr;
+        if (rioRead(rdb, &cksum, 8) == 0) goto eoferr;
         memrev64ifbe(&cksum);
-        if (cksum == 0) {
+        if (rdb->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) {
+            rdbCheckInfo("Streaming-compressed RDB: integrity validated by codec checksums.");
+        } else if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
+            rdbCheckInfo("RDB file was saved with checksum disabled: skipped checksum for this transfer.");
+        } else if (cksum == 0) {
             rdbCheckInfo("RDB file was saved with checksum disabled: no check performed.");
         } else if (cksum != expected) {
             rdbCheckError("RDB CRC error");
@@ -824,6 +853,8 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         }
     }
 
+    rdbInputStreamDestroy(&input);
+    rdbstate.rio = &file_rdb;
     if (closefile) fclose(fp);
     stopLoading(1);
     return 0;
@@ -831,10 +862,14 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
 eoferr: /* unexpected end of file is handled here with a fatal exit */
     if (rdbstate.error_set) {
         rdbCheckError(rdbstate.error);
+    } else if (rdbRioHasCorruptCompressedInput(rdb)) {
+        rdbCheckError("Corrupt compressed RDB stream");
     } else {
         rdbCheckError("Unexpected EOF reading RDB file");
     }
 err:
+    rdbInputStreamDestroy(&input);
+    rdbstate.rio = &file_rdb;
     if (closefile) fclose(fp);
     stopLoading(0);
     return 1;

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -627,7 +627,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     rdbInputStreamInit(&input, &file_rdb);
 
     /* Support both plain RDB files and VKCS-wrapped streaming-compressed RDBs. */
-    decompress_rio_init_result_t init_rc = rdbInputStreamPrepare(&input);
+    decompressRioInitResult init_rc = rdbInputStreamPrepare(&input);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         rdbCheckError("Invalid RDB stream envelope");
         goto err;

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -1,0 +1,504 @@
+tags {"rdb-compression external:skip needs:debug"} {
+
+proc read_binary_file_prefix {path count} {
+    set fd [open $path r]
+    fconfigure $fd -translation binary
+    set prefix [read $fd $count]
+    close $fd
+    return $prefix
+}
+
+proc dump_rdb_path {client} {
+    return [file join [lindex [$client config get dir] 1] dump.rdb]
+}
+
+proc read_dump_rdb_header_bytes {client} {
+    return [read_binary_file_prefix [dump_rdb_path $client] 8]
+}
+
+proc write_rdb_test_dataset {client prefix} {
+    $client flushall
+    for {set i 0} {$i < 12} {incr i} {
+        $client set "${prefix}:str:$i" [string repeat "${prefix}:value:$i " 16]
+    }
+    $client lpush "${prefix}:list" a b c d e
+    $client sadd "${prefix}:set" alpha beta gamma
+    $client zadd "${prefix}:zset" 1 one 2 two 3 three
+    $client hset "${prefix}:hash" f1 v1 f2 [string repeat "${prefix}:hash " 8]
+    $client xadd "${prefix}:stream" * f1 s1 f2 [string repeat "${prefix}:stream " 4]
+    $client xadd "${prefix}:stream" * f1 s2 f2 tail
+}
+
+proc assert_rdb_test_dataset {client prefix} {
+    assert_equal [string repeat "${prefix}:value:0 " 16] [$client get "${prefix}:str:0"]
+    assert_equal 17 [$client dbsize]
+    assert_equal 5 [$client llen "${prefix}:list"]
+    assert_equal 3 [$client scard "${prefix}:set"]
+    assert_equal 3 [$client zcard "${prefix}:zset"]
+    assert_equal v1 [$client hget "${prefix}:hash" f1]
+    assert_equal 2 [$client xlen "${prefix}:stream"]
+}
+
+start_server {overrides {save "" enable-debug-command local}} {
+    test {RDB save and load round-trip with LZ4 compression} {
+        set prefix "lz4-round-trip"
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        write_rdb_test_dataset r $prefix
+        assert_rdb_test_dataset r $prefix
+        set digest [debug_digest]
+
+        assert_equal "OK" [r save]
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_rdb_test_dataset r $prefix
+    }
+
+    test {Empty LZ4-compressed RDB saves and loads correctly} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+
+        assert_equal 0 [r dbsize]
+        assert_equal "OK" [r save]
+        r config rewrite
+        assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
+
+        restart_server 0 true false
+
+        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal 0 [r dbsize]
+    }
+
+    test {RDB save with LZF (default) round-trips correctly} {
+        set prefix "lzf-round-trip"
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lzf
+        write_rdb_test_dataset r $prefix
+        assert_rdb_test_dataset r $prefix
+
+        set digest [debug_digest]
+        assert_equal "OK" [r save]
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal "lzf" [lindex [r config get rdb-compression-algo] 1]
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_rdb_test_dataset r $prefix
+    }
+
+    test {Uncompressed RDB files load correctly (backward compat)} {
+        set prefix "plain-rdb"
+        r config set rdbcompression no
+        r config set rdb-compression-algo lzf
+        write_rdb_test_dataset r $prefix
+        assert_rdb_test_dataset r $prefix
+
+        set digest [debug_digest]
+        assert_equal "OK" [r save]
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal "no" [lindex [r config get rdbcompression] 1]
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_rdb_test_dataset r $prefix
+    }
+
+    test {LZ4 compressed RDB with large dataset} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+        for {set i 0} {$i < 1000} {incr i} {
+            r set "bulk:$i" [string repeat "payload:$i " 32]
+        }
+        r lpush bulk:list a b c d e
+        r hset bulk:hash f1 v1 f2 v2
+
+        set digest [debug_digest]
+        assert_equal "OK" [r save]
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_equal [string repeat "payload:42 " 32] [r get bulk:42]
+        assert_equal 5 [r llen bulk:list]
+        assert_equal "v1" [r hget bulk:hash f1]
+        assert_equal 1002 [r dbsize]
+    }
+
+    test {Changing compression config during active BGSAVE does not affect the in-flight save} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r config set rdb-key-save-delay 10000
+        r flushall
+        for {set i 0} {$i < 128} {incr i} {
+            r set "bgsave-race:$i" [string repeat "payload:$i " 128]
+        }
+
+        assert_match {*Background saving started*} [r bgsave]
+        wait_for_condition 200 10 {
+            [s rdb_bgsave_in_progress] eq 1
+        } else {
+            r config set rdb-key-save-delay 0
+            fail "BGSAVE did not start in time"
+        }
+
+        r config set rdb-compression-algo lzf
+
+        wait_for_condition 500 10 {
+            [s rdb_bgsave_in_progress] eq 0
+        } else {
+            r config set rdb-key-save-delay 0
+            fail "BGSAVE did not finish in time"
+        }
+        r config set rdb-key-save-delay 0
+
+        assert_equal "lzf" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
+
+        assert_equal "OK" [r save]
+        assert_equal "VALKEY" [string range [read_dump_rdb_header_bytes r] 0 5]
+
+        r config set rdb-compression-algo lz4
+    }
+
+    test {Switching from LZ4 to LZF preserves data} {
+        set prefix "lz4-to-lzf"
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        write_rdb_test_dataset r $prefix
+        assert_rdb_test_dataset r $prefix
+        set digest [debug_digest]
+
+        # Save with LZ4, then restart with LZF and load the existing file.
+        assert_equal "OK" [r save]
+        r config set rdb-compression-algo lzf
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal "lzf" [lindex [r config get rdb-compression-algo] 1]
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_rdb_test_dataset r $prefix
+    }
+
+    test {Switching from LZF to LZ4 preserves data} {
+        set prefix "lzf-to-lz4"
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lzf
+        write_rdb_test_dataset r $prefix
+        assert_rdb_test_dataset r $prefix
+        set digest [debug_digest]
+
+        # Save with LZF, then restart with LZ4 and load the existing file.
+        assert_equal "OK" [r save]
+        r config set rdb-compression-algo lz4
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_rdb_test_dataset r $prefix
+    }
+
+    test {Invalid compression algo config is rejected} {
+        catch {r config set rdb-compression-algo snappy} err
+        assert_match "*argument(s) must be one of the following: lzf, lz4*" $err
+    }
+
+    test {RDB compression configs survive CONFIG REWRITE and restart} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r config rewrite
+
+        restart_server 0 true false
+
+        assert_equal "yes" [lindex [r config get rdbcompression] 1]
+        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+    }
+
+    test {LZ4 compressed RDB with rdb-checksum yes sets the VKCS codec checksum flag} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+        for {set i 0} {$i < 200} {incr i} {
+            r set "cksum:$i" [string repeat "payload$i " 200]
+        }
+
+        r save
+        set header [read_dump_rdb_header_bytes r]
+        assert_equal "VKCS" [string range $header 0 3]
+        binary scan [string index $header 6] cu flags
+        assert {$flags == 1}
+
+        set digest [debug_digest]
+        restart_server 0 true false
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_equal [string repeat "payload42 " 200] [r get cksum:42]
+    }
+
+    test {Partial VKCS snapshot copied from an interrupted BGSAVE is rejected on load} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r config set rdb-key-save-delay 10000
+        r flushall
+        set noisy_payload ""
+        for {set j 0} {$j < 32768} {incr j} {
+            append noisy_payload [format %c [expr {(($j * 31) + 17) % 94 + 33}]]
+        }
+        for {set i 0} {$i < 128} {incr i} {
+            r set "partial:$i" "${noisy_payload}:$i"
+        }
+
+        assert_match {*Background saving started*} [r bgsave]
+        wait_for_condition 200 10 {
+            [s rdb_bgsave_in_progress] eq 1
+        } else {
+            r config set rdb-key-save-delay 0
+            fail "BGSAVE did not start in time"
+        }
+
+        wait_for_condition 200 10 {
+            [get_child_pid 0] ne ""
+        } else {
+            r config set rdb-key-save-delay 0
+            fail "Timed out waiting for BGSAVE child pid"
+        }
+        set child_pid [get_child_pid 0]
+        set dir [lindex [r config get dir] 1]
+        set temp_rdb [file join $dir temp-${child_pid}.rdb]
+        set partial_rdb [file join $dir partial-vkcs.rdb]
+        wait_for_condition 500 10 {
+            [file exists $temp_rdb] && [file size $temp_rdb] > 4096
+        } else {
+            r config set rdb-key-save-delay 0
+            catch {exec kill -9 $child_pid}
+            fail "Timed out waiting for partial VKCS snapshot"
+        }
+
+        file copy -force $temp_rdb $partial_rdb
+        assert_equal "VKCS" [string range [read_binary_file_prefix $partial_rdb 8] 0 3]
+
+        catch {exec kill -9 $child_pid}
+        wait_for_condition 500 10 {
+            [s rdb_bgsave_in_progress] eq 0
+        } else {
+            r config set rdb-key-save-delay 0
+            fail "Interrupted BGSAVE child was not collected in time"
+        }
+        r config set rdb-key-save-delay 0
+
+        file copy -force $partial_rdb [dump_rdb_path r]
+        catch {r debug reload nosave} err
+        assert_match "*Error*" $err
+    }
+
+    test {LZ4 compressed RDB detects tail corruption when codec checksums are enabled} {
+        r config set rdb-compression-algo lz4
+        r flushall
+        for {set i 0} {$i < 100} {incr i} {
+            r set "footer:$i" [string repeat "payload$i " 100]
+        }
+
+        r save
+        set rdbfile [file join [lindex [r config get dir] 1] dump.rdb]
+        set fd [open $rdbfile r+]
+        fconfigure $fd -translation binary
+        seek $fd -8 end
+        puts -nonewline $fd "foobar00"
+        close $fd
+
+        catch {r debug reload nosave} err
+        assert_match "*Error*" $err
+    }
+
+    test {LZ4 compressed RDB with REPL stream kind is rejected} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+        r set wrong-kind:key [string repeat "payload " 100]
+
+        assert_equal "OK" [r save]
+
+        set rdbfile [file join [lindex [r config get dir] 1] dump.rdb]
+        set fd [open $rdbfile r+]
+        fconfigure $fd -translation binary
+        set data [read $fd]
+        set data [string replace $data 7 7 [binary format c 0x01]]
+        seek $fd 0
+        puts -nonewline $fd $data
+        close $fd
+
+        catch {r debug reload nosave} err
+        assert_match "*Error*" $err
+    }
+
+    test {LZ4 compressed RDB detects corruption in compressed payload} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+        for {set i 0} {$i < 100} {incr i} {
+            r set "corrupt:$i" [string repeat "testdata$i " 100]
+        }
+
+        assert_equal "OK" [r save]
+
+        set rdbfile [file join [lindex [r config get dir] 1] dump.rdb]
+
+        # Read the file, flip a byte in the compressed payload
+        # (skip the VKCS envelope at offset 0-7, corrupt somewhere in the middle)
+        set fd [open $rdbfile r+]
+        fconfigure $fd -translation binary
+        set data [read $fd]
+        set len [string length $data]
+        # Corrupt a byte roughly in the middle of the compressed data
+        set pos [expr {$len / 2}]
+        set byte [string index $data $pos]
+        binary scan $byte c val
+        set newval [expr {($val + 1) & 0xFF}]
+        set newbyte [binary format c $newval]
+        set data [string replace $data $pos $pos $newbyte]
+        seek $fd 0
+        puts -nonewline $fd $data
+        close $fd
+
+        # Reload should fail due to corruption
+        catch {r debug reload nosave} err
+        assert_match "*Error*" $err
+    }
+
+    test {Invalid non-VKCS/non-RDB file fails reload} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+        r set smoke-key smoke-value
+
+        assert_equal "OK" [r save]
+
+        set rdbfile [file join [lindex [r config get dir] 1] dump.rdb]
+        set fd [open $rdbfile w]
+        fconfigure $fd -translation binary
+        puts -nonewline $fd "NOTANRDB"
+        close $fd
+
+        catch {r debug reload nosave} err
+        assert_match "*Error*" $err
+    }
+}
+
+start_server {config "minimal.conf" args {"--rdb-compression-algo lz4"}} {
+    test {Startup accepts valid LZ4 compression config} {
+        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+    }
+}
+
+start_server {overrides {save "" enable-debug-command local rdbchecksum no}} {
+    test {LZ4 compressed RDB with rdb-checksum no leaves VKCS flags clear and loads correctly} {
+        r config set rdbcompression yes
+        r config set rdb-compression-algo lz4
+        r flushall
+        for {set i 0} {$i < 50} {incr i} {
+            r set "nocksum:$i" [string repeat "data$i " 100]
+        }
+
+        r save
+        set header [read_dump_rdb_header_bytes r]
+        assert_equal "VKCS" [string range $header 0 3]
+        binary scan [string index $header 6] cu flags
+        assert {$flags == 0}
+
+        set digest [debug_digest]
+        restart_server 0 true false
+        set newdigest [debug_digest]
+        assert {$digest eq $newdigest}
+        assert_equal [string repeat "data10 " 100] [r get nocksum:10]
+    }
+}
+
+start_server {tags {"rdb-compression repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_host [srv 0 host]
+    set replica_port [srv 0 port]
+
+    start_server {overrides {save "" enable-debug-command local}} {
+        set primary [srv 0 client]
+        set primary_host [srv 0 host]
+        set primary_port [srv 0 port]
+
+        test {Disk-based full sync replication works with LZ4-compressed RDB snapshot} {
+            $primary config set rdbcompression yes
+            $primary config set rdb-compression-algo lz4
+            $primary flushall
+            for {set i 0} {$i < 500} {incr i} {
+                $primary set "repl:$i" [string repeat "payload$i " 40]
+            }
+
+            $replica replicaof $primary_host $primary_port
+            wait_for_sync $replica
+
+            wait_for_condition 50 100 {
+                [status $replica master_link_status] eq "up" &&
+                [$primary debug digest] eq [$replica debug digest]
+            } else {
+                fail "Replica digest mismatch after LZ4 RDB full sync"
+            }
+
+            assert_equal [string repeat "payload42 " 40] [$replica get repl:42]
+        }
+
+        test {Incremental replication continues after LZ4 full sync} {
+            $primary set repl:post-sync "after-sync"
+            wait_for_condition 50 100 {
+                [$replica get repl:post-sync] eq "after-sync"
+            } else {
+                fail "Replica did not receive post-sync write"
+            }
+        }
+
+        test {Diskless full sync remains compatible when rdb-compression-algo is lz4} {
+            $replica replicaof no one
+            $primary config set repl-diskless-sync yes
+            $primary config set repl-diskless-sync-delay 0
+            $replica config set repl-diskless-load swapdb
+            $primary flushall
+            for {set i 0} {$i < 300} {incr i} {
+                $primary set "diskless:$i" [string repeat "payload$i " 60]
+            }
+
+            $replica replicaof $primary_host $primary_port
+            wait_for_sync $replica
+
+            wait_for_condition 50 100 {
+                [status $replica master_link_status] eq "up" &&
+                [$primary debug digest] eq [$replica debug digest]
+            } else {
+                fail "Replica digest mismatch after diskless LZ4 full sync"
+            }
+
+            assert_equal [string repeat "payload42 " 60] [$replica get diskless:42]
+            $primary config set repl-diskless-sync no
+        }
+
+        $replica replicaof no one
+    }
+}
+
+set cluster_bus_port [find_available_port $::baseport $::portcount]
+start_server [list tags {"rdb-compression cluster external:skip singledb"} overrides [list save "" cluster-enabled yes cluster-port $cluster_bus_port]] {
+    test {RDB compression config works in cluster mode} {
+        r config set rdb-compression-algo lz4
+        assert_equal "OK" [r save]
+    }
+}
+
+}

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -164,6 +164,54 @@ tags {"repl external:skip"} {
         }
     }
 
+    test "Replica restart falls back to bgrewriteaof when synced RDB uses streaming compression" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save "" rdb-compression-algo lz4}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 40} {incr i} {
+                $primary set "lz4-key:$i" "value:$i"
+            }
+            waitForBgrewriteaof $primary
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                set replica_rdb [file join [lindex [$replica config get dir] 1] dump.rdb]
+                wait_for_condition 50 100 {
+                    [file exists $replica_rdb]
+                } else {
+                    fail "Replica removed the synced RDB before BGREWRITEAOF fallback completed"
+                }
+
+                after 1000
+                assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
+                waitForBgrewriteaof $replica
+
+                for {set i 40} {$i < 60} {incr i} {
+                    $primary set "lz4-key:$i" "value:$i"
+                }
+                wait_for_ofs_sync $primary $replica
+
+                $replica replicaof no one
+
+                restart_server 0 true false
+                set replica [srv 0 client]
+                wait_done_loading $replica
+
+                assert_equal 60 [$replica dbsize]
+                for {set i 0} {$i < 60} {incr i} {
+                    assert_equal "value:$i" [$replica get "lz4-key:$i"]
+                }
+            }
+        }
+    }
+
     # Test 4: aof-use-rdb-preamble no should fall back to bgrewriteaof
     test "Disk-based sync with aof-use-rdb-preamble no uses bgrewriteaof" {
         start_server {overrides {appendonly yes aof-use-rdb-preamble no repl-diskless-sync no save ""}} {

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -49,6 +49,24 @@ tags {"check-rdb external:skip logreqres:skip"} {
 
 tags {"check-rdb network external:skip logreqres:skip"} {
     start_server {} {
+        test "test valkey-check-rdb validates LZ4-compressed RDB" {
+            r flushall
+            r config set rdbcompression yes
+            r config set rdb-compression-algo lz4
+            r set lz4:key [string repeat "payload " 200]
+            r save
+
+            set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
+            catch {
+                exec $::VALKEY_CHECK_RDB_BIN $dump_rdb
+            } result
+            assert_match {*RDB looks OK!*} $result
+            assert_match {*Streaming-compressed RDB: integrity validated by codec checksums.*} $result
+
+            # Keep subsequent tests on default path unless they explicitly change it.
+            r config set rdb-compression-algo lzf
+        }
+
         test "test valkey-check-rdb stats with empty RDB" {
             r flushall
             r save
@@ -139,6 +157,27 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             assert_match "*db.3.type.zset.keys.total:10*" $result
             assert_match "*db.4.type.hash.keys.total:10*" $result
             assert_match "*db.5.type.stream.keys.total:10*" $result
+        }
+    }
+}
+
+tags {"check-rdb network external:skip logreqres:skip"} {
+    start_server {overrides {save "" rdbchecksum no}} {
+        test "test valkey-check-rdb reports checksum-disabled compressed RDBs accurately" {
+            r flushall
+            r config set rdbcompression yes
+            r config set rdb-compression-algo lz4
+            r set lz4:no-cksum [string repeat "payload " 200]
+            r save
+
+            set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
+            catch {
+                exec $::VALKEY_CHECK_RDB_BIN $dump_rdb
+            } result
+            assert_match {*RDB file was saved with checksum disabled: no check performed.*} $result
+            assert_match {*RDB looks OK!*} $result
+
+            r config set rdb-compression-algo lzf
         }
     }
 }

--- a/valkey.conf
+++ b/valkey.conf
@@ -595,6 +595,19 @@ stop-writes-on-bgsave-error yes
 # the dataset will likely be bigger if you have compressible values or keys.
 rdbcompression yes
 
+# Select the compression algorithm used when rdbcompression is enabled.
+# Supported values:
+#   lzf  - legacy/default per-string compression inside the RDB payload
+#   lz4  - streaming LZ4 frame compression for the entire RDB file
+#
+# RDB files written with lz4 can be loaded only by Valkey versions that
+# support streaming RDB compression. Older versions will fail with a
+# "Wrong signature" load error. Before downgrading or introducing an older
+# replica, rewrite the snapshot in the legacy format:
+#   CONFIG SET rdb-compression-algo lzf
+#   SAVE
+rdb-compression-algo lzf
+
 # Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
 # This makes the format more resistant to corruption but there is a performance
 # hit to pay (around 10%) when saving and loading RDB files, so you can disable it


### PR DESCRIPTION
## Must-Fix Review Findings

1. **`serverassert.h` instead of `assert.h`** — `assert()` compiles out with `-DNDEBUG`, leading to UB in `streamWriterEnsureOutBuf` when the compressor is in a bad state. Valkey convention is `serverassert.h` which keeps asserts unconditionally.

2. **Namespace enum values** — `ALGO_NONE/LZF/LZ4` and `FLUSH_CONTINUE/SYNC/END` are too generic for global scope. Renamed to `COMPRESSION_ALGO_*` and `COMPRESS_FLUSH_*`.

3. **`fmacros.h` in header** — Valkey convention is to include `fmacros.h` only from `.c` files, not headers. Removed from `compression.h`.

4. **Misplaced doc comment** — The VKCS envelope layout comment was above `vkcsCodecIsSupported()` instead of `writeVkcsEnvelope()`. Moved.

5. **Misplaced doc comment** — The `restartAOFWithSyncRdb` docstring was attached to `rdbFileUsesStreamingCompression()`. Moved and added correct comment.

### Verified
- `make -j$(nproc)` clean
- `clang-format-18` clean on all changed files