### PR TITLE
[bot-fix] Fix crash:signal-6:255.255.255 in test-fedoralatest-tls-module

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2445,7 +2445,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster aofrw} overrides {
     }
 }
 
-start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluster-require-full-coverage no slot-migration-max-failover-repl-bytes 0}} {
+start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluster-require-full-coverage no slot-migration-max-failover-repl-bytes 0 repl-timeout 300}} {
     test "Slot migration remaining_repl_size on the source node" {
         set 16383_slot_tag "{6ZJ}"
         set_debug_prevent_pause 1
@@ -2488,7 +2488,7 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluste
     }
 }
 
-start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluster-require-full-coverage no slot-migration-max-failover-repl-bytes -1}} {
+start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluster-require-full-coverage no slot-migration-max-failover-repl-bytes -1 repl-timeout 300}} {
     test "slot-migration-max-failover-repl-bytes -1 disables repl bytes limit" {
         set 16383_slot_tag "{6ZJ}"
 


### PR DESCRIPTION
Fixes #113

## Automated fix for `test-fedoralatest-tls-module`

- Failing run: https://github.com/valkey-io/valkey/actions/runs/25141089135
- Commit: `98724dda089a`
- Branch: `bot/fix/test-fedoralatest-tls-module-98724dda`

### Claude output

```
{"type":"system","subtype":"init","cwd":"/tmp/valkey-fix-nr9vzxvf","session_id":"86125eae-7abc-420f-8612-ac7302afd08b","tools":["Task","AskUserQuestion","Bash","CronCreate","CronDelete","CronList","Edit","EnterPlanMode","EnterWorktree","ExitPlanMode","ExitWorktree","Glob","Grep","NotebookEdit","Read","ScheduleWakeup","Skill","TaskOutput","TaskStop","TodoWrite","ToolSearch","WebFetch","Write"],"mcp_servers":[],"model":"us.anthropic.claude-opus-4-7","permissionMode":"default","slash_commands":["update-config","debug","simplify","batch","fewer-permission-prompts","loop","claude-api","clear","compact","context","heapdump","init","review","security-review","usage","insights","team-onboarding"],"apiKeySource":"none","claude_code_version":"2.1.123","output_style":"default","agents":["Explore","general-purpose","Plan","statusline-setup"],"skills":["update-config","debug","simplify","batch","fewer-permission-prompts","loop","claude-api"],"plugins":[],"analytics_disabled":true,"uuid":"25fede4a-310a-462e-89a7-1b54c867fc5d","memory_paths":{"auto":"/home/runner/.claude/projects/-tmp-valkey-fix-nr9vzxvf/memory/"},"fast_mode_state":"off"}
{"type":"assistant","message":{"model":"claude-opus-4-7","id":"msg_bdrk_bd2qxwu7hwoc6xwvg4f46xzcj4s567cdt6oh4eq7gmiruv3zd55a","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"ErIEClkIDRABGAIqQLwJH3NgcLydWPcpGZKREoKZxEWVBDqB8GvkPicJJ0EWsls2IQ9XvPFc5Xsj1wi9YyeO36w3tGB6XrGqAm18/MEyDWNsYXVkZS1udXRtZWc4ABIMIdyxVQ9psq2kPcYkGgwskDnPwBdsDblhchsiMDe7NwLs1Mu0UHtRvt21gwoT6wi9YgujxSQr/j18AjLT3QP8uLdZoyrxLNR0FlUu2yqGA/NHfB6AMxAt8DcMJNElzBljPyDgRr7UX4ptwGnXpRYHIW9bYAPQtegL+gV91g+8dJ6rxOQvMHURT3wcvS+H74mREtXkZ98u/0ewr2NkJIKGEdO1q5MqprIwYQlwVfeBYnmXJxow6yr0B/TrfluyFshu2wRAcqO1455gVW9Zs6uQJkWFiLoozAT/FBs/8yaLDaJmuCiELz89JhPntbKtC3OvRBxHLpUcolI1vu+XGePXw9M+RZzIV8suIoDirdzaxnSb3zG4+xvkwu/kpp+H7QVJfofGgHvGzgaNmZY+ileGj+03adoxKyhxsv55JUVmSsUw1rFJQimroTY3Nn/XqNM1dyvOq2voDjtcEJh+2pUI438mxA2hqfHsIZfeph/W/FpKRlagQMpFa2aeYh68GUeUB3pcHod8h7e3CTzZHELkKSZoApyGZbabbCF4RUVXZZEyYxfsZldpmaC3vsjGymiJMh3DC8E9FcFvo941XGkvX5tOLMMqO5m46fLguOSyk1ULAaI/tBgB"}],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":6,"cache_creation_input_tokens":44514,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":44514,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"},"context_management":null},"parent_tool_use_id":null,"session_id":"86125eae-7abc-420f-8612-ac7302afd08b","uuid":"c254070b-47da-44f8-b352-cedfd0e07f0f"}
{"type":"assistant","message":{"model":"claude-opus-4-7","id":"msg_bdrk_bd2qxwu7hwoc6xwvg4f46xzcj4s567cdt6oh4eq7gmiruv3zd55a","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_bdrk_01MstdXzRcL9mmf542xQEoB6","name":"Read","input":{"file_path":"/tmp/valkey-fix-nr9vzxvf/tests/unit/cluster/cluster-migrateslots.tcl"}}],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":6,"cache_creation_inp
```

---
*Generated by valkey-ci-agent using Claude Code.*