### PR TITLE
[bot-fix] Fix valgrind-leak:possibly::None in test-valgrind-no-malloc-usable-size-test

### DIFF
--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -464,7 +464,11 @@ proc get_open_slots {srv_idx} {
 }
 
 proc wait_for_slot_state {srv_idx pattern} {
-    wait_for_condition 100 100 {
+    # Slot migration state (migrating_slots_to / importing_slots_from) propagates
+    # via PING/PONG gossip separately from primary ownership. After a failover,
+    # wait_for_role may return before the updated state has been gossiped to all
+    # nodes, so allow plenty of time, especially under valgrind.
+    wait_for_condition 1000 50 {
         [get_open_slots $srv_idx] eq $pattern
     } else {
         fail "incorrect slot state on R $srv_idx: expected $pattern; got [get_open_slots $srv_idx]"


### PR DESCRIPTION
Fixes #114

## Automated fix for `test-valgrind-no-malloc-usable-size-test`

- Failing run: https://github.com/valkey-io/valkey/actions/runs/25141089135
- Commit: `98724dda089a`
- Branch: `bot/fix/test-valgrind-no-malloc-usable-size-test-98724dda`

### Claude output

```
{"type":"system","subtype":"init","cwd":"/tmp/valkey-fix-43wf05dh","session_id":"01718e16-26ba-4e78-97b8-bc8de2369103","tools":["Task","AskUserQuestion","Bash","CronCreate","CronDelete","CronList","Edit","EnterPlanMode","EnterWorktree","ExitPlanMode","ExitWorktree","Glob","Grep","NotebookEdit","Read","ScheduleWakeup","Skill","TaskOutput","TaskStop","TodoWrite","ToolSearch","WebFetch","Write"],"mcp_servers":[],"model":"us.anthropic.claude-opus-4-7","permissionMode":"default","slash_commands":["update-config","debug","simplify","batch","fewer-permission-prompts","loop","claude-api","clear","compact","context","heapdump","init","review","security-review","usage","insights","team-onboarding"],"apiKeySource":"none","claude_code_version":"2.1.123","output_style":"default","agents":["Explore","general-purpose","Plan","statusline-setup"],"skills":["update-config","debug","simplify","batch","fewer-permission-prompts","loop","claude-api"],"plugins":[],"analytics_disabled":true,"uuid":"672604aa-4459-42c2-9491-557790b0d334","memory_paths":{"auto":"/home/runner/.claude/projects/-tmp-valkey-fix-43wf05dh/memory/"},"fast_mode_state":"off"}
{"type":"assistant","message":{"model":"claude-opus-4-7","id":"msg_bdrk_npsitzvxnbkh5f7fdnydsouovg3r4bn73osdxxtv4h2inunxgzna","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"EvQJClkIDRABGAIqQNJZo0Z5sjcOTmAyAxCFwiSOOSyncdcvKw0oDTvE6dKo305UHCSmwcobPp6kfAHVtFOXlVdvTpWwDd8Gn9glK48yDWNsYXVkZS1udXRtZWc4ABIMaqfSOi2ecFW7b2zLGgwjwC2Htimx+uDZR0UiMOWvK2VSRDl6B44ExcHM03W1IzBTEM+DQQqoWkkxL4nRcghn12xdsKeRujQAQK7JWCrICMpWujrWwwLkZsaM/6jVFiUgXyHU9wcELU5Vng6cofKbvKA5ANQfj2a9G1JPhH8aIthY1vfclO9N3HlecvjCobaASYWGCPXPCpyA+G+HmZwbnt/BBpNnO2WLM+KirKL7Ayu40aWihzXOjQk40mwwf2fVG3w7vNZAXxCkGNbAzSgTLoiDD9sUmUX3jo24sUOhFR8IJmxNRlKFOVpx35dQbbqSAcQEo0E0EDmhpNSlRUqYRC43bpz75/4W+LlneI6p3oZwPIavvNvUdguiJSI99PQUDhLg6f8x5YALE326PU/reT0fwZTCwVayAaDWsdSc/MxJVZbfgHOI4ss567hDcGBcP3AMZjHFjNlN2DSaeczpQhO/cvIgFzunnBA1rnCfJHO7iHg4dnJGLWjniB1UMYa4n58JuoAxe3hgxtOaJ3ltAa3Q0pGHmrUY0CYAcEWa6R3aSxtJwwnTqD++Vi/CNRQWN+xguGtEXoysnKUXRQrzX/9eJtyb0Opmne+dzo7FO+F6B9QFHsVF2oC7aTAHXy41snaNLP7vvIbpBhltgdTt3ocHoMP+2dWh1Dmv6tWb8iT7a23DO+Ses3BrFvnHdgoJ4JJUuWWzszqDZ/LBzODwSSVMogqGUXE+svuy2JZ8sD5s+nJF7ao2KCCtBmKa/JVwu8aVRtZ5S1BUxzg7HgrVz9G/bcFGsaqnboerp+MDhEAvvqkJXQJaZNMVFGZLJOtLiYfvbIWT1ekP9Bh9jMrH2WEuGpnzy4vwnwrLxnWX24p6E9iG8V0AiIIZYSM0pQ4c917jbrdqDQpCIeyzz0m/mXTh7fYzMpALZPOaQIzERmoLjEanKh9lKVsT8X2iRGOCOssyNVSqQ1JUZ4DSIH6pKrOfWrlVR3ru+u6ztaOwhkARIKYUwaAUtk6MR8vc9/Pvjw1Y/AXjIKdiUjgFqokbV+5ztGpYgZqiPip9AH2SzA18bYrGiwuz+hYqMFeSv08PSgBRIzzdp6DBG9F6UD5r0LhYk7wK7q6qr0Cyt0ufzEG0JRIfatsE1/HQEtNfv5L7xD/seMVWq3OlLV13LF8umiozFfEwXQYv14B3JZiT2Mf/T3KmLySwNiPNrx9HIWvcNK/j4pqs7tqPgF304D7aJxH964GlWtj+1c0TjnrOdMnPYqiq4HCg7gRg4e2G+3khez0O0+YiKCR3/sFLeYXrfec5moaZkN0QhY27Zv36Sjcc6D/zkOO8hfqeCCfq2ZtBi8oNmFixnBP/2lp+mH7cDzziaWFk8rTbo866DCtnaD3h2borkthgNmGG8Mtjh8Jn+WOK0f30hCJlNttduU5hTHLXZq4RptrgW6rRK/54N3yqdL7w4SyUI0RS7jPbYueV+cOQsW0EW5ktwipt44Vp33jqBU5jcPljgYhALL0
```

---
*Generated by valkey-ci-agent using Claude Code.*