### PR TITLE
[Shadow] API cleanup: eliminate dictSetKey

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -84,11 +84,6 @@ static inline int dictExpand(dict *d, unsigned long size) {
 }
 
 /* Entry accessor functions */
-static inline void dictSetKey(dict *d, dictEntry *de, void *key) {
-    UNUSED(d);
-    de->key = key;
-}
-
 static inline void dictSetVal(dict *d, dictEntry *de, void *val) {
     UNUSED(d);
     de->v.val = val;

--- a/src/expire.c
+++ b/src/expire.c
@@ -529,31 +529,57 @@ ustime_t activeExpireCycle(int type) {
  * the keys as implemented in 3.2.
  *----------------------------------------------------------------------------*/
 
-/* The dictionary where we remember key names and database ID of keys we may
+/* The hashtable where we remember key names and database ID of keys we may
  * want to expire from the replica. Since this function is not often used we
  * don't even care to initialize the database at startup. We'll do it once
  * the feature is used the first time, that is, when rememberreplicaKeyWithExpire()
  * is called.
  *
- * The dictionary has an SDS string representing the key as the hash table
- * key, while the value is a 64 bit unsigned integer with the bits corresponding
- * to the DB where the keys may exist set to 1. Currently the keys created
- * with a DB id > 63 are not expired, but a trivial fix is to set the bitmap
- * to the max 64 bit unsigned value when we know there is a key with a DB
- * ID greater than 63, and check all the configured DBs in such a case. */
-dict *replicaKeysWithExpire = NULL;
+ * The hashtable stores replicaKeyExpireEntry structs, each containing an SDS
+ * key name and a 64 bit unsigned bitmap with the bits corresponding to the DB
+ * where the keys may exist set to 1. Currently the keys created with a DB id
+ * > 63 are not expired, but a trivial fix is to set the bitmap to the max 64
+ * bit unsigned value when we know there is a key with a DB ID greater than 63,
+ * and check all the configured DBs in such a case. */
+
+typedef struct replicaKeyExpireEntry {
+    sds key;
+    uint64_t dbids;
+} replicaKeyExpireEntry;
+
+static const void *replicaKeyExpireEntryGetKey(const void *entry) {
+    const replicaKeyExpireEntry *e = entry;
+    return e->key;
+}
+
+static void replicaKeyExpireEntryDestructor(void *entry) {
+    replicaKeyExpireEntry *e = entry;
+    sdsfree(e->key);
+    zfree(e);
+}
+
+static hashtableType replicaKeyExpireHashtableType = {
+    .entryGetKey = replicaKeyExpireEntryGetKey,
+    .hashFunction = dictSdsHash,
+    .keyCompare = dictSdsKeyCompare,
+    .entryDestructor = replicaKeyExpireEntryDestructor,
+};
+
+hashtable *replicaKeysWithExpire = NULL;
 
 /* Check the set of keys created by the primary with an expire set in order to
  * check if they should be evicted. */
 void expireReplicaKeys(void) {
-    if (replicaKeysWithExpire == NULL || dictSize(replicaKeysWithExpire) == 0) return;
+    if (replicaKeysWithExpire == NULL || hashtableSize(replicaKeysWithExpire) == 0) return;
 
     int cycles = 0, noexpire = 0;
     mstime_t start = mstime();
     while (1) {
-        dictEntry *de = dictGetRandomKey(replicaKeysWithExpire);
-        sds keyname = dictGetKey(de);
-        uint64_t dbids = dictGetUnsignedIntegerVal(de);
+        void *entry = NULL;
+        hashtableRandomEntry(replicaKeysWithExpire, &entry);
+        replicaKeyExpireEntry *e = entry;
+        sds keyname = e->key;
+        uint64_t dbids = e->dbids;
         uint64_t new_dbids = 0;
 
         /* Check the key against every database corresponding to the
@@ -586,57 +612,52 @@ void expireReplicaKeys(void) {
             dbids >>= 1;
         }
 
-        /* Set the new bitmap as value of the key, in the dictionary
+        /* Set the new bitmap as value of the key, in the hashtable
          * of keys with an expire set directly in the writable replica. Otherwise
          * if the bitmap is zero, we no longer need to keep track of it. */
         if (new_dbids)
-            dictSetUnsignedIntegerVal(de, new_dbids);
+            e->dbids = new_dbids;
         else
-            dictDelete(replicaKeysWithExpire, keyname);
+            hashtableDelete(replicaKeysWithExpire, keyname);
 
         /* Stop conditions: found 3 keys we can't expire in a row or
          * time limit was reached. */
         cycles++;
         if (noexpire > 3) break;
         if ((cycles % 64) == 0 && mstime() - start > 1) break;
-        if (dictSize(replicaKeysWithExpire) == 0) break;
+        if (hashtableSize(replicaKeysWithExpire) == 0) break;
     }
 }
 
 /* Track keys that received an EXPIRE or similar command in the context
  * of a writable replica. */
-
 void rememberReplicaKeyWithExpire(serverDb *db, robj *key) {
     if (replicaKeysWithExpire == NULL) {
-        static dictType dt = {
-            .entryGetKey = dictEntryGetKey,
-            .hashFunction = dictSdsHash,
-            .keyCompare = dictSdsKeyCompare,
-            .entryDestructor = dictEntryDestructorSdsKey,
-        };
-        replicaKeysWithExpire = dictCreate(&dt);
+        replicaKeysWithExpire = hashtableCreate(&replicaKeyExpireHashtableType);
     }
     if (db->id > 63) return;
 
-    dictEntry *de = dictAddOrFind(replicaKeysWithExpire, objectGetVal(key));
-    /* If the entry was just created, set it to a copy of the SDS string
-     * representing the key: we don't want to need to take those keys
-     * in sync with the main DB. The keys will be removed by expireReplicaKeys()
-     * as it scans to find keys to remove. */
-    if (dictGetKey(de) == objectGetVal(key)) {
-        dictSetKey(replicaKeysWithExpire, de, sdsdup(objectGetVal(key)));
-        dictSetUnsignedIntegerVal(de, 0);
+    void *existing = NULL;
+    hashtablePosition pos;
+    replicaKeyExpireEntry *e;
+
+    if (hashtableFindPositionForInsert(replicaKeysWithExpire, objectGetVal(key), &pos, &existing)) {
+        /* Key is new; allocate the entry and insert it. */
+        e = zmalloc(sizeof(*e));
+        e->key = sdsdup(objectGetVal(key));
+        e->dbids = 0;
+        hashtableInsertAtPosition(replicaKeysWithExpire, e, &pos);
+    } else {
+        e = existing;
     }
 
-    uint64_t dbids = dictGetUnsignedIntegerVal(de);
-    dbids |= (uint64_t)1 << db->id;
-    dictSetUnsignedIntegerVal(de, dbids);
+    e->dbids |= (uint64_t)1 << db->id;
 }
 
 /* Return the number of keys we are tracking. */
 size_t getReplicaKeyWithExpireCount(void) {
     if (replicaKeysWithExpire == NULL) return 0;
-    return dictSize(replicaKeysWithExpire);
+    return hashtableSize(replicaKeysWithExpire);
 }
 
 /* Remove the keys in the hash table. We need to do that when data is
@@ -652,7 +673,7 @@ void flushReplicaKeysWithExpireList(int async) {
         if (async) {
             freeReplicaKeysWithExpireAsync(replicaKeysWithExpire);
         } else {
-            dictRelease(replicaKeysWithExpire);
+            hashtableRelease(replicaKeysWithExpire);
         }
         replicaKeysWithExpire = NULL;
     }

--- a/src/expire.h
+++ b/src/expire.h
@@ -55,6 +55,7 @@ enum activeExpiryType {
 typedef struct client client;
 typedef struct serverObject robj;
 typedef struct serverDb serverDb;
+typedef struct hashtable hashtable;
 
 /* return the relevant expiration policy based on the current server state and the provided flags.
  * FLAGS can indicate either:
@@ -71,6 +72,6 @@ void rememberReplicaKeyWithExpire(serverDb *db, robj *key);
 void flushReplicaKeysWithExpireList(int async);
 size_t getReplicaKeyWithExpireCount(void);
 bool timestampIsExpired(mstime_t when);
-void freeReplicaKeysWithExpireAsync(dict *replica_keys_with_expire);
+void freeReplicaKeysWithExpireAsync(hashtable *replica_keys_with_expire);
 
 #endif

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -85,11 +85,11 @@ void lazyFreeReplicationBacklogRefMem(void *args[]) {
     atomic_fetch_add_explicit(&lazyfreed_objects, len, memory_order_relaxed);
 }
 
-/* Release the replicaKeysWithExpire dict. */
+/* Release the replicaKeysWithExpire hashtable. */
 void lazyFreeReplicaKeysWithExpire(void *args[]) {
-    dict *replica_keys_with_expire = args[0];
-    size_t len = dictSize(replica_keys_with_expire);
-    dictRelease(replica_keys_with_expire);
+    hashtable *replica_keys_with_expire = args[0];
+    size_t len = hashtableSize(replica_keys_with_expire);
+    hashtableRelease(replica_keys_with_expire);
     atomic_fetch_sub_explicit(&lazyfree_objects, len, memory_order_relaxed);
     atomic_fetch_add_explicit(&lazyfreed_objects, len, memory_order_relaxed);
 }
@@ -279,13 +279,13 @@ void freeReplicationBacklogRefMemAsync(list *blocks, rax *index) {
     }
 }
 
-/* Free replicaKeysWithExpire dict, if the dict is huge enough, free it in async way. */
-void freeReplicaKeysWithExpireAsync(dict *replica_keys_with_expire) {
-    if (dictSize(replica_keys_with_expire) > LAZYFREE_THRESHOLD) {
-        atomic_fetch_add_explicit(&lazyfree_objects, dictSize(replica_keys_with_expire), memory_order_relaxed);
+/* Free replicaKeysWithExpire hashtable, if it is huge enough, free it in async way. */
+void freeReplicaKeysWithExpireAsync(hashtable *replica_keys_with_expire) {
+    if (hashtableSize(replica_keys_with_expire) > LAZYFREE_THRESHOLD) {
+        atomic_fetch_add_explicit(&lazyfree_objects, hashtableSize(replica_keys_with_expire), memory_order_relaxed);
         bioCreateLazyFreeJob(lazyFreeReplicaKeysWithExpire, 1, replica_keys_with_expire);
     } else {
-        dictRelease(replica_keys_with_expire);
+        hashtableRelease(replica_keys_with_expire);
     }
 }
 


### PR DESCRIPTION
Mirror for CI agent eval. Do not merge.