### PR TITLE
[Backport 9.0] Fix off-by-one boundary in lpEncodeBacklen() for 3 values

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -270,20 +270,20 @@ static inline unsigned long lpEncodeBacklen(unsigned char *buf, uint64_t l) {
     if (l <= 127) {
         if (buf) buf[0] = l;
         return 1;
-    } else if (l < 16383) {
+    } else if (l <= 16383) {
         if (buf) {
             buf[0] = l >> 7;
             buf[1] = (l & 127) | 128;
         }
         return 2;
-    } else if (l < 2097151) {
+    } else if (l <= 2097151) {
         if (buf) {
             buf[0] = l >> 14;
             buf[1] = ((l >> 7) & 127) | 128;
             buf[2] = (l & 127) | 128;
         }
         return 3;
-    } else if (l < 268435455) {
+    } else if (l <= 268435455) {
         if (buf) {
             buf[0] = l >> 21;
             buf[1] = ((l >> 14) & 127) | 128;


### PR DESCRIPTION
## Backport Summary

Cherry-pick applied cleanly with no conflicts.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3601` |
| Source title | Fix off-by-one boundary in lpEncodeBacklen() for 3 values |
| Target branch | `9.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | no |
| Auto-resolved files | 0 |
| Unresolved files | 0 |
| Risk level | `medium` |

### Backport Risk

- Level: `medium`
- Signals:
  - target branch `9.0` is an older release line
- Touched paths: unknown

### Reviewer Checklist

- Compare this backport against the source PR before merge.

### Cherry-Picked Commits

- `38080c046fdcd24d8c84a2d89835514eeac72623`
