### PR TITLE
[Backport 9.0] fix: validate key count before allocating result in keyspec

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2354,19 +2354,21 @@ int getKeysUsingKeySpecs(struct serverCommand *cmd, robj **argv, int argc, int s
             }
 
             first += spec->fk.keynum.firstkey;
-            last = first + (int)numkeys - 1;
+            long long temp_last = first + numkeys - 1;
+            if (temp_last > INT_MAX || temp_last < INT_MIN) goto invalid_spec;
+            last = (int)temp_last;
         } else {
             /* unknown spec */
             goto invalid_spec;
         }
 
-        int count = ((last - first) + 1);
-        keys = getKeysPrepareResult(result, result->numkeys + count);
-
         /* First or last is out of bounds, which indicates a syntax error */
         if (last >= argc || last < first || first >= argc) {
             goto invalid_spec;
         }
+
+        int count = ((last - first) + 1);
+        keys = getKeysPrepareResult(result, result->numkeys + count);
 
         for (i = first; i <= last; i += step) {
             if (i >= argc || i < first) {

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -162,6 +162,10 @@ start_server {tags {"introspection"}} {
         assert_equal {} [r command getkeys eval "return 1" 0]
     }
 
+    test {COMMAND GETKEYS EVAL with huge numkeys} {
+        assert_equal {} [r command getkeys eval "return 1" 2147483647 key1]
+    }
+
     test {COMMAND GETKEYS LCS} {
         assert_equal {key1 key2} [r command getkeys lcs key1 key2]
     }


### PR DESCRIPTION
## Backport Summary

Cherry-pick encountered conflicts and the conflicted files were resolved automatically.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3598` |
| Source title | fix: validate key count before allocating result in keyspec |
| Target branch | `9.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | yes |
| Auto-resolved files | 1 |
| Unresolved files | 0 |
| Risk level | `high` |

### Backport Risk

- Level: `high`
- Signals:
  - cherry-pick required conflict resolution
  - 1 file(s) were auto-resolved
  - target branch `9.0` is an older release line
- Touched paths: unknown

### Reviewer Checklist

- Compare this backport against the source PR before merge.
- Run subsystem-focused tests before merge; this backport has high-risk signals.
- Review the automatically resolved files carefully for semantic drift.

### Cherry-Picked Commits

- `1f1f56bfe9594b5ac42f21b196015c2f8dd4575a`

### Conflict Details

- `src/db.c`: Resolved automatically. resolved by Claude Code

### Human Review Required

Some conflicts in this backport were resolved using an LLM. These resolutions require careful human review to ensure correctness. Please verify that the resolved code matches the intent of the original pull request.