### PR TITLE
[Backport 9.0] fix compile warning in util.c

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -622,7 +622,8 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 }
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
-__attribute__((no_sanitize_address, used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+VALKEY_NO_SANITIZE("address")
+__attribute__((used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
     /* Ifunc resolvers run before ASan initialization and before CPU detection
      * is initialized, so disable ASan and init CPU detection here. */
     __builtin_cpu_init();


### PR DESCRIPTION
## Backport Summary

Cherry-pick encountered conflicts and the conflicted files were resolved automatically.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3585` |
| Source title | fix compile warning in util.c |
| Target branch | `9.0` |
| Cherry-picked commits | 3 |
| Conflicts detected | yes |
| Auto-resolved files | 1 |
| Unresolved files | 0 |
| Risk level | `high` |

### Backport Risk

- Level: `high`
- Signals:
  - cherry-pick required conflict resolution
  - 1 file(s) were auto-resolved
  - target branch `9.0` is an older release line
- Touched paths: unknown

### Reviewer Checklist

- Compare this backport against the source PR before merge.
- Run subsystem-focused tests before merge; this backport has high-risk signals.
- Review the automatically resolved files carefully for semantic drift.

### Cherry-Picked Commits

- `a3dcb94c300b1b32a0e3caff29ef2ec46e9f41fb`
- `cfe095d4271a36007a933428b70c731ec6335ee9`
- `a7020edf8d6ea4add811eabf8b06248b5e3b6195`

### Conflict Details

- `src/util.c`: Resolved automatically. resolved by Claude Code

### Human Review Required

Some conflicts in this backport were resolved using an LLM. These resolutions require careful human review to ensure correctness. Please verify that the resolved code matches the intent of the original pull request.