### PR TITLE
Address streaming RDB compression review

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1006,10 +1006,6 @@ int startAppendOnly(void) {
     return C_OK;
 }
 
-/* Try to restart AOF after replica full sync by adopting `server.rdb_filename`
- * as the new BASE file (RDB preamble mode), avoiding a redundant AOFRW.
- * Returns C_OK on success; on C_ERR caller should fallback to
- * restartAOFAfterSYNC(). */
 static int rdbFileUsesStreamingCompression(const char *filename) {
     unsigned char header[VKCS_ENVELOPE_SIZE];
     int fd = open(filename, O_RDONLY);
@@ -1024,12 +1020,15 @@ static int rdbFileUsesStreamingCompression(const char *filename) {
         return -1;
     }
     if (nread < (ssize_t)sizeof(header)) return 0;
-    /* Validate the full 8-byte VKCS envelope (magic + version + codec)
-     * so a file that happens to start with "VKCS" but has an invalid
-     * version or codec is not misclassified as compressed. */
-    return memcmp(header, "VKCS", 4) == 0 && header[4] == VKCS_VERSION;
+
+    streamReaderInfo info = {0};
+    return streamReadEnvelopeInfo(header, sizeof(header), STREAM_KIND_RDB, &info) == 0;
 }
 
+/* Try to restart AOF after replica full sync by adopting `server.rdb_filename`
+ * as the new BASE file (RDB preamble mode), avoiding a redundant AOFRW.
+ * Returns C_OK on success; on C_ERR caller should fallback to
+ * restartAOFAfterSYNC(). */
 int restartAOFWithSyncRdb(void) {
     serverAssert(server.aof_state == AOF_OFF);
 

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -112,6 +112,8 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
     if (input_len > 0) {
         size_t r;
 
+        /* Capacity shortage before calling into LZ4F is retriable because the
+         * codec state has not changed yet. */
         if (offset >= output_capacity) return -1;
         r = LZ4F_compressUpdate(cctx, output + offset, output_capacity - offset,
                                 input, input_len, NULL);
@@ -123,6 +125,8 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
     if (flush_mode == FLUSH_SYNC) {
         size_t r;
 
+        /* Capacity shortage before calling into LZ4F is retriable because the
+         * codec state has not changed yet. */
         if (offset >= output_capacity) return -1;
         r = LZ4F_flush(cctx, output + offset, output_capacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;
@@ -130,6 +134,8 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
     } else if (flush_mode == FLUSH_END) {
         size_t r;
 
+        /* Capacity shortage before calling into LZ4F is retriable because the
+         * codec state has not changed yet. */
         if (offset >= output_capacity) return -1;
         r = LZ4F_compressEnd(cctx, output + offset, output_capacity - offset, NULL);
         if (LZ4F_isError(r)) goto lz4_error;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -54,12 +54,6 @@ static void rioInitBase(rio *base,
 /* ===================================================================
  * Compression Rio Decorator
  * Wraps an inner rio for transparent compression on write.
- * Currently used by file-backed RDB save paths.
- *
- * RDB CHECKSUM SEMANTICS:
- * - when codec checksums are enabled, they are the authoritative integrity
- *   signal for the compressed stream and the RDB checksum field is left zero.
- * - otherwise the standard RDB checksum protects the logical stream.
  * =================================================================== */
 
 /* Emit callback for compress_rio: writes compressed bytes to inner rio.
@@ -115,19 +109,8 @@ int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *c
 
     memset(cr, 0, sizeof(*cr));
 
-    uint64_t flags = RIO_FLAG_STREAMING_COMPRESSION;
-    if (cfg->codec_checksum_enabled) flags |= RIO_FLAG_STREAMING_CODEC_CHECKSUM;
-    flags |= inner->flags & RIO_FLAG_SKIP_RDB_CHECKSUM;
-
     rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
-                compressRioFlush, flags, rioCheckType(inner));
-    /* Track the uncompressed byte stream only when the standard RDB checksum is
-     * the active integrity mechanism. Honor explicit skip requests from the
-     * wrapped rio and skip checksum tracking whenever codec checksums are
-     * authoritative. */
-    if (!(flags & (RIO_FLAG_SKIP_RDB_CHECKSUM | RIO_FLAG_STREAMING_CODEC_CHECKSUM))) {
-        cr->base.update_cksum = rioGenericUpdateChecksum;
-    }
+                compressRioFlush, RIO_FLAG_STREAMING_COMPRESSION, rioCheckType(inner));
 
     cr->inner = inner;
     cr->finalized = 0;
@@ -219,6 +202,11 @@ streamReaderError decompressRioGetError(const decompressRio *dr) {
     return streamReaderGetError(dr->reader);
 }
 
+int decompressRioValidateEnd(decompressRio *dr) {
+    if (!dr || !dr->reader) return -1;
+    return streamReaderValidateEnd(dr->reader);
+}
+
 /* Initialize a decompression rio and eagerly probe the wrapped stream so the
  * caller gets a stable classification up front: passthrough, compressed, or
  * incompatible envelope. */
@@ -252,9 +240,6 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
 
     if (local_info.compressed) {
         dr->base.flags |= RIO_FLAG_STREAMING_COMPRESSION;
-        if (local_info.codec_checksum_enabled) {
-            dr->base.flags |= RIO_FLAG_STREAMING_CODEC_CHECKSUM;
-        }
     }
     if (info) *info = local_info;
     return DECOMPRESS_RIO_INIT_OK;

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -44,6 +44,7 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
                                               const streamReaderConfig *cfg,
                                               streamReaderInfo *info);
 streamReaderError decompressRioGetError(const decompressRio *dr);
+int decompressRioValidateEnd(decompressRio *dr);
 /* Destroy the adapter without additional I/O. */
 void decompressRioDestroy(decompressRio *dr);
 

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -6,7 +6,6 @@
 
 #include "compression_stream.h"
 #include "zmalloc.h"
-#include <assert.h>
 #include <limits.h>
 #include <string.h>
 
@@ -147,15 +146,17 @@ static int readVkcsEnvelope(const uint8_t *buf,
     return 0;
 }
 
-static int readVkcsEnvelopeInfo(const uint8_t *buf,
-                                uint8_t expected_stream_kind,
-                                streamReaderInfo *info) {
+int streamReadEnvelopeInfo(const uint8_t *buf,
+                           size_t len,
+                           uint8_t expected_stream_kind,
+                           streamReaderInfo *info) {
     vkcsCodec codec;
     uint8_t stream_kind = 0;
     bool codec_checksum_enabled = false;
     compressionAlgo algo = ALGO_NONE;
 
-    if (readVkcsEnvelope(buf, VKCS_ENVELOPE_SIZE,
+    if (!info || len < VKCS_ENVELOPE_SIZE ||
+        readVkcsEnvelope(buf, len,
                          &codec, &stream_kind, &codec_checksum_enabled) != 0 ||
         stream_kind != expected_stream_kind ||
         vkcsCodecToCompressionAlgo(codec, &algo) != 0) {
@@ -211,7 +212,8 @@ static vkcsProbeResult vkcsProbeFeed(vkcsProbe *probe,
         if (probe->header_len == VKCS_ENVELOPE_SIZE) {
             streamReaderInfo info = {0};
 
-            if (readVkcsEnvelopeInfo(probe->header, cfg->expected_stream_kind, &info) != 0) {
+            if (streamReadEnvelopeInfo(probe->header, VKCS_ENVELOPE_SIZE,
+                                       cfg->expected_stream_kind, &info) != 0) {
                 *src_consumed = consumed;
                 return VKCS_PROBE_ERROR;
             }
@@ -304,15 +306,17 @@ static int streamWriterEmit(streamWriter *t, const uint8_t *buf, size_t len) {
 /* Ensure the output buffer is large enough for the given input.
  * Reuses the existing buffer when possible to avoid per-write allocation.
  * zmalloc aborts on OOM, so this cannot fail. */
-static void streamWriterEnsureOutBuf(streamWriter *t, size_t input_len) {
+static int streamWriterEnsureOutBuf(streamWriter *t, size_t input_len) {
     size_t needed = streamCompressOutputBound(&t->compressor, input_len);
-    /* A zero bound means the compressor is in an invalid state (NULL or no
-     * codec). The caller should have failed before reaching this point. */
-    assert(needed > 0);
+    if (needed == 0) {
+        t->errored = true;
+        return -1;
+    }
     if (needed > t->out_buf_size) {
         t->out_buf = zrealloc(t->out_buf, needed);
         t->out_buf_size = needed;
     }
+    return 0;
 }
 
 /* Compress one chunk with the requested flush mode and emit produced bytes.
@@ -321,7 +325,7 @@ static int streamWriterFeedAndEmit(streamWriter *t,
                                    const uint8_t *input,
                                    size_t input_len,
                                    compressFlushMode flush_mode) {
-    streamWriterEnsureOutBuf(t, input_len);
+    if (streamWriterEnsureOutBuf(t, input_len) != 0) return -1;
 
     ssize_t compressed = streamCompressFeed(&t->compressor, t->out_buf,
                                             t->out_buf_size,
@@ -552,10 +556,6 @@ int streamReaderProbe(streamReader *t) {
             streamReaderSetError(t, STREAM_READER_ERROR_INCOMPATIBLE);
             return -1;
         }
-        if (consumed != (size_t)(got > 0 ? got : 0)) {
-            streamReaderSetError(t, STREAM_READER_ERROR_IO);
-            return -1;
-        }
         if (status == VKCS_PROBE_NEED_INPUT) continue;
         if (status == VKCS_PROBE_COMPRESSED &&
             !t->decompressor_initialized &&
@@ -772,6 +772,39 @@ int streamReaderGetInfo(streamReader *t, streamReaderInfo *info) {
 
 streamReaderError streamReaderGetError(const streamReader *t) {
     return t ? t->error_kind : STREAM_READER_ERROR_IO;
+}
+
+int streamReaderValidateEnd(streamReader *t) {
+    uint8_t buf[4096];
+
+    if (!t) return -1;
+    if (streamReaderProbe(t) != 0) return -1;
+    if (!t->probe.compressed) return 0;
+
+    while (!streamDecompressorFrameDone(&t->decompressor)) {
+        ssize_t nread = streamReaderRead(t, buf, sizeof(buf));
+        if (nread < 0) return -1;
+        if (nread > 0) {
+            streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+            return -1;
+        }
+    }
+
+    if (t->compressed_buf_len > 0) {
+        streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+        return -1;
+    }
+
+    ssize_t got = t->read_cb(t->read_ctx, buf, 1);
+    if (got < 0) {
+        streamReaderSetError(t, STREAM_READER_ERROR_IO);
+        return -1;
+    }
+    if (got > 0) {
+        streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+        return -1;
+    }
+    return 0;
 }
 
 void streamReaderDestroy(streamReader *t) {

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -106,6 +106,10 @@ void streamWriterDestroy(streamWriter *t);
  * (for example via waitForClientIO-equivalent quiesce). */
 int streamWriterIsErrored(const streamWriter *t);
 void streamWriterSetError(streamWriter *t);
+int streamReadEnvelopeInfo(const uint8_t *buf,
+                           size_t len,
+                           uint8_t expected_stream_kind,
+                           streamReaderInfo *info);
 
 /* Streaming reader API.
  * Ownership: returned context is owned by caller and must be destroyed. */
@@ -128,6 +132,7 @@ ssize_t streamReaderRead(streamReader *t, void *buf, size_t len);
  * Returns 0 on success, -1 on error. */
 int streamReaderGetInfo(streamReader *t, streamReaderInfo *info);
 streamReaderError streamReaderGetError(const streamReader *t);
+int streamReaderValidateEnd(streamReader *t);
 void streamReaderDestroy(streamReader *t);
 
 #endif /* COMPRESSION_STREAM_H */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1612,7 +1612,9 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
         save_rio = (rio *)&cr;
         cr_initialized = true;
     }
-    if (!server.rdb_checksum) {
+    /* Streaming-compressed RDBs rely on codec checksums and clean frame-end
+     * validation instead of the logical RDB CRC64 trailer. */
+    if (use_streaming_compression || !server.rdb_checksum) {
         save_rio->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
         save_rio->update_cksum = NULL;
         save_rio->cksum = 0;
@@ -3165,6 +3167,9 @@ decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
     if (init_rc == DECOMPRESS_RIO_INIT_OK) {
         input->initialized = true;
         input->rdb_rio = (rio *)&input->decompressor;
+        /* Streaming compression validates the encoded frame; avoid also
+         * hashing decoded logical RDB bytes with CRC64. */
+        if (input->stream_info.compressed) input->rdb_rio->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
     }
     return init_rc;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1493,9 +1493,7 @@ int rdbSaveRio(int req, int rdbver, rio *rdb, int *error, int rdbflags, rdbSaveI
     long key_counter = 0;
     int j;
 
-    /* Track the RDB checksum whenever checksums are enabled and codec
-     * checksums are not the authoritative integrity mechanism. */
-    if (server.rdb_checksum && !(rdb->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM))
+    if (server.rdb_checksum && !(rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM))
         rdb->update_cksum = rioGenericUpdateChecksum;
     const char *magic_prefix = rdbUseValkeyMagic(rdbver) ? "VALKEY" : "REDIS0";
     serverAssert(rdbver >= 0 && rdbver <= RDB_VERSION);
@@ -3117,9 +3115,7 @@ void stopSaving(int success) {
 /* Track loading progress in order to serve client's from time to time
    and if needed calculate rdb checksum  */
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
-    /* Track the RDB checksum only when codec checksums are not authoritative
-     * for this stream. */
-    if (server.rdb_checksum && !(r->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM))
+    if (server.rdb_checksum && !(r->flags & RIO_FLAG_SKIP_RDB_CHECKSUM))
         rioGenericUpdateChecksum(r, buf, len);
 
     /* Event scheduling uses decoded (logical) bytes so that
@@ -3180,6 +3176,11 @@ void rdbInputStreamDestroy(rdbInputStream *input) {
         input->initialized = false;
     }
     input->rdb_rio = input->raw_rio;
+}
+
+int rdbInputStreamValidateEnd(rdbInputStream *input) {
+    if (!input || !input->initialized) return C_OK;
+    return decompressRioValidateEnd(&input->decompressor) == 0 ? C_OK : C_ERR;
 }
 
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
@@ -3682,10 +3683,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         if (rioRead(rdb, &cksum, 8) == 0) goto eoferr;
         if (server.rdb_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
-            if (rdb->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) {
-                serverLog(LL_NOTICE,
-                          "Streaming-compressed RDB: integrity validated by codec checksums.");
-            } else if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
+            if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
                 serverLog(LL_NOTICE, "RDB file was saved with checksum disabled: skipped checksum for this transfer");
             } else if (cksum == 0) {
                 serverLog(LL_NOTICE, "RDB file was saved with checksum disabled: no check performed.");
@@ -3769,6 +3767,10 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     }
 
     retval = rdbLoadRio(input.rdb_rio, rdbflags, rsi);
+    if (retval == RDB_OK && rdbInputStreamValidateEnd(&input) != C_OK) {
+        serverLog(LL_WARNING, "Compressed RDB stream in %s did not end cleanly", filename);
+        retval = RDB_FAILED;
+    }
 
 done:
     rdbInputStreamDestroy(&input);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -245,6 +245,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtxScopedRdb(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
 void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
 decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input);
+int rdbInputStreamValidateEnd(rdbInputStream *input);
 void rdbInputStreamDestroy(rdbInputStream *input);
 bool rdbRioHasCorruptCompressedInput(const rio *rdb);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, sds *err);

--- a/src/rio.c
+++ b/src/rio.c
@@ -76,7 +76,10 @@ static size_t rioBufferRead(rio *r, void *buf, size_t len) {
 
 /* Partial-read variant: returns bytes read (may be less than len), 0 on EOF. */
 static ssize_t rioBufferReadSome(rio *r, void *buf, size_t len) {
-    size_t avail = sdslen(r->io.buffer.ptr) - r->io.buffer.pos;
+    size_t buflen = sdslen(r->io.buffer.ptr);
+    if (r->io.buffer.pos < 0 || (size_t)r->io.buffer.pos >= buflen) return 0;
+
+    size_t avail = buflen - (size_t)r->io.buffer.pos;
     if (avail == 0) return 0;
 
     size_t got = avail < len ? avail : len;

--- a/src/rio.h
+++ b/src/rio.h
@@ -42,9 +42,8 @@
 #define RIO_FLAG_WRITE_ERROR (1 << 1)
 #define RIO_FLAG_CLOSE_ASAP (1 << 2) /* Rio was closed asynchronously during the current rio operation. */
 #define RIO_FLAG_SKIP_RDB_CHECKSUM (1 << 3)
-#define RIO_FLAG_STREAMING_COMPRESSION (1 << 4)    /* Streaming compression active — skip per-string LZF */
-#define RIO_FLAG_STREAMING_DECOMPRESSION (1 << 5)  /* rio is a stream decompression adapter */
-#define RIO_FLAG_STREAMING_CODEC_CHECKSUM (1 << 6) /* Streaming frame integrity checks are authoritative */
+#define RIO_FLAG_STREAMING_COMPRESSION (1 << 4)   /* Streaming compression active — skip per-string LZF */
+#define RIO_FLAG_STREAMING_DECOMPRESSION (1 << 5) /* rio is a stream decompression adapter */
 
 #define RIO_TYPE_FILE (1 << 0)
 #define RIO_TYPE_BUFFER (1 << 1)

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -928,6 +928,59 @@ TEST(compression, streamWriterCodecChecksumToggle) {
     }
 }
 
+TEST(compression, streamReaderValidateEndAcceptsClosedFrame) {
+    const char *payload = "validate frame end payload";
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL);
+    ASSERT_TRUE(streamWriterWrite(w, payload, strlen(payload)) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+
+    mem_reader_t reader_ctx = {db.data, sdslen((const char *)db.data), 0, 7};
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
+    ASSERT_TRUE(reader != NULL);
+
+    char out[64];
+    ASSERT_TRUE(streamReaderRead(reader, out, strlen(payload)) == (ssize_t)strlen(payload));
+    ASSERT_TRUE(memcmp(out, payload, strlen(payload)) == 0);
+    ASSERT_TRUE(streamReaderValidateEnd(reader) == 0);
+
+    streamReaderDestroy(reader);
+    streamWriterDestroy(w);
+    dynamicBufFree(&db);
+}
+
+TEST(compression, streamReaderValidateEndRejectsTrailingBytes) {
+    const char *payload = "payload with trailing compressed bytes";
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL);
+    ASSERT_TRUE(streamWriterWrite(w, payload, strlen(payload)) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    db.data = (uint8_t *)sdscatlen((sds)db.data, "x", 1);
+
+    mem_reader_t reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
+    ASSERT_TRUE(reader != NULL);
+
+    char out[64];
+    ASSERT_TRUE(streamReaderRead(reader, out, strlen(payload)) == (ssize_t)strlen(payload));
+    ASSERT_TRUE(streamReaderValidateEnd(reader) == -1);
+    ASSERT_TRUE(streamReaderGetError(reader) == STREAM_READER_ERROR_CORRUPT);
+
+    streamReaderDestroy(reader);
+    streamWriterDestroy(w);
+    dynamicBufFree(&db);
+}
+
 /* --- Test: compressRio write + finish round-trip --- */
 TEST(compression, compressRioRoundTrip) {
     /* Use a buffer rio as the inner rio */
@@ -989,7 +1042,7 @@ TEST(compression, compressRioRoundTrip) {
     return;
 }
 
-TEST(compression, compressRioTracksUncompressedChecksum) {
+TEST(compression, compressRioDoesNotInstallRdbChecksum) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
@@ -997,14 +1050,13 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_TRUE(cr.base.update_cksum == NULL);
 
     const char *payload = "checksum-payload-for-compressed-rio";
     size_t payload_len = strlen(payload);
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, payload_len) != 0);
 
-    rio expected = {};
-    rioGenericUpdateChecksum(&expected, payload, payload_len);
-    ASSERT_TRUE(cr.base.cksum == expected.cksum) << "compress_rio should track the checksum of uncompressed bytes";
+    ASSERT_TRUE(cr.base.cksum == 0) << "compress_rio should not own RDB checksum policy";
 
     ASSERT_TRUE(compressRioFinish(&cr) == 0);
     compressRioDestroy(&cr);
@@ -1012,7 +1064,7 @@ TEST(compression, compressRioTracksUncompressedChecksum) {
     return;
 }
 
-TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
+TEST(compression, compressRioDoesNotCopyRdbChecksumFlags) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
@@ -1021,11 +1073,11 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
-    ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0);
+    ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) == 0);
 
     const char *payload = "skip-checksum-payload";
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
-    ASSERT_TRUE(cr.base.cksum == 0) << "skip-checksum should disable uncompressed RDB checksum tracking";
+    ASSERT_TRUE(cr.base.cksum == 0) << "compress_rio should not inspect RDB checksum flags";
 
     ASSERT_TRUE(compressRioFinish(&cr) == 0);
     compressRioDestroy(&cr);
@@ -1033,7 +1085,7 @@ TEST(compression, compressRioPreservesSkipRdbChecksumFlag) {
     return;
 }
 
-TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) {
+TEST(compression, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
@@ -1041,12 +1093,11 @@ TEST(compression, compressRioUsesCodecChecksumsInsteadOfRdbChecksumWhenEnabled) 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
-    ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) != 0);
 
     const char *payload = "codec-checksum-enabled";
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
     ASSERT_TRUE(cr.base.cksum == 0)
-        << "codec checksums should disable standard RDB checksum tracking for compressed RDB";
+        << "codec checksums should not control standard RDB checksum tracking";
 
     ASSERT_TRUE(compressRioFinish(&cr) == 0);
     compressRioDestroy(&cr);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -460,16 +460,6 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
 
 extern "C" {
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
-typedef struct {
-    rio *raw_rio;
-    rio *rdb_rio;
-    decompressRio decompressor;
-    streamReaderInfo stream_info;
-    bool initialized;
-} rdbInputStream;
-void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
-decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input);
-void rdbInputStreamDestroy(rdbInputStream *input);
 }
 
 /* --- Emit callback that appends to a dynamically growing buffer --- */
@@ -1247,47 +1237,6 @@ TEST(compression, decompressRioClassifiesInput) {
         sdsfree(buf);
     }
     return;
-}
-
-TEST(compression, rdbInputStreamSkipsRdbChecksumForCompressedStreams) {
-    dynamic_buf_t db;
-    dynamicBufInit(&db);
-
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
-    streamWriter *writer = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(writer != NULL);
-    const char *payload = "VALKEY001compressed logical rdb payload";
-    ASSERT_TRUE(streamWriterWrite(writer, payload, strlen(payload)) >= 0);
-    ASSERT_TRUE(streamWriterFinish(writer) == 0);
-    streamWriterDestroy(writer);
-
-    sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
-    rio comp_rio;
-    rioInitWithBuffer(&comp_rio, comp);
-    rdbInputStream compressed_input;
-    rdbInputStreamInit(&compressed_input, &comp_rio);
-
-    ASSERT_TRUE(rdbInputStreamPrepare(&compressed_input) == DECOMPRESS_RIO_INIT_OK);
-    ASSERT_TRUE(compressed_input.stream_info.compressed);
-    ASSERT_TRUE(compressed_input.rdb_rio->flags & RIO_FLAG_SKIP_RDB_CHECKSUM)
-        << "streaming-compressed RDB input should not compute logical RDB CRC64";
-    rdbInputStreamDestroy(&compressed_input);
-    sdsfree(comp);
-
-    sds plain = sdsnew("VALKEY001plain logical rdb payload");
-    rio plain_rio;
-    rioInitWithBuffer(&plain_rio, plain);
-    rdbInputStream plain_input;
-    rdbInputStreamInit(&plain_input, &plain_rio);
-
-    ASSERT_TRUE(rdbInputStreamPrepare(&plain_input) == DECOMPRESS_RIO_INIT_OK);
-    ASSERT_TRUE(!plain_input.stream_info.compressed);
-    ASSERT_TRUE((plain_input.rdb_rio->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) == 0)
-        << "plain RDB input should keep the normal RDB checksum policy";
-    rdbInputStreamDestroy(&plain_input);
-    sdsfree(plain);
-
-    dynamicBufFree(&db);
 }
 
 /* --- Test: compressRioFinish is idempotent --- */

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -460,6 +460,16 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
 
 extern "C" {
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
+typedef struct {
+    rio *raw_rio;
+    rio *rdb_rio;
+    decompressRio decompressor;
+    streamReaderInfo stream_info;
+    bool initialized;
+} rdbInputStream;
+void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
+decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input);
+void rdbInputStreamDestroy(rdbInputStream *input);
 }
 
 /* --- Emit callback that appends to a dynamically growing buffer --- */
@@ -1237,6 +1247,47 @@ TEST(compression, decompressRioClassifiesInput) {
         sdsfree(buf);
     }
     return;
+}
+
+TEST(compression, rdbInputStreamSkipsRdbChecksumForCompressedStreams) {
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    streamWriter *writer = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(writer != NULL);
+    const char *payload = "VALKEY001compressed logical rdb payload";
+    ASSERT_TRUE(streamWriterWrite(writer, payload, strlen(payload)) >= 0);
+    ASSERT_TRUE(streamWriterFinish(writer) == 0);
+    streamWriterDestroy(writer);
+
+    sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
+    rio comp_rio;
+    rioInitWithBuffer(&comp_rio, comp);
+    rdbInputStream compressed_input;
+    rdbInputStreamInit(&compressed_input, &comp_rio);
+
+    ASSERT_TRUE(rdbInputStreamPrepare(&compressed_input) == DECOMPRESS_RIO_INIT_OK);
+    ASSERT_TRUE(compressed_input.stream_info.compressed);
+    ASSERT_TRUE(compressed_input.rdb_rio->flags & RIO_FLAG_SKIP_RDB_CHECKSUM)
+        << "streaming-compressed RDB input should not compute logical RDB CRC64";
+    rdbInputStreamDestroy(&compressed_input);
+    sdsfree(comp);
+
+    sds plain = sdsnew("VALKEY001plain logical rdb payload");
+    rio plain_rio;
+    rioInitWithBuffer(&plain_rio, plain);
+    rdbInputStream plain_input;
+    rdbInputStreamInit(&plain_input, &plain_rio);
+
+    ASSERT_TRUE(rdbInputStreamPrepare(&plain_input) == DECOMPRESS_RIO_INIT_OK);
+    ASSERT_TRUE(!plain_input.stream_info.compressed);
+    ASSERT_TRUE((plain_input.rdb_rio->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) == 0)
+        << "plain RDB input should keep the normal RDB checksum policy";
+    rdbInputStreamDestroy(&plain_input);
+    sdsfree(plain);
+
+    dynamicBufFree(&db);
 }
 
 /* --- Test: compressRioFinish is idempotent --- */

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -839,9 +839,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         rdbstate.doing = RDB_CHECK_DOING_CHECK_SUM;
         if (rioRead(rdb, &cksum, 8) == 0) goto eoferr;
         memrev64ifbe(&cksum);
-        if (rdb->flags & RIO_FLAG_STREAMING_CODEC_CHECKSUM) {
-            rdbCheckInfo("Streaming-compressed RDB: integrity validated by codec checksums.");
-        } else if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
+        if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
             rdbCheckInfo("RDB file was saved with checksum disabled: skipped checksum for this transfer.");
         } else if (cksum == 0) {
             rdbCheckInfo("RDB file was saved with checksum disabled: no check performed.");
@@ -851,6 +849,11 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         } else {
             rdbCheckInfo("Checksum OK");
         }
+    }
+
+    if (rdbInputStreamValidateEnd(&input) != C_OK) {
+        rdbCheckError("Compressed RDB stream did not end cleanly");
+        goto err;
     }
 
     rdbInputStreamDestroy(&input);

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -226,7 +226,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
     }
 
-    test {LZ4 compressed RDB with rdb-checksum yes sets the VKCS codec checksum flag} {
+    test {LZ4 compressed RDB with rdbchecksum yes sets the VKCS codec checksum flag} {
         r config set rdbcompression yes
         r config set rdb-compression-algo lz4
         r flushall
@@ -403,7 +403,7 @@ start_server {config "minimal.conf" args {"--rdb-compression-algo lz4"}} {
 }
 
 start_server {overrides {save "" enable-debug-command local rdbchecksum no}} {
-    test {LZ4 compressed RDB with rdb-checksum no leaves VKCS flags clear and loads correctly} {
+    test {LZ4 compressed RDB with rdbchecksum no leaves VKCS flags clear and loads correctly} {
         r config set rdbcompression yes
         r config set rdb-compression-algo lz4
         r flushall

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -61,7 +61,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
                 exec $::VALKEY_CHECK_RDB_BIN $dump_rdb
             } result
             assert_match {*RDB looks OK!*} $result
-            assert_match {*Streaming-compressed RDB: integrity validated by codec checksums.*} $result
+            assert_match {*Checksum OK*} $result
 
             # Keep subsequent tests on default path unless they explicitly change it.
             r config set rdb-compression-algo lzf

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -49,7 +49,7 @@ tags {"check-rdb external:skip logreqres:skip"} {
 
 tags {"check-rdb network external:skip logreqres:skip"} {
     start_server {} {
-        test "test valkey-check-rdb validates LZ4-compressed RDB" {
+        test "test valkey-check-rdb validates LZ4-compressed RDB frame" {
             r flushall
             r config set rdbcompression yes
             r config set rdb-compression-algo lz4
@@ -61,7 +61,8 @@ tags {"check-rdb network external:skip logreqres:skip"} {
                 exec $::VALKEY_CHECK_RDB_BIN $dump_rdb
             } result
             assert_match {*RDB looks OK!*} $result
-            assert_match {*Checksum OK*} $result
+            assert_match {*RDB file was saved with checksum disabled: skipped checksum for this transfer.*} $result
+            assert_no_match {*Checksum OK*} $result
 
             # Keep subsequent tests on default path unless they explicitly change it.
             r config set rdb-compression-algo lzf
@@ -174,7 +175,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             catch {
                 exec $::VALKEY_CHECK_RDB_BIN $dump_rdb
             } result
-            assert_match {*RDB file was saved with checksum disabled: no check performed.*} $result
+            assert_match {*RDB file was saved with checksum disabled: skipped checksum for this transfer.*} $result
             assert_match {*RDB looks OK!*} $result
 
             r config set rdb-compression-algo lzf


### PR DESCRIPTION
## Summary
- keep compression checksum state inside the compression layer instead of exposing it as a rio flag
- remove the temporary compression checksum config surface and let the RDB save caller choose the codec checksum setting
- validate compressed stream termination on load/check paths and tighten VKCS envelope validation
- leave LZ4 block size/mode defaults unchanged while adding the requested defensive fixes

## Validation
- make -C src/unit valkey-unit-gtests && ./src/unit/valkey-unit-gtests --gtest_filter='compression.*'
- make -C src
- ./runtest --single tests/integration/rdb-compression.tcl
- ./runtest --single tests/integration/valkey-check-rdb.tcl
- git diff --check origin/streaming-compression-rio-pr...HEAD