### PR TITLE
[Backport 9.0] fix LTO compilation warning in eval

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -241,7 +241,9 @@ int evalExtractShebangFlags(sds body,
         }
 
         if (out_engine) {
-            uint32_t engine_name_len = sdslen(parts[0]) - 2;
+            size_t part0_len = sdslen(parts[0]);
+            serverAssert(part0_len >= 2);
+            size_t engine_name_len = part0_len - 2;
             *out_engine = zcalloc(engine_name_len + 1);
             valkey_strlcpy(*out_engine, parts[0] + 2, engine_name_len + 1);
         }


### PR DESCRIPTION
## Backport Summary

Cherry-pick encountered conflicts and the conflicted files were resolved automatically.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3584` |
| Source title | fix LTO compilation warning in eval |
| Target branch | `9.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | yes |
| Auto-resolved files | 1 |
| Unresolved files | 0 |
| Risk level | `high` |

### Backport Risk

- Level: `high`
- Signals:
  - cherry-pick required conflict resolution
  - 1 file(s) were auto-resolved
  - target branch `9.0` is an older release line
- Touched paths: unknown

### Reviewer Checklist

- Compare this backport against the source PR before merge.
- Run subsystem-focused tests before merge; this backport has high-risk signals.
- Review the automatically resolved files carefully for semantic drift.

### Cherry-Picked Commits

- `88303babb8384ed7bff95c3806452be3d21662b1`

### Conflict Details

- `src/eval.c`: Resolved automatically. resolved by Claude Code

### Human Review Required

Some conflicts in this backport were resolved using an LLM. These resolutions require careful human review to ensure correctness. Please verify that the resolved code matches the intent of the original pull request.