### PR TITLE
[Backport 9.0] Fix: prevent NULL dereference crash in connectSlotExportJob when target node disappears

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1300,6 +1300,13 @@ void slotExportConnectHandler(connection *conn) {
  * the job as private data. */
 int connectSlotExportJob(slotMigrationJob *job) {
     clusterNode *n = clusterLookupNode(job->target_node_name, CLUSTER_NAMELEN);
+    if (n == NULL) {
+        serverLog(LL_WARNING,
+                  "Slot migration %s: target node %.40s not found in cluster, "
+                  "aborting connection attempt.",
+                  job->description, job->target_node_name);
+        return C_ERR;
+    }
     int port = getNodeDefaultReplicationPort(n);
     serverLog(LL_NOTICE, "Connecting slot migration %s (ip: %s, port %d)",
               job->description,
@@ -1993,10 +2000,11 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                 status = proceedWithSlotExportJobConnecting(job, &completed);
             }
             if (status == C_ERR) {
+                const char *conn_err = job->conn ? connGetLastError(job->conn) : "target node not found";
                 sds status_msg =
                     sdscatfmt(sdsempty(),
                               "Unable to connect to target node: %s",
-                              connGetLastError(job->conn));
+                              conn_err);
                 finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                        status_msg);
                 sdsfree(status_msg);


### PR DESCRIPTION
## Backport Summary

Cherry-pick applied cleanly with no conflicts.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3596` |
| Source title | Fix: prevent NULL dereference crash in connectSlotExportJob when target node disappears |
| Target branch | `9.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | no |
| Auto-resolved files | 0 |
| Unresolved files | 0 |
| Risk level | `high` |

### Backport Risk

- Level: `high`
- Signals:
  - target branch `9.0` is an older release line
  - touches cluster, replication, persistence, module, or server core code
- Touched paths: src/cluster_migrateslots.c

### Reviewer Checklist

- Compare this backport against the source PR before merge.
- Run subsystem-focused tests before merge; this backport has high-risk signals.

### Cherry-Picked Commits

- `bca3cbd9b1a9ead52bf1040a6b6beed8542ed62f`