### PR TITLE
[Backport 9.0] Fix FD leak in connSocketBlockingConnect on timeout

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -374,13 +374,14 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
         return C_ERR;
     }
 
+    conn->fd = fd;
+
     if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
         conn->state = CONN_STATE_ERROR;
         conn->last_errno = ETIMEDOUT;
         return C_ERR;
     }
 
-    conn->fd = fd;
     conn->state = CONN_STATE_CONNECTED;
     return C_OK;
 }


### PR DESCRIPTION
## Backport Summary

Cherry-pick applied cleanly with no conflicts.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3541` |
| Source title | Fix FD leak in connSocketBlockingConnect on timeout |
| Target branch | `9.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | no |
| Auto-resolved files | 0 |
| Unresolved files | 0 |
| Risk level | `medium` |

### Backport Risk

- Level: `medium`
- Signals:
  - target branch `9.0` is an older release line
  - touches source, dependency, CI, or integration-test code
- Touched paths: src/socket.c

### Reviewer Checklist

- Compare this backport against the source PR before merge.

### Cherry-Picked Commits

- `747483586ec62d7948af4e6ba7c43c57f9014f29`