### PR TITLE
[backport] Weekly backport sweep for 9.1

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1303,6 +1303,13 @@ void slotExportConnectHandler(connection *conn) {
  * the job as private data. */
 int connectSlotExportJob(slotMigrationJob *job) {
     clusterNode *n = clusterLookupNode(job->target_node_name, CLUSTER_NAMELEN);
+    if (n == NULL) {
+        serverLog(LL_WARNING,
+                  "Slot migration %s: target node %.40s not found in cluster, "
+                  "aborting connection attempt.",
+                  job->description, job->target_node_name);
+        return C_ERR;
+    }
     int port = getNodeDefaultReplicationPort(n);
     serverLog(LL_NOTICE, "Connecting slot migration %s (ip: %s, port %d)",
               job->description,
@@ -1995,10 +2002,11 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                 status = proceedWithSlotExportJobConnecting(job, &completed);
             }
             if (status == C_ERR) {
+                const char *conn_err = job->conn ? connGetLastError(job->conn) : "target node not found";
                 sds status_msg =
                     sdscatfmt(sdsempty(),
                               "Unable to connect to target node: %s",
-                              connGetLastError(job->conn));
+                              conn_err);
                 finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                        status_msg);
                 sdsfree(status_msg);

--- a/src/geo.c
+++ b/src/geo.c
@@ -580,6 +580,8 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
     long long count = 0; /* Max number of results to return. 0 means unlimited. */
     if (c->argc > base_args) {
         int remaining = c->argc - base_args;
+        /* Call geoPolygonPointsFree() from error paths even when it may be a
+         * no-op, so cleanup stays safe if option parsing order changes. */
         for (int i = 0; i < remaining; i++) {
             char *arg = objectGetVal(c->argv[base_args + i]);
             if (!strcasecmp(arg, "withdist")) {
@@ -595,9 +597,13 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
             } else if (!strcasecmp(arg, "desc")) {
                 sort = SORT_DESC;
             } else if (!strcasecmp(arg, "count") && (i + 1) < remaining) {
-                if (getLongLongFromObjectOrReply(c, c->argv[base_args + i + 1], &count, NULL) != C_OK) return;
+                if (getLongLongFromObjectOrReply(c, c->argv[base_args + i + 1], &count, NULL) != C_OK) {
+                    geoPolygonPointsFree(&shape);
+                    return;
+                }
                 if (count <= 0) {
                     addReplyError(c, "COUNT must be > 0");
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 i++;
@@ -622,50 +628,60 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
                 }
                 robj *member = c->argv[base_args + i + 1];
                 if (longLatFromMemberOrReply(c, zobj, member, shape.xy) == C_ERR) {
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 frommember = 1;
                 i++;
             } else if (!strcasecmp(arg, "fromlonlat") && (i + 2) < remaining && flags & GEOSEARCH && !frommember && !bypolygon) {
-                if (extractLongLatOrReply(c, c->argv + base_args + i + 1, shape.xy) == C_ERR) return;
+                if (extractLongLatOrReply(c, c->argv + base_args + i + 1, shape.xy) == C_ERR) {
+                    geoPolygonPointsFree(&shape);
+                    return;
+                }
                 fromloc = 1;
                 i += 2;
             } else if (!strcasecmp(arg, "byradius") && (i + 2) < remaining && flags & GEOSEARCH && !bybox && !bypolygon) {
-                if (extractDistanceOrReply(c, c->argv + base_args + i + 1, &shape.conversion, &shape.t.radius) != C_OK)
+                if (extractDistanceOrReply(c, c->argv + base_args + i + 1, &shape.conversion, &shape.t.radius) != C_OK) {
+                    geoPolygonPointsFree(&shape);
                     return;
+                }
                 shape.type = CIRCULAR_TYPE;
                 byradius = 1;
                 i += 2;
             } else if (!strcasecmp(arg, "bybox") && (i + 3) < remaining && flags & GEOSEARCH && !byradius && !bypolygon) {
                 if (extractBoxOrReply(c, c->argv + base_args + i + 1, &shape.conversion, &shape.t.r.width,
-                                      &shape.t.r.height) != C_OK)
+                                      &shape.t.r.height) != C_OK) {
+                    geoPolygonPointsFree(&shape);
                     return;
+                }
                 shape.type = RECTANGLE_TYPE;
                 bybox = 1;
                 i += 3;
             } else if (!strcasecmp(arg, "bypolygon") && (i + 2) < remaining && flags & GEOSEARCH && !byradius && !bybox && !frommember && !fromloc) {
                 int num_vertices = 0;
                 if (getIntFromObjectOrReply(c, c->argv[base_args + i + 1], &num_vertices, "invalid number of vertices") != C_OK) {
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 /* Check how many args are remaining. Divide by 2 to see the possible number of vertices. */
                 int possible_vertices = (remaining - i - 2) / 2;
                 if (num_vertices < 3 || possible_vertices < num_vertices) {
                     addReplyError(c, "GEOSEARCH BYPOLYGON must have at least 3 vertices");
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 /* Extract polygon vertices. */
                 shape.conversion = 1;
                 shape.t.polygon.num_vertices = num_vertices;
                 shape.t.polygon.points = zmalloc(num_vertices * sizeof(double[2]));
+                shape.type = POLYGON_TYPE;
+                bypolygon = 1;
                 for (int j = 0; j < num_vertices * 2; j += 2) {
                     if (extractLongLatOrReply(c, c->argv + base_args + i + 2 + j, shape.t.polygon.points[j / 2]) == C_ERR) {
-                        zfree(shape.t.polygon.points);
+                        geoPolygonPointsFree(&shape);
                         return;
                     }
                 }
-                shape.type = POLYGON_TYPE;
-                bypolygon = 1;
                 i += (1 + num_vertices * 2);
             } else {
                 addReplyErrorObject(c, shared.syntaxerr);

--- a/src/module.c
+++ b/src/module.c
@@ -14634,7 +14634,7 @@ size_t moduleCount(void) {
  * servers's maxmemory policy is LFU based. Value is idle time in milliseconds.
  * returns VALKEYMODULE_OK if the LRU was updated, VALKEYMODULE_ERR otherwise. */
 int VM_SetLRU(ValkeyModuleKey *key, mstime_t lru_idle) {
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (objectSetLRUOrLFU(key->value, -1, lru_idle * 1000)) return VALKEYMODULE_OK;
     return VALKEYMODULE_ERR;
 }
@@ -14645,7 +14645,7 @@ int VM_SetLRU(ValkeyModuleKey *key, mstime_t lru_idle) {
  * returns VALKEYMODULE_OK if when key is valid. */
 int VM_GetLRU(ValkeyModuleKey *key, mstime_t *lru_idle) {
     *lru_idle = -1;
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) return VALKEYMODULE_OK;
     *lru_idle = objectGetLRUIdleSecs(key->value) * 1000;
     return VALKEYMODULE_OK;
@@ -14657,7 +14657,7 @@ int VM_GetLRU(ValkeyModuleKey *key, mstime_t *lru_idle) {
  * the access frequency (must be <= 255).
  * returns VALKEYMODULE_OK if the LFU was updated, VALKEYMODULE_ERR otherwise. */
 int VM_SetLFU(ValkeyModuleKey *key, long long lfu_freq) {
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (objectSetLRUOrLFU(key->value, lfu_freq, -1)) return VALKEYMODULE_OK;
     return VALKEYMODULE_ERR;
 }
@@ -14667,7 +14667,7 @@ int VM_SetLFU(ValkeyModuleKey *key, long long lfu_freq) {
  * returns VALKEYMODULE_OK if when key is valid. */
 int VM_GetLFU(ValkeyModuleKey *key, long long *lfu_freq) {
     *lfu_freq = -1;
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (lrulfu_isUsingLFU()) *lfu_freq = objectGetLFUFrequency(key->value);
     return VALKEYMODULE_OK;
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -391,15 +391,27 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
  */
 
 static ssize_t connSocketSyncWrite(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    return syncWrite(conn->fd, ptr, size, timeout);
+    ssize_t ret = syncWrite(conn->fd, ptr, size, timeout);
+    if (ret == -1) {
+        conn->last_errno = errno;
+    }
+    return ret;
 }
 
 static ssize_t connSocketSyncRead(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    return syncRead(conn->fd, ptr, size, timeout);
+    ssize_t ret = syncRead(conn->fd, ptr, size, timeout);
+    if (ret == -1) {
+        conn->last_errno = errno;
+    }
+    return ret;
 }
 
 static ssize_t connSocketSyncReadLine(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    return syncReadLine(conn->fd, ptr, size, timeout);
+    ssize_t ret = syncReadLine(conn->fd, ptr, size, timeout);
+    if (ret == -1) {
+        conn->last_errno = errno;
+    }
+    return ret;
 }
 
 static int connSocketGetType(void) {

--- a/src/syncio.c
+++ b/src/syncio.c
@@ -94,7 +94,10 @@ ssize_t syncRead(int fd, char *ptr, ssize_t size, long long timeout) {
         /* Optimistically try to read before checking if the file descriptor
          * is actually readable. At worst we get EAGAIN. */
         nread = read(fd, ptr, size);
-        if (nread == 0) return -1; /* short read. */
+        if (nread == 0) {
+            errno = ECONNRESET;
+            return -1;
+        }
         if (nread == -1) {
             if (errno != EAGAIN) return -1;
         } else {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -819,12 +819,12 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
             /* Mark the entry as deleted. */
             if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
-                intptr_t delta = p - lp;
+                ptrdiff_t delta = p ? p - lp : 0;
                 flags |= STREAM_ITEM_FLAG_DELETED;
                 lp = lpReplaceInteger(lp, &pcopy, flags);
+                if (p) p = lp + delta;
                 deleted_from_lp++;
                 s->length--;
-                p = lp + delta;
             }
         }
         deleted += deleted_from_lp;

--- a/src/tls.c
+++ b/src/tls.c
@@ -1677,6 +1677,9 @@ static ssize_t connTLSSyncWrite(connection *conn_, char *ptr, ssize_t size, long
         unsetBlockingTimeout(conn);
     }
 
+    if (ret < 0) {
+        conn->c.last_errno = errno;
+    }
     return ret;
 }
 
@@ -1692,6 +1695,9 @@ static ssize_t connTLSSyncRead(connection *conn_, char *ptr, ssize_t size, long 
         unsetBlockingTimeout(conn);
     }
 
+    if (ret < 0) {
+        conn->c.last_errno = errno;
+    }
     return ret;
 }
 
@@ -1728,6 +1734,9 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
 exit:
     if (!blocking) {
         unsetBlockingTimeout(conn);
+    }
+    if (nread < 0) {
+        conn->c.last_errno = errno;
     }
     return nread;
 }

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -4285,7 +4285,6 @@ static void clusterManagerOptimizeAntiAffinity(clusterManagerNodeArray *ipnodes,
                           "for anti-affinity\n");
     int node_len = cluster_manager.nodes->len;
     int maxiter = 500 * node_len; // Effort is proportional to cluster size...
-    srand(time(NULL));
     while (maxiter > 0) {
         int offending_len = 0;
         if (offenders != NULL) {
@@ -6204,7 +6203,6 @@ static clusterManagerNode *clusterManagerNodePrimaryRandom(void) {
     }
 
     assert(primary_count > 0);
-    srand(time(NULL));
     idx = rand() % primary_count;
     listRewind(cluster_manager.nodes, &li);
     while ((ln = listNext(&li)) != NULL) {
@@ -8961,8 +8959,6 @@ static void pipeMode(void) {
     char magic[20]; /* Special reply we recognize. */
     time_t last_read_time = time(NULL);
 
-    srand(time(NULL));
-
     /* Use non blocking I/O. */
     if (anetNonBlock(aneterr, context->fd) == ANET_ERR) {
         fprintf(stderr, "Can't set the socket in non blocking mode: %s\n", aneterr);
@@ -9816,7 +9812,6 @@ static void LRUTestMode(void) {
     long long start_cycle;
     int j;
 
-    srand(time(NULL) ^ getpid());
     while (1) {
         /* Perform cycles of 1 second with 50% writes and 50% reads.
          * We use pipelining batching writes / reads N times per cycle in order
@@ -10035,6 +10030,8 @@ void testHintSuite(char *filename) {
 int main(int argc, char **argv) {
     int firstarg;
     struct timeval tv;
+
+    srand(time(NULL) ^ getpid());
 
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));
     config.ct = VALKEY_CONN_TCP;

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -200,6 +200,7 @@ int test_getlru(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lru;
     ValkeyModule_GetLRU(key, &lru);
     ValkeyModule_ReplyWithLongLong(ctx, lru);
@@ -214,6 +215,7 @@ int test_setlru(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lru;
     if (ValkeyModule_StringToLongLong(argv[2], &lru) != VALKEYMODULE_OK) {
         ValkeyModule_ReplyWithError(ctx, "invalid idle time");
@@ -232,6 +234,7 @@ int test_getlfu(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lfu;
     ValkeyModule_GetLFU(key, &lfu);
     ValkeyModule_ReplyWithLongLong(ctx, lfu);
@@ -246,6 +249,7 @@ int test_setlfu(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lfu;
     if (ValkeyModule_StringToLongLong(argv[2], &lfu) != VALKEYMODULE_OK) {
         ValkeyModule_ReplyWithError(ctx, "invalid freq");

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -561,6 +561,18 @@ start_server {tags {"geo"}} {
         assert_equal {{1 0.0001} {2 9.8182}} [r GEORADIUS points -122.407107 37.794300 30 mi ASC WITHDIST]
     }
 
+    test {GEOSEARCH BYPOLYGON with invalid COUNT} {
+        r del points
+        r geoadd points 151.2093 -33.8688 "Sydney"
+
+        assert_error {ERR value is not an integer or out of range} {
+            r GEOSEARCH points BYPOLYGON 3 151.2039 -33.8744 151.2132 -33.8829 151.2229 -33.8839 COUNT notanumber
+        }
+        assert_error {ERR COUNT must be > 0} {
+            r GEOSEARCH points BYPOLYGON 3 151.2039 -33.8744 151.2132 -33.8829 151.2229 -33.8839 COUNT -1
+        }
+    }
+
     test {GEOSEARCH BYPOLYGON standard operations} {
         r geoadd points 151.20932132005692 -33.877723137822436 "146, Elizabeth Street, Koreatown, Sydney, Sydney CBD, Sydney, Council of the City of Sydney, New South Wales, 2000, Australia"
         r geoadd points 151.2119820713997 -33.87697539508043 "Connaught Centre, 187, Liverpool Street, Koreatown, Sydney, Sydney CBD, Sydney, Council of the City of Sydney, New South Wales, 2000, Australia"

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -83,6 +83,13 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
     }
     r config set maxmemory-policy allkeys-lru
 
+    test {test module lru/lfu api with nonexistent key} {
+        assert_error {*key not found*} {r test.getlru nonexistent_key}
+        assert_error {*key not found*} {r test.setlru nonexistent_key 100}
+        assert_error {*key not found*} {r test.getlfu nonexistent_key}
+        assert_error {*key not found*} {r test.setlfu nonexistent_key 100}
+    }
+
     test {test module lfu api} {
         r config set maxmemory-policy allkeys-lfu
         r set x foo

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -772,6 +772,35 @@ start_server {
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] == 0}
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 2] == 2}
     }
+
+    test {XTRIM MINID marking last entry in listpack as deleted} {
+        # Regression test: when XTRIM marks the last entry in a listpack
+        # node as deleted, the pointer past the lp-count field is NULL
+        # (EOF). The delta recalculation after lpReplaceInteger must
+        # handle this to avoid listpack corruption.
+        r del mystream
+        r config set stream-node-max-entries 3
+
+        # Add 4 entries: first 3 go into node 1, 4th into node 2.
+        r XADD mystream 1-0 f v
+        r XADD mystream 2-0 f v
+        r XADD mystream 3-0 f v
+        r XADD mystream 4-0 f v
+
+        # Exact MINID trim: marks entries 1-0 and 2-0 as deleted inside
+        # node 1. Entry 3-0 is the last entry in that node, so after
+        # skipping its lp-count the pointer hits EOF (NULL).
+        r XTRIM mystream MINID = 4-0
+
+        # Verify the stream is intact and XREAD works.
+        assert_equal [r XLEN mystream] 1
+        set result [r XRANGE mystream - +]
+        assert_equal $result {{4-0 {f v}}}
+        set result [r XREAD COUNT 10 STREAMS mystream 0-0]
+        assert_equal $result {{mystream {{4-0 {f v}}}}}
+
+        r config set stream-node-max-entries 100
+    }
 }
 
 start_server {tags {"stream needs:debug"} overrides {appendonly yes}} {


### PR DESCRIPTION
# Weekly backport sweep for 9.1

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| `#3568` | Fix GEOSEARCH BYPOLYGON leak on invalid COUNT |  |
| `#3580` | fix(syncio): Set errno on EOF in syncRead and propagate to conn->last… |  |
| `#3586` | fix(cluster): Remove per-call srand in clusterManagerNodePrimaryRandom | conflicts resolved by Claude Code |
| `#3591` | Handle NULL pointer in streamTrim listpack delta calculation |  |
| `#3596` | Fix: prevent NULL dereference crash in connectSlotExportJob when target node disappears |  |
| `#3610` | Fix SIGSEGV in VM_GetLRU/SetLRU/GetLFU/SetLFU on NULL key |  |

<details><summary>Skipped / unresolved (31)</summary>

| Source PR | Title | Reason |
|---|---|---|
| `#2227` | Do the failover immediately if the replica is the best ranked replica | skipped-existing: resolution was already satisfied on target branch |
| `#3122` | Adds new (hidden) ValkeyModule_CallArgv API functions | skipped-existing: resolution was already satisfied on target branch |
| `#2936` | Module command result callback addition | skipped-existing: resolution was already satisfied on target branch |
| `#2811` | Enhance cluster stale packet detection to prevent sub-replica and empty primary | skipped-existing: already applied or empty cherry-pick |
| `#3306` | Improve COB memory tracking with copy avoidance | skipped-existing: already applied or empty cherry-pick |
| `#3359` | Fix incorrect memory overhead calculation for watched keys | skipped-conflict: unresolved: src/multi.c |
| `#3368` | Make scripting debug test skippable | skipped-existing: already applied or empty cherry-pick |
| `#3372` | Add cluster-config-save-behavior option to control nodes.conf save behavior | skipped-existing: already applied or empty cherry-pick |
| `#3281` | Fix use zfree in cli --eval path  | skipped-existing: already applied or empty cherry-pick |
| `#3209` | Fix `valkey-cli --cluster del-node` for unreachable nodes | skipped-existing: already applied or empty cherry-pick |
| `#3392` | Add Static Module Support | skipped-conflict: unresolved: src/server.c |
| `#3033` | ARM NEON SIMD optimization for pvFind() in vset.c | skipped-existing: already applied or empty cherry-pick |
| `#3401` | Big endian bitmap byte order mismatch fix | skipped-existing: already applied or empty cherry-pick |
| `#3360` | Optimize WATCH duplicate key check from O(N) to O(1) using per-db hashtable | skipped-existing: already applied or empty cherry-pick |
| `#3443` | Fix slot-migration-max-failover-repl-bytes unable to accept -1 | skipped-existing: resolution was already satisfied on target branch |
| `#3420` | Avoid having server.h being included by cli and benchmark | skipped-existing: already applied or empty cherry-pick |
| `#3397` | Increase embedded string threshold from 64 to 128 bytes | skipped-existing: already applied or empty cherry-pick |
| `#3380` | CLUSTERSCAN MATCH pattern maps to a specific slot optimizations | skipped-existing: already applied or empty cherry-pick |
| `#3444` | Skip faster-failover test under TLS  | skipped-existing: resolution was already satisfied on target branch |
| `#3452` | Fix some flaky tests using CLIENT REPLY OFF | skipped-existing: already applied or empty cherry-pick |
| `#3461` | Attempt to deflake 'diskless no replicas drop during rdb pipe' | skipped-existing: resolution was already satisfied on target branch |
| `#3471` | Defer argument redaction by storing indices instead of rewriting argv | skipped-existing: already applied or empty cherry-pick |
| `#3440` | Fix config rewrite producing negative values for unsigned memory configs | skipped-existing: already applied or empty cherry-pick |
| `#3458` | Fix race condition during async client freeing with IO threading enabled | skipped-existing: already applied or empty cherry-pick |
| `#3498` | Fix double free in stream consumer PEL loading with corrupt RDB data | skipped-existing: already applied or empty cherry-pick |
| `#3495` | Rewrite the faster failover test case | skipped-existing: already applied or empty cherry-pick |
| `#3516` | Fix HPERSIST RESP protocol violation on wrong-type key | skipped-existing: already applied or empty cherry-pick |
| `#3541` | Fix FD leak in connSocketBlockingConnect on timeout | skipped-existing: already applied or empty cherry-pick |
| `#3548` | Fix lua-enable-insecure-api default value cannot be changed to yes | skipped-existing: already applied or empty cherry-pick |
| `#3554` | Ensure client slot migration pointer is cleared during reset | skipped-existing: already applied or empty cherry-pick |
| `#3503` | Fix remove cached eval scripts on engine unregister | skipped-existing: already applied or empty cherry-pick |

</details>

---
*Generated by valkey-ci-agent using Claude Code.*