### PR TITLE
[Backport 9.0] Fix CI latest fedora: install awk and tcl8, build tcltls from source

### DIFF
--- a/.github/actions/rpm-distros-tcl8/action.yml
+++ b/.github/actions/rpm-distros-tcl8/action.yml
@@ -1,0 +1,31 @@
+name: 'Install TCL8'
+description: 'Installs tcl8 and tcltls from source on Fedora-based or uses the system package on others.'
+
+inputs:
+  matrix_name:
+    description: 'The name of the matrix to check for fedora'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # Fedora 42 comes with Tcl 9 by default, but tcltls is currently incompatible with Tcl 9.
+    # As a workaround, we install Tcl 8 and manually build tcltls 1.7.22 from source.
+    # Once tcltls adds support for Tcl 9, this logic can be removed and system packages used instead.
+    - run: |
+        if [[ "${{ inputs.matrix_name }}" =~ "fedora" ]]; then
+          dnf -y install tcl8 tcl8-devel gcc make awk openssl openssl-devel
+          ln -s /usr/bin/tclsh8.6 /usr/bin/tclsh
+          curl -LO https://core.tcl-lang.org/tcltls/uv/tcltls-1.7.22.tar.gz
+          tar -xzf tcltls-1.7.22.tar.gz
+          pushd tcltls-1.7.22
+          ./configure --with-tcl=/usr/lib64/tcl8.6
+          make
+          mkdir -p /usr/lib64/tcl8.6/tls1.7.22
+          cp tcltls.so pkgIndex.tcl /usr/lib64/tcl8.6/tls1.7.22/
+          popd
+        else
+            dnf -y install tcl tcltls
+        fi
+        ./utils/gen-test-certs.sh
+      shell: bash

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -950,10 +950,12 @@ jobs:
         run: dnf -y install epel-release
       - name: make
         run: |
-          dnf -y install gcc make procps-ng which /usr/bin/kill /usr/bin/awk
+          dnf -y install gcc make procps-ng openssl-devel openssl which /usr/bin/kill /usr/bin/awk
           make -j SERVER_CFLAGS='-Werror'
       - name: testprep
-        run: dnf -y install tcl tcltls
+        uses: ./.github/actions/rpm-distros-tcl8
+        with:
+          matrix_name: ${{ matrix.name }}
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -1019,9 +1021,9 @@ jobs:
           dnf -y install make gcc openssl-devel openssl procps-ng which /usr/bin/kill /usr/bin/awk
           make -j BUILD_TLS=module SERVER_CFLAGS='-Werror'
       - name: testprep
-        run: |
-          dnf -y install tcl tcltls
-          ./utils/gen-test-certs.sh
+        uses: ./.github/actions/rpm-distros-tcl8
+        with:
+          matrix_name: ${{ matrix.name }}
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: |
@@ -1091,9 +1093,9 @@ jobs:
           dnf -y install make gcc openssl-devel openssl procps-ng which /usr/bin/kill /usr/bin/awk
           make -j BUILD_TLS=module SERVER_CFLAGS='-Werror'
       - name: testprep
-        run: |
-          dnf -y install tcl tcltls
-          ./utils/gen-test-certs.sh
+        uses: ./.github/actions/rpm-distros-tcl8
+        with:
+          matrix_name: ${{ matrix.name }}
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: |


### PR DESCRIPTION
## Backport Summary

Cherry-pick encountered conflicts and the conflicted files were resolved automatically.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/1965` |
| Source title | Fix CI latest fedora: install awk and tcl8, build tcltls from source |
| Target branch | `9.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | yes |
| Auto-resolved files | 1 |
| Unresolved files | 0 |
| Risk level | `high` |

### Backport Risk

- Level: `high`
- Signals:
  - cherry-pick required conflict resolution
  - 1 file(s) were auto-resolved
  - target branch `9.0` is an older release line
  - touches source, dependency, CI, or integration-test code
- Touched paths: .github/actions/rpm-distros-tcl8/action.yml, .github/workflows/daily.yml

### Reviewer Checklist

- Compare this backport against the source PR before merge.
- Run subsystem-focused tests before merge; this backport has high-risk signals.
- Review the automatically resolved files carefully for semantic drift.

### Cherry-Picked Commits

- `18408715a32c85807ad0ddc6ec70983b902c98b3`

### Conflict Details

- `.github/workflows/daily.yml`: Resolved automatically. resolved by Claude Code

### Human Review Required

Some conflicts in this backport were resolved using an LLM. These resolutions require careful human review to ensure correctness. Please verify that the resolved code matches the intent of the original pull request.