### PR TITLE
[Backport 8.1] Add null check in updateSSLPendingFlag

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -623,7 +623,7 @@ static void updatePendingData(tls_connection *conn) {
 }
 
 void updateSSLPendingFlag(tls_connection *conn) {
-    if (SSL_pending(conn->ssl) > 0) {
+    if (conn->ssl && SSL_pending(conn->ssl) > 0) {
         conn->flags |= TLS_CONN_FLAG_HAS_PENDING;
     } else {
         conn->flags &= ~TLS_CONN_FLAG_HAS_PENDING;


### PR DESCRIPTION
## Backport Summary

Cherry-pick applied cleanly with no conflicts.

| Field | Value |
|---|---|
| Source PR | `https://github.com/valkey-io/valkey/pull/3641` |
| Source title | Add null check in updateSSLPendingFlag |
| Target branch | `8.1` |
| Cherry-picked commits | 1 |
| Conflicts detected | no |
| Auto-resolved files | 0 |
| Unresolved files | 0 |
| Risk level | `medium` |

### Backport Risk

- Level: `medium`
- Signals:
  - target branch `8.1` is an older release line
  - touches source, dependency, CI, or integration-test code
- Touched paths: src/tls.c

### Reviewer Checklist

- Compare this backport against the source PR before merge.

### Cherry-Picked Commits

- `2f161077123e8c2aa6e1b9301eb3d3e62be45711`