### PR TITLE
[backport] Weekly backport sweep for 9.1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -582,7 +582,7 @@ ENGINE_SERVER_OBJ = \
     ziplist.o \
     zipmap.o \
     zmalloc.o \
-	queues.o
+    queues.o
 ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)
 ENGINE_CLI_OBJ = \

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1740,46 +1740,21 @@ void clusterscanCommand(client *c) {
 
     int slot;
     unsigned long long cursor;
-    int input_slot = -1;
-    int match_slot = -1;
+    scanOptions opts;
     int skip_scan = 0;
 
-    /* Parse all arguments together so that values of MATCH/COUNT/SLOT/TYPE are
-     * not mistaken for the option names.*/
-    for (int i = 2; i < c->argc; i++) {
-        int remaining = c->argc - i;
-        char *opt = objectGetVal(c->argv[i]);
-
-        if (!strcasecmp(opt, "slot") && remaining >= 2) {
-            if (input_slot != -1) {
-                addReplyError(c, "SLOT option can only be specified once");
-                return;
-            }
-            if ((input_slot = getSlotOrReply(c, c->argv[i + 1])) == -1) return;
-            i++;
-        } else if (!strcasecmp(opt, "match") && remaining >= 2) {
-            sds pat = objectGetVal(c->argv[i + 1]);
-            int patlen = sdslen(pat);
-            match_slot = (patlen == 1 && pat[0] == '*') ? -1 : patternHashSlot(pat, patlen);
-            i++;
-        } else if ((!strcasecmp(opt, "count") || !strcasecmp(opt, "type")) && remaining >= 2) {
-            i++; /* Let scanGenericCommand parse this */
-        } else {
-            addReplyErrorObject(c, shared.syntaxerr);
-            return;
-        }
-    }
+    if (parseScanOptionsOrReply(c, NULL, 2, true, &opts) != C_OK) return;
 
     /* SLOT and single slot MATCH target different slots hence conclude the scan */
-    skip_scan = input_slot != -1 && match_slot != -1 && input_slot != match_slot;
+    skip_scan = opts.input_slot != -1 && opts.match_slot != -1 && opts.input_slot != opts.match_slot;
 
     /* Handle cursor "0" case. If slot information is provided we return
      * the updated cursor to scan input slot, else scan from slot 0. */
     if (strcmp(objectGetVal(c->argv[1]), "0") == 0) {
-        if (input_slot != -1) {
-            slot = input_slot;
-        } else if (match_slot != -1) {
-            slot = match_slot; /* If match maps to a particular slot, start scan from there */
+        if (opts.input_slot != -1) {
+            slot = opts.input_slot;
+        } else if (opts.match_slot != -1) {
+            slot = opts.match_slot; /* If match maps to a particular slot, start scan from there */
         } else {
             slot = 0;
         }
@@ -1799,16 +1774,16 @@ void clusterscanCommand(client *c) {
             return;
         }
 
-        if (input_slot != -1 && slot != input_slot) {
+        if (opts.input_slot != -1 && slot != opts.input_slot) {
             addReplyError(c, "Cursor slot mismatch with SLOT argument");
             return;
         }
 
-        if (match_slot != -1 && slot != match_slot) {
+        if (opts.match_slot != -1 && slot != opts.match_slot) {
             /* Advance cursor to the slot matched by MATCH if required but do not go back. */
             addReplyArrayLen(c, 2);
-            if (!skip_scan && match_slot > slot) {
-                sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[match_slot]);
+            if (!skip_scan && opts.match_slot > slot) {
+                sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[opts.match_slot]);
                 addReplyBulkSds(c, new_cursor);
             } else {
                 addReplyBulkCString(c, "0");
@@ -1818,24 +1793,24 @@ void clusterscanCommand(client *c) {
         }
     }
 
-    /* Scan the slot using scanGenericCommand */
-    sds cursor_prefix = sdscatfmt(sdsempty(), "%s-{%s}-", clusterscanFingerprint(), crc16_slot_table[slot]);
-    sds finished_cursor_prefix = NULL;
-
-    /* If SLOT argument was provided or implied by MATCH, don't advance to next slot then return 0 cursor.
-     * Else, advance to next slot for full cluster scan */
-    if (input_slot != -1 || match_slot != -1) {
-        finished_cursor_prefix = sdsnew("");
-    } else {
-        int next_slot = slot + 1;
-        if (next_slot >= CLUSTER_SLOTS) {
-            finished_cursor_prefix = sdsnew("");
-        } else {
-            finished_cursor_prefix = sdscatfmt(sdsempty(), "0-{%s}-", crc16_slot_table[next_slot]);
+    /* If SLOT argument was provided or implied by MATCH, scan only that slot.
+     * Otherwise, scan the continuous range of slots owned by this node. */
+    int final_slot = slot;
+    bool advance_to_next_slot = false;
+    if (opts.input_slot == -1 && opts.match_slot == -1) {
+        clusterNode *owner = getNodeBySlot(slot);
+        while (final_slot + 1 < CLUSTER_SLOTS && getNodeBySlot(final_slot + 1) == owner) {
+            final_slot++;
         }
+        advance_to_next_slot = true;
     }
 
-    scanGenericCommand(c, NULL, cursor, slot, cursor_prefix, finished_cursor_prefix);
-    sdsfree(cursor_prefix);
-    sdsfree(finished_cursor_prefix);
+    serverAssert(slot >= 0 && slot < CLUSTER_SLOTS);
+    clusterScanCtx cluster_ctx = {
+        .slot = slot,
+        .final_slot = final_slot,
+        .advance_to_next_slot = advance_to_next_slot,
+        .fp = clusterscanFingerprint(),
+    };
+    scanGenericCommandWithOptions(c, NULL, cursor, &opts, &cluster_ctx);
 }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1303,6 +1303,13 @@ void slotExportConnectHandler(connection *conn) {
  * the job as private data. */
 int connectSlotExportJob(slotMigrationJob *job) {
     clusterNode *n = clusterLookupNode(job->target_node_name, CLUSTER_NAMELEN);
+    if (n == NULL) {
+        serverLog(LL_WARNING,
+                  "Slot migration %s: target node %.40s not found in cluster, "
+                  "aborting connection attempt.",
+                  job->description, job->target_node_name);
+        return C_ERR;
+    }
     int port = getNodeDefaultReplicationPort(n);
     serverLog(LL_NOTICE, "Connecting slot migration %s (ip: %s, port %d)",
               job->description,
@@ -1995,10 +2002,11 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                 status = proceedWithSlotExportJobConnecting(job, &completed);
             }
             if (status == C_ERR) {
+                const char *conn_err = job->conn ? connGetLastError(job->conn) : "target node not found";
                 sds status_msg =
                     sdscatfmt(sdsempty(),
                               "Unable to connect to target node: %s",
-                              connGetLastError(job->conn));
+                              conn_err);
                 finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                        status_msg);
                 sdsfree(status_msg);

--- a/src/db.c
+++ b/src/db.c
@@ -37,6 +37,7 @@
 #include "module.h"
 #include "vector.h"
 #include "expire.h"
+#include "crc16_slottable.h"
 
 /*-----------------------------------------------------------------------------
  * C-level DB API
@@ -1146,93 +1147,91 @@ char *getObjectTypeName(robj *o) {
     }
 }
 
+/* Parse options for SCAN, HSCAN, SSCAN, ZSCAN and CLUSTERSCAN commands,
+ * replying with an error on invalid input. */
+int parseScanOptionsOrReply(client *c, robj *o, int start_idx, bool allow_slot, scanOptions *opts) {
+    *opts = (scanOptions){
+        .count = DEFAULT_SCAN_COMMAND_COUNT,
+        .type = LLONG_MAX,
+        .input_slot = -1,
+        .match_slot = -1,
+    };
+
+    for (int i = start_idx; i < c->argc;) {
+        int j = c->argc - i;
+        char *opt = objectGetVal(c->argv[i]);
+        if (!strcasecmp(opt, "count") && j >= 2) {
+            if (getLongFromObjectOrReply(c, c->argv[i + 1], &opts->count, NULL) != C_OK) return C_ERR;
+            if (opts->count < 1) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return C_ERR;
+            }
+            i += 2;
+        } else if (!strcasecmp(opt, "match") && j >= 2) {
+            opts->pat = objectGetVal(c->argv[i + 1]);
+            opts->patlen = sdslen(opts->pat);
+            opts->use_pattern = !(opts->patlen == 1 && opts->pat[0] == '*');
+            opts->match_slot = opts->use_pattern && server.cluster_enabled ? patternHashSlot(opts->pat, opts->patlen) : -1;
+            i += 2;
+        } else if (!strcasecmp(opt, "type") && o == NULL && j >= 2) {
+            /* TYPE filter applies to key names only, not to object fields. */
+            char *typename = objectGetVal(c->argv[i + 1]);
+            opts->type = getObjectTypeByName(typename);
+            if (opts->type == LLONG_MAX) {
+                addReplyErrorFormat(c, "unknown type name '%s'", typename);
+                return C_ERR;
+            }
+            i += 2;
+        } else if (!strcasecmp(opt, "novalues")) {
+            if (!o || o->type != OBJ_HASH) {
+                addReplyError(c, "NOVALUES option can only be used in HSCAN");
+                return C_ERR;
+            }
+            opts->only_keys = 1;
+            i++;
+        } else if (!strcasecmp(opt, "noscores")) {
+            if (!o || o->type != OBJ_ZSET) {
+                addReplyError(c, "NOSCORES option can only be used in ZSCAN");
+                return C_ERR;
+            }
+            opts->only_keys = 1;
+            i++;
+        } else if (allow_slot && !strcasecmp(opt, "slot") && j >= 2) {
+            if (opts->input_slot != -1) {
+                addReplyError(c, "SLOT option can only be specified once");
+                return C_ERR;
+            }
+            if ((opts->input_slot = getSlotOrReply(c, c->argv[i + 1])) == -1) return C_ERR;
+            i += 2;
+        } else {
+            addReplyErrorObject(c, shared.syntaxerr);
+            return C_ERR;
+        }
+    }
+    return C_OK;
+}
+
 /* This command implements SCAN, HSCAN, SSCAN and CLUSTERSCAN commands.
  * If object 'o' is passed, then it must be a Hash, Set or Zset object, otherwise
  * if 'o' is NULL the command will operate on the dictionary associated with
  * the current database.
  *
- * When 'o' is not NULL the function assumes that the first argument in
- * the client arguments vector is a key so it skips it before iterating
- * in order to parse options.
- *
  * In the case of a Hash object the function returns both the field and value
  * of every element on the Hash.
  *
- * slot, cursor_prefix and finished_cursor_prefix are used during CLUSTERSCAN to scan
- * a specific slot and to return the valid cursor to advance the scan.
+ * cluster_ctx is used during CLUSTERSCAN to scan a specific slot or range of
+ * slots and to return the valid cursor to advance the scan.
  */
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, sds cursor_prefix, sds finished_cursor_prefix) {
-    int i, j;
-    long count = DEFAULT_SCAN_COMMAND_COUNT;
-    sds pat = NULL;
-    sds typename = NULL;
-    long long type = LLONG_MAX;
-    int patlen = 0, use_pattern = 0, only_keys = 0;
+void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor, const scanOptions *opts, const clusterScanCtx *cluster_ctx) {
+    int slot = cluster_ctx ? cluster_ctx->slot : -1;
+    int final_slot = cluster_ctx ? cluster_ctx->final_slot : -1;
     vector result;
 
     /* Object must be NULL (to iterate keys names), or the type of the object
      * must be Set, Sorted Set, or Hash. */
     serverAssert(o == NULL || o->type == OBJ_SET || o->type == OBJ_HASH || o->type == OBJ_ZSET);
 
-    /* Set i to the first option argument. The previous one is the cursor. */
-    i = (o == NULL) ? 2 : 3; /* Skip the key argument if needed. */
-
-    /* Step 1: Parse options. */
-    while (i < c->argc) {
-        j = c->argc - i;
-        if (!strcasecmp(objectGetVal(c->argv[i]), "count") && j >= 2) {
-            if (getLongFromObjectOrReply(c, c->argv[i + 1], &count, NULL) != C_OK) {
-                return;
-            }
-
-            if (count < 1) {
-                addReplyErrorObject(c, shared.syntaxerr);
-                return;
-            }
-
-            i += 2;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "match") && j >= 2) {
-            pat = objectGetVal(c->argv[i + 1]);
-            patlen = sdslen(pat);
-
-            /* The pattern always matches if it is exactly "*", so it is
-             * equivalent to disabling it. */
-            use_pattern = !(patlen == 1 && pat[0] == '*');
-
-            i += 2;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "type") && o == NULL && j >= 2) {
-            /* SCAN for a particular type only applies to the db dict */
-            typename = objectGetVal(c->argv[i + 1]);
-            type = getObjectTypeByName(typename);
-            if (type == LLONG_MAX) {
-                addReplyErrorFormat(c, "unknown type name '%s'", typename);
-                return;
-            }
-            i += 2;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "novalues")) {
-            if (!o || o->type != OBJ_HASH) {
-                addReplyError(c, "NOVALUES option can only be used in HSCAN");
-                return;
-            }
-            only_keys = 1;
-            i++;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "noscores")) {
-            if (!o || o->type != OBJ_ZSET) {
-                addReplyError(c, "NOSCORES option can only be used in ZSCAN");
-                return;
-            }
-            only_keys = 1;
-            i++;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "slot") && j >= 2 && slot >= 0) {
-            /* SLOT is already parsed by clusterscanCommand, we can skip it here. */
-            i += 2;
-        } else {
-            addReplyErrorObject(c, shared.syntaxerr);
-            return;
-        }
-    }
-
-    /* Step 2: Iterate the collection.
+    /* Iterate the collection.
      *
      * Note that if the object is encoded with a listpack, intset, or any other
      * representation that is not a hash table, we are sure that it is also
@@ -1268,7 +1267,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
          * COUNT, so if the hash table is in a pathological state (very
          * sparsely populated) we avoid to block too much time at the cost
          * of returning no or very few elements. */
-        unsigned long maxiterations = (unsigned long)count * 10UL;
+        unsigned long maxiterations = (unsigned long)opts->count * 10UL;
 
         /* We pass scanData which have three pointers to the callback:
          * 1. data.keys: the list to which it will add new elements;
@@ -1287,28 +1286,31 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
             .result = &result,
             .db = c->db,
             .o = o,
-            .type = type,
-            .pattern = use_pattern ? pat : NULL,
+            .type = opts->type,
+            .pattern = opts->use_pattern ? opts->pat : NULL,
             .sampled = 0,
-            .only_keys = only_keys,
+            .only_keys = opts->only_keys,
         };
 
-        /* Determine which slot to scan:
-         * - If slot >= 0, scan the specific slot (CLUSTERSCAN)
-         * - If slot == -1 try to derive from pattern; otherwise scan all */
-        int onlydidx = slot;
-        if (onlydidx == -1 && o == NULL && use_pattern && server.cluster_enabled) {
-            onlydidx = patternHashSlot(pat, patlen);
+        /* For regular SCAN in cluster mode, derive the slot from the pattern's hashtag. */
+        if (slot == -1 && o == NULL && opts->use_pattern && server.cluster_enabled) {
+            slot = opts->match_slot;
+            final_slot = slot;
+        }
+        if (slot >= 0) {
+            serverAssert(final_slot >= slot && final_slot < CLUSTER_SLOTS);
+        } else {
+            serverAssert(final_slot == -1);
         }
         do {
             /* In cluster mode there is a separate dictionary for each slot.
              * If cursor is empty, we should try exploring next non-empty slot. */
             if (o == NULL) {
-                cursor = kvstoreScan(c->db->keys, cursor, onlydidx, keysScanCallback, NULL, &data);
+                cursor = kvstoreScan(c->db->keys, cursor, slot, final_slot, keysScanCallback, NULL, &data);
             } else {
                 cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
             }
-        } while (cursor && maxiterations-- && data.sampled < count);
+        } while (cursor && maxiterations-- && data.sampled < opts->count);
     } else if (o->type == OBJ_SET) {
         char *str;
         char buf[LONG_STR_SIZE];
@@ -1320,7 +1322,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
                 len = ll2string(buf, sizeof(buf), llele);
             }
             char *key = str ? str : buf;
-            if (use_pattern && !stringmatchlen(pat, sdslen(pat), key, len, 0)) {
+            if (opts->use_pattern && !stringmatchlen(opts->pat, opts->patlen, key, len, 0)) {
                 continue;
             }
             sds item = sdsnewlen(key, len);
@@ -1338,7 +1340,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
             str = lpGet(p, &len, intbuf);
             /* point to the value */
             p = lpNext(objectGetVal(o), p);
-            if (use_pattern && !stringmatchlen(pat, sdslen(pat), (char *)str, len, 0)) {
+            if (opts->use_pattern && !stringmatchlen(opts->pat, opts->patlen, (char *)str, len, 0)) {
                 /* jump to the next key/val pair */
                 p = lpNext(objectGetVal(o), p);
                 continue;
@@ -1347,7 +1349,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
             sds item = sdsnewlen(str, len);
             addScanDataItem(&result, (const char *)item, sdslen(item));
             /* add value object */
-            if (!only_keys) {
+            if (!opts->only_keys) {
                 str = lpGet(p, &len, intbuf);
                 item = sdsnewlen(str, len);
                 addScanDataItem(&result, (const char *)item, sdslen(item));
@@ -1359,15 +1361,19 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
         serverPanic("Not handled encoding in SCAN.");
     }
 
-    /* Step 3: Reply to the client. */
+    /* Reply to the client. */
     addReplyArrayLen(c, 2);
 
-    /* Handle CLUSTERSCAN prefixing */
-    if (cursor == 0 && finished_cursor_prefix) {
-        sds new_cursor = sdscatfmt(sdsempty(), "%S%U", finished_cursor_prefix, cursor);
+    /* Handle CLUSTERSCAN prefixing. */
+    if (cursor == 0 && cluster_ctx && cluster_ctx->advance_to_next_slot && final_slot + 1 < CLUSTER_SLOTS) {
+        /* Range mode: advance to next slot outside the current node's range. */
+        sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[final_slot + 1]);
         addReplyBulkSds(c, new_cursor);
-    } else if (cursor_prefix) {
-        sds new_cursor = sdscatfmt(sdsempty(), "%S%U", cursor_prefix, cursor);
+    } else if (cluster_ctx && cursor != 0) {
+        /* Derive hashtag from the cursor's actual slot for resharding safety.
+         * Works for single slot mode as well. */
+        int actual_slot = (int)(cursor & (CLUSTER_SLOTS - 1));
+        sds new_cursor = sdscatfmt(sdsempty(), "%s-{%s}-%U", cluster_ctx->fp, crc16_slot_table[actual_slot], cursor);
         addReplyBulkSds(c, new_cursor);
     } else {
         addReplyBulkLongLong(c, cursor);
@@ -1385,11 +1391,18 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
     vectorCleanup(&result);
 }
 
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
+    scanOptions opts;
+    int start_idx = (o == NULL) ? 2 : 3; /* Skip the key argument if needed. */
+    if (parseScanOptionsOrReply(c, o, start_idx, false, &opts) != C_OK) return;
+    scanGenericCommandWithOptions(c, o, cursor, &opts, NULL);
+}
+
 /* The SCAN command completely relies on scanGenericCommand. */
 void scanCommand(client *c) {
     unsigned long long cursor;
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[1]), &cursor) == C_ERR) return;
-    scanGenericCommand(c, NULL, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, NULL, cursor);
 }
 
 void dbsizeCommand(client *c) {
@@ -2259,7 +2272,7 @@ unsigned long long dbSize(serverDb *db) {
 }
 
 unsigned long long dbScan(serverDb *db, unsigned long long cursor, kvstoreScanFunction scan_cb, void *privdata) {
-    return kvstoreScan(db->keys, cursor, -1, scan_cb, NULL, privdata);
+    return kvstoreScan(db->keys, cursor, -1, -1, scan_cb, NULL, privdata);
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/expire.c
+++ b/src/expire.c
@@ -338,7 +338,7 @@ static ustime_t activeExpireCycleJob(enum activeExpiryType jobType, int cycleTyp
 
             while (data.sampled < num && checked_buckets < max_buckets) {
                 unsigned long cursor = db->expiry[jobType].cursor;
-                cursor = kvstoreScan(kvs, cursor, -1, scan_cb,
+                cursor = kvstoreScan(kvs, cursor, -1, -1, scan_cb,
                                      expireShouldSkipTableForSamplingCb, &data);
                 if (!data.has_more_expired_entries) db->expiry[jobType].cursor = cursor;
                 if (db->expiry[jobType].cursor == 0 && !data.has_more_expired_entries) {

--- a/src/geo.c
+++ b/src/geo.c
@@ -580,6 +580,8 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
     long long count = 0; /* Max number of results to return. 0 means unlimited. */
     if (c->argc > base_args) {
         int remaining = c->argc - base_args;
+        /* Call geoPolygonPointsFree() from error paths even when it may be a
+         * no-op, so cleanup stays safe if option parsing order changes. */
         for (int i = 0; i < remaining; i++) {
             char *arg = objectGetVal(c->argv[base_args + i]);
             if (!strcasecmp(arg, "withdist")) {
@@ -595,9 +597,13 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
             } else if (!strcasecmp(arg, "desc")) {
                 sort = SORT_DESC;
             } else if (!strcasecmp(arg, "count") && (i + 1) < remaining) {
-                if (getLongLongFromObjectOrReply(c, c->argv[base_args + i + 1], &count, NULL) != C_OK) return;
+                if (getLongLongFromObjectOrReply(c, c->argv[base_args + i + 1], &count, NULL) != C_OK) {
+                    geoPolygonPointsFree(&shape);
+                    return;
+                }
                 if (count <= 0) {
                     addReplyError(c, "COUNT must be > 0");
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 i++;
@@ -622,50 +628,60 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
                 }
                 robj *member = c->argv[base_args + i + 1];
                 if (longLatFromMemberOrReply(c, zobj, member, shape.xy) == C_ERR) {
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 frommember = 1;
                 i++;
             } else if (!strcasecmp(arg, "fromlonlat") && (i + 2) < remaining && flags & GEOSEARCH && !frommember && !bypolygon) {
-                if (extractLongLatOrReply(c, c->argv + base_args + i + 1, shape.xy) == C_ERR) return;
+                if (extractLongLatOrReply(c, c->argv + base_args + i + 1, shape.xy) == C_ERR) {
+                    geoPolygonPointsFree(&shape);
+                    return;
+                }
                 fromloc = 1;
                 i += 2;
             } else if (!strcasecmp(arg, "byradius") && (i + 2) < remaining && flags & GEOSEARCH && !bybox && !bypolygon) {
-                if (extractDistanceOrReply(c, c->argv + base_args + i + 1, &shape.conversion, &shape.t.radius) != C_OK)
+                if (extractDistanceOrReply(c, c->argv + base_args + i + 1, &shape.conversion, &shape.t.radius) != C_OK) {
+                    geoPolygonPointsFree(&shape);
                     return;
+                }
                 shape.type = CIRCULAR_TYPE;
                 byradius = 1;
                 i += 2;
             } else if (!strcasecmp(arg, "bybox") && (i + 3) < remaining && flags & GEOSEARCH && !byradius && !bypolygon) {
                 if (extractBoxOrReply(c, c->argv + base_args + i + 1, &shape.conversion, &shape.t.r.width,
-                                      &shape.t.r.height) != C_OK)
+                                      &shape.t.r.height) != C_OK) {
+                    geoPolygonPointsFree(&shape);
                     return;
+                }
                 shape.type = RECTANGLE_TYPE;
                 bybox = 1;
                 i += 3;
             } else if (!strcasecmp(arg, "bypolygon") && (i + 2) < remaining && flags & GEOSEARCH && !byradius && !bybox && !frommember && !fromloc) {
                 int num_vertices = 0;
                 if (getIntFromObjectOrReply(c, c->argv[base_args + i + 1], &num_vertices, "invalid number of vertices") != C_OK) {
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 /* Check how many args are remaining. Divide by 2 to see the possible number of vertices. */
                 int possible_vertices = (remaining - i - 2) / 2;
                 if (num_vertices < 3 || possible_vertices < num_vertices) {
                     addReplyError(c, "GEOSEARCH BYPOLYGON must have at least 3 vertices");
+                    geoPolygonPointsFree(&shape);
                     return;
                 }
                 /* Extract polygon vertices. */
                 shape.conversion = 1;
                 shape.t.polygon.num_vertices = num_vertices;
                 shape.t.polygon.points = zmalloc(num_vertices * sizeof(double[2]));
+                shape.type = POLYGON_TYPE;
+                bypolygon = 1;
                 for (int j = 0; j < num_vertices * 2; j += 2) {
                     if (extractLongLatOrReply(c, c->argv + base_args + i + 2 + j, shape.t.polygon.points[j / 2]) == C_ERR) {
-                        zfree(shape.t.polygon.points);
+                        geoPolygonPointsFree(&shape);
                         return;
                     }
                 }
-                shape.type = POLYGON_TYPE;
-                bypolygon = 1;
                 i += (1 + num_vertices * 2);
             } else {
                 addReplyErrorObject(c, shared.syntaxerr);

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -8,6 +8,10 @@
 #include "queues.h"
 #include <sys/resource.h>
 
+#define IO_MPSC_QUEUE_SIZE 16384
+#define IO_SPMC_QUEUE_SIZE 4096
+#define IO_SPSC_QUEUE_SIZE 4096
+
 static _Thread_local int thread_id = 0;
 static _Thread_local mpscTicket io_thread_ticket = {0};
 /* Backlog of responses when io_shared_outbox is full. Should be rare. */
@@ -44,8 +48,8 @@ static inline void untagJob(void *tagged_ptr, void **ptr, int *type) {
 /* Handler prototypes */
 void ioThreadReadQueryFromClient(client *c);
 void ioThreadWriteToClient(client *c);
-void IOThreadFreeArgv(robj **argv);
-void IOThreadPoll(aeEventLoop *el);
+void ioThreadFreeArgv(robj **argv);
+void ioThreadPoll(aeEventLoop *el);
 static void ioThreadAccept(client *c);
 
 int inMainThread(void) {
@@ -107,9 +111,6 @@ void waitForClientIO(client *c) {
 }
 
 void IOThreadsBeforeSleep(long long current_time) {
-#ifndef RUSAGE_THREAD
-    UNUSED(current_time);
-#endif
     if (server.io_threads_num == 1) return;
     serverAssert(inMainThread());
 
@@ -126,29 +127,23 @@ void IOThreadsBeforeSleep(long long current_time) {
         }
     }
 
-#ifdef RUSAGE_THREAD
-    /* If threads are not active track main thread CPU time for ignition decision */
+    /* If threads are not active, track main-thread active time for ignition decision */
     if (server.active_io_threads_num == 1) {
         static long long last_measurement_time = 0;
         if (current_time - last_measurement_time < 50000) return; /* Sample once in 50ms */
         last_measurement_time = current_time;
-        struct rusage ru;
-        if (getrusage(RUSAGE_THREAD, &ru) == 0) {
-            long long sys_time_us = ru.ru_stime.tv_sec * 1000000LL + ru.ru_stime.tv_usec;
-            long long user_time_us = ru.ru_utime.tv_sec * 1000000LL + ru.ru_utime.tv_usec;
-            trackInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_SYS, sys_time_us, current_time, 1000000);
-            trackInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_USER, user_time_us, current_time, 1000000);
-        }
+        trackInstantaneousMetric(STATS_METRIC_MAIN_THREAD_ACTIVE_TIME, server.stat_active_time, current_time, 1000000);
     }
-#endif
 }
 
 #define IO_COOLDOWN_MS 1000
 #define IO_SAMPLE_RATE_MS 10
 #define IO_IGNITION_EVENTS 4
-#define IO_IGNITION_CPU_SYS 30.0
-#define IO_IGNITION_CPU_SYS_LOW 5.0
-#define IO_IGNITION_CPU_USER 50.0
+/* Start using I/O threads when the main thread is active for more than the below
+ * defined percentage of the time. This number is picked somewhat arbitrarily but
+ * needed to be low enough to make sure we start the next thread quickly while not
+ * starting too many threads unnecessarily to avoid contention. */
+#define IO_IGNITION_MAIN_THREAD_ACTIVE_PERCENT 30
 #define BATCH_SIZE 32
 
 void IOThreadsAfterSleep(int numevents) {
@@ -171,15 +166,9 @@ void IOThreadsAfterSleep(int numevents) {
     /* Ignition Policy */
     if (server.active_io_threads_num == 1) {
         int should_ignite = 0;
-#ifdef RUSAGE_THREAD
-        float cpu_sys = (float)getInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_SYS) / 10000.0;
-        float cpu_user = (float)getInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_USER) / 10000.0;
-        /* Ignite IO threads if sys CPU > 30%, or if sys CPU > 5% and user CPU > 50% */
-        should_ignite = (cpu_sys > IO_IGNITION_CPU_SYS) ||
-                        (cpu_sys > IO_IGNITION_CPU_SYS_LOW && cpu_user > IO_IGNITION_CPU_USER);
-#else
-        should_ignite = (numevents >= IO_IGNITION_EVENTS);
-#endif
+        float main_thread_active_time = (float)getInstantaneousMetric(STATS_METRIC_MAIN_THREAD_ACTIVE_TIME) / 10000.0;
+        /* Ignite IO threads when main-thread active time exceeds the threshold (30%) */
+        should_ignite = (main_thread_active_time > (float)IO_IGNITION_MAIN_THREAD_ACTIVE_PERCENT);
         if (should_ignite) {
             pthread_mutex_unlock(&io_threads_mutex[1]);
             server.active_io_threads_num++;
@@ -243,7 +232,7 @@ void IOThreadsAfterSleep(int numevents) {
 
 /* This function performs polling on the given event loop and updates the server's
  * IO fired events count and poll state. */
-void IOThreadPoll(aeEventLoop *el) {
+void ioThreadPoll(aeEventLoop *el) {
     struct timeval tvp = {0, 0};
     int num_events = aePoll(el, &tvp);
     server.io_ae_fired_events = num_events;
@@ -326,10 +315,10 @@ static void *IOThreadMain(void *myid) {
 
                 switch (type) {
                 case JOB_REQ_FREE_ARGV:
-                    IOThreadFreeArgv((robj **)data);
+                    ioThreadFreeArgv((robj **)data);
                     break;
                 case JOB_REQ_POLL:
-                    IOThreadPoll((aeEventLoop *)data);
+                    ioThreadPoll((aeEventLoop *)data);
                     break;
                 default:
                     serverPanic("Invalid SPSC job type: %d", type);
@@ -338,10 +327,8 @@ static void *IOThreadMain(void *myid) {
             processed += batch_count;
         }
 
-        /*
-         * PRIORITY 2: Shared Global Queue (SPMC)
-         * Only checked after SPSC is drained.
-         */
+        /* PRIORITY 2: Shared Global Queue (SPMC)
+         * Only checked after SPSC is drained. */
         void *tagged_job = spmcDequeue(&io_shared_inbox);
         if (tagged_job) {
             void *data;
@@ -356,13 +343,13 @@ static void *IOThreadMain(void *myid) {
                 ioThreadWriteToClient((client *)data);
                 break;
             case JOB_REQ_FREE_OBJ:
-                decrRefCount(data);
+                zfree(data);
                 break;
             case JOB_REQ_ACCEPT:
                 ioThreadAccept((client *)data);
                 break;
             case JOB_REQ_POLL:
-                IOThreadPoll((aeEventLoop *)data);
+                ioThreadPoll((aeEventLoop *)data);
                 break;
             default:
                 serverPanic("Invalid SPMC job type: %d", type);
@@ -398,7 +385,7 @@ static void createIOThread(int id) {
     serverAssert(id > 0 && id < server.io_threads_num);
 
     /* Initialize the private SPSC queue for this thread */
-    spscInit(&io_private_inbox[id]);
+    spscInit(&io_private_inbox[id], IO_SPSC_QUEUE_SIZE);
 
     pthread_t tid;
     pthread_mutex_init(&io_threads_mutex[id], NULL);
@@ -458,7 +445,7 @@ int updateIOThreads(const char **err) {
      * in that state, we will deadlock (Main thread waits for worker, Worker waits for queue space). */
     size_t pending = getPendingIOResponsesCount();
 
-    if (pending > MPSC_QUEUE_SIZE) {
+    if (pending > io_shared_outbox.queue_size) {
         if (err) *err = "Can't update IO threads under load, try again later";
         return 0;
     }
@@ -497,8 +484,8 @@ void initIOThreads(int prev_threads_num) {
         server.active_io_threads_num = 1; /* We start with threads not active. */
         server.io_poll_state = AE_IO_STATE_NONE;
         server.io_ae_fired_events = 0;
-        spmcInit(&io_shared_inbox);
-        mpscInit(&io_shared_outbox);
+        spmcInit(&io_shared_inbox, IO_SPMC_QUEUE_SIZE);
+        mpscInit(&io_shared_outbox, IO_MPSC_QUEUE_SIZE);
         io_jobs_submitted = 0;
         atomic_init(&io_jobs_finished, 0);
         prefetchCommandsBatchInit();
@@ -560,6 +547,7 @@ int trySendWriteToIOThreads(client *c) {
     if (c->flag.lua_debug) return C_ERR;
 
     int is_replica = getClientType(c) == CLIENT_TYPE_REPLICA;
+    clientReplyBlock *block = NULL;
     if (is_replica) {
         c->io_last_reply_block = listLast(server.repl_buffer_blocks);
         replBufBlock *o = listNodeValue(c->io_last_reply_block);
@@ -571,14 +559,10 @@ int trySendWriteToIOThreads(client *c) {
          * threads from reading data that might be invalid in their local CPU cache. */
         c->io_last_reply_block = listLast(c->reply);
         if (c->io_last_reply_block) {
-            clientReplyBlock *block = (clientReplyBlock *)listNodeValue(c->io_last_reply_block);
+            block = (clientReplyBlock *)listNodeValue(c->io_last_reply_block);
             c->io_last_bufpos = block->used;
-            /* If buffer is encoded force new header */
-            if (block->flag.buf_encoded) block->last_header = NULL;
         } else {
             c->io_last_bufpos = (size_t)c->bufpos;
-            /* If buffer is encoded force new header */
-            if (c->flag.buf_encoded) c->last_header = NULL;
         }
     }
 
@@ -597,7 +581,15 @@ int trySendWriteToIOThreads(client *c) {
         c->io_last_bufpos = 0;
         return C_ERR;
     }
-
+    /* Force new header after successful enqueue so the main thread doesn't
+     * extend a header the I/O thread is currently reading. */
+    if (!is_replica) {
+        if (block) {
+            if (block->flag.buf_encoded) block->last_header = NULL;
+        } else {
+            if (c->flag.buf_encoded) c->last_header = NULL;
+        }
+    }
     if (c->flag.pending_write) {
         listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         c->flag.pending_write = 0;
@@ -609,7 +601,7 @@ int trySendWriteToIOThreads(client *c) {
 }
 
 /* Internal function to free the client's argv in an IO thread. */
-void IOThreadFreeArgv(robj **argv) {
+void ioThreadFreeArgv(robj **argv) {
     int last_arg = 0;
     for (int i = 0;; i++) {
         robj *o = argv[i];
@@ -697,8 +689,12 @@ int tryOffloadFreeObjToIOThreads(robj *obj) {
 
     if (obj->encoding != OBJ_ENCODING_RAW || obj->type != OBJ_STRING) return C_ERR;
 
-    void *job = tagJob(obj, JOB_REQ_FREE_OBJ);
+    /* We offload only the free of the ptr that may be allocated by the I/O thread.
+     * The object itself was allocated by the main thread and will be freed by the main thread. */
+    void *job = tagJob(sdsAllocPtr(objectGetVal(obj)), JOB_REQ_FREE_OBJ);
     if (unlikely(spmcEnqueue(&io_shared_inbox, job) == false)) return C_ERR;
+    objectSetVal(obj, NULL);
+    decrRefCount(obj);
     io_jobs_submitted++;
     server.stat_io_freed_objects++;
     return C_OK;

--- a/src/io_threads.h
+++ b/src/io_threads.h
@@ -12,16 +12,14 @@ typedef enum {
     JOB_REQ_ACCEPT,
     JOB_REQ_COUNT
 } JobRequest;
-_Static_assert(JOB_REQ_COUNT <= 8, "JOB_REQ_COUNT must not exceed 7 for pointer arithmetic");
+_Static_assert(JOB_REQ_COUNT <= 8, "JOB_REQ_COUNT must not exceed 8 for pointer arithmetic");
 
 typedef enum {
     JOB_RES_READ_CLIENT = 0,
     JOB_RES_WRITE_CLIENT,
     JOB_RES_COUNT
 } JobResult;
-_Static_assert(JOB_RES_COUNT <= 8, "JOB_RES_COUNT must not exceed 7 for pointer arithmetic");
-
-typedef void (*job_handler)(void *);
+_Static_assert(JOB_RES_COUNT <= 8, "JOB_RES_COUNT must not exceed 8 for pointer arithmetic");
 
 void initIOThreads(int prev_threads_num);
 void killIOThreads(void);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -408,12 +408,14 @@ void hashtableScanToKvstoreScanCallback(void *privdata, void *entry) {
  * 3. If the hashtable is entirely scanned i.e. the cursor has reached 0, the next non empty hashtable is discovered.
  *    The hashtable information is embedded into the cursor and returned.
  *
- * To restrict the scan to a single hashtable, pass a valid hashtable index as
- * 'onlydidx', otherwise pass -1.
+ * Scanning modes controlled by first_idx and last_idx:
+ * 1. first_idx == -1 and last_idx == -1: scan all hashtables.
+ * 2. first_idx >= 0 and last_idx >= 0: scan range [first_idx, last_idx].
  */
 unsigned long long kvstoreScan(kvstore *kvs,
                                unsigned long long cursor,
-                               int onlydidx,
+                               int first_idx,
+                               int last_idx,
                                kvstoreScanFunction scan_cb,
                                kvstoreScanShouldSkipHashtable *skip_cb,
                                void *privdata) {
@@ -423,14 +425,15 @@ unsigned long long kvstoreScan(kvstore *kvs,
      * Hashtable index is always 0 at the start of iteration and can be incremented only if there are
      * multiple hashtables. */
     int didx = getAndClearHashtableIndexFromCursor(kvs, &cursor);
-    if (onlydidx >= 0) {
-        if (didx < onlydidx) {
-            /* Fast-forward to onlydidx. */
-            assert(onlydidx < kvs->num_hashtables);
-            didx = onlydidx;
+    if (first_idx >= 0) {
+        assert(last_idx >= first_idx);
+        assert(last_idx < kvs->num_hashtables);
+        if (didx < first_idx) {
+            /* Fast-forward to first_idx. */
+            didx = first_idx;
             cursor = 0;
-        } else if (didx > onlydidx) {
-            /* The cursor is already past onlydidx. */
+        } else if (didx > last_idx) {
+            /* The cursor is already past last_idx. */
             return 0;
         }
     }
@@ -446,8 +449,16 @@ unsigned long long kvstoreScan(kvstore *kvs,
     }
     /* scanning done for the current hash table or if the scanning wasn't possible, move to the next hashtable index. */
     if (next_cursor == 0 || skip) {
-        if (onlydidx >= 0) return 0;
-        didx = kvstoreGetNextNonEmptyHashtableIndex(kvs, didx);
+        if (first_idx >= 0 && didx >= last_idx) {
+            /* Range exhausted; no need to look up the next hashtable. */
+            return 0;
+        }
+        int nextdidx = kvstoreGetNextNonEmptyHashtableIndex(kvs, didx);
+        if (first_idx >= 0 && nextdidx > last_idx) {
+            /* Range exhausted. */
+            return 0;
+        }
+        didx = nextdidx;
     }
     if (didx == KVSTORE_INDEX_NOT_FOUND) {
         return 0;

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -28,7 +28,8 @@ unsigned long kvstoreBuckets(kvstore *kvs);
 size_t kvstoreMemUsage(kvstore *kvs);
 unsigned long long kvstoreScan(kvstore *kvs,
                                unsigned long long cursor,
-                               int onlydidx,
+                               int first_idx,
+                               int last_idx,
                                kvstoreScanFunction scan_cb,
                                kvstoreScanShouldSkipHashtable *skip_cb,
                                void *privdata);

--- a/src/module.c
+++ b/src/module.c
@@ -14634,7 +14634,7 @@ size_t moduleCount(void) {
  * servers's maxmemory policy is LFU based. Value is idle time in milliseconds.
  * returns VALKEYMODULE_OK if the LRU was updated, VALKEYMODULE_ERR otherwise. */
 int VM_SetLRU(ValkeyModuleKey *key, mstime_t lru_idle) {
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (objectSetLRUOrLFU(key->value, -1, lru_idle * 1000)) return VALKEYMODULE_OK;
     return VALKEYMODULE_ERR;
 }
@@ -14645,7 +14645,7 @@ int VM_SetLRU(ValkeyModuleKey *key, mstime_t lru_idle) {
  * returns VALKEYMODULE_OK if when key is valid. */
 int VM_GetLRU(ValkeyModuleKey *key, mstime_t *lru_idle) {
     *lru_idle = -1;
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) return VALKEYMODULE_OK;
     *lru_idle = objectGetLRUIdleSecs(key->value) * 1000;
     return VALKEYMODULE_OK;
@@ -14657,7 +14657,7 @@ int VM_GetLRU(ValkeyModuleKey *key, mstime_t *lru_idle) {
  * the access frequency (must be <= 255).
  * returns VALKEYMODULE_OK if the LFU was updated, VALKEYMODULE_ERR otherwise. */
 int VM_SetLFU(ValkeyModuleKey *key, long long lfu_freq) {
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (objectSetLRUOrLFU(key->value, lfu_freq, -1)) return VALKEYMODULE_OK;
     return VALKEYMODULE_ERR;
 }
@@ -14667,7 +14667,7 @@ int VM_SetLFU(ValkeyModuleKey *key, long long lfu_freq) {
  * returns VALKEYMODULE_OK if when key is valid. */
 int VM_GetLFU(ValkeyModuleKey *key, long long *lfu_freq) {
     *lfu_freq = -1;
-    if (!key->value) return VALKEYMODULE_ERR;
+    if (!key || !key->value) return VALKEYMODULE_ERR;
     if (lrulfu_isUsingLFU()) *lfu_freq = objectGetLFUFrequency(key->value);
     return VALKEYMODULE_OK;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -521,6 +521,20 @@ void deleteCachedResponseClient(client *recording_client) {
     freeClient(recording_client);
 }
 
+/* Return the reply list that new reply data should be appended to.
+ * When the deferred reply buffer is active, replies go to
+ * c->deferred_reply; otherwise they go to c->reply. */
+static inline list *clientGetReplyList(client *c) {
+    return isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
+}
+
+/* Return the reply bytes for the client.
+ * When the deferred reply buffer is active, replies go to
+ * c->deferred_reply_bytes; otherwise they go to c->reply_bytes. */
+static inline unsigned long long *clientGetReplyBytesPtr(client *c) {
+    return isDeferredReplyEnabled(c) ? &c->deferred_reply_bytes : &c->reply_bytes;
+}
+
 /* -----------------------------------------------------------------------------
  * Low level functions to add more data to output buffers.
  * -------------------------------------------------------------------------- */
@@ -675,7 +689,7 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         memcpy(tail->buf + tail->used, payload, len);
         tail->used += len;
         listAddNodeTail(reply_list, tail);
-        unsigned long long *reply_bytes = (isDeferredReplyEnabled(c)) ? &c->deferred_reply_bytes : &c->reply_bytes;
+        unsigned long long *reply_bytes = clientGetReplyBytesPtr(c);
         *reply_bytes += tail->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
@@ -1065,8 +1079,9 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
  * the previous one, when that happens, we wanna try to trim the unused space
  * at the end of the last reply node which we won't use anymore. */
 void trimReplyUnusedTailSpace(client *c) {
-    listNode *ln = listLast(c->reply);
+    listNode *ln = listLast(clientGetReplyList(c));
     clientReplyBlock *tail = ln ? listNodeValue(ln) : NULL;
+    unsigned long long *reply_bytes = clientGetReplyBytesPtr(c);
 
     /* Note that 'tail' may be NULL even if we have a tail node, because when
      * addReplyDeferredLen() is used */
@@ -1084,7 +1099,7 @@ void trimReplyUnusedTailSpace(client *c) {
         /* take over the allocation's internal fragmentation (at least for
          * memory usage tracking) */
         tail->size = usable_size - sizeof(clientReplyBlock);
-        c->reply_bytes = c->reply_bytes + tail->size - old_size;
+        *reply_bytes = *reply_bytes + tail->size - old_size;
         listNodeValue(ln) = tail;
     }
 }
@@ -1112,9 +1127,15 @@ void *addReplyDeferredLen(client *c) {
      * buffer offset (see function comment) */
     reqresSaveClientReplyOffset(c);
 
+    /* When the deferred reply buffer is active, the placeholder must go into
+     * the same list that subsequent ReplyWith* calls will append to.
+     * Otherwise setDeferredReply will fill the placeholder in c->reply while
+     * the array elements live in c->deferred_reply, producing a malformed
+     * response after commitDeferredReplyBuffer joins the two lists. */
+    list *reply_list = clientGetReplyList(c);
     trimReplyUnusedTailSpace(c);
-    listAddNodeTail(c->reply, NULL); /* NULL is our placeholder. */
-    return listLast(c->reply);
+    listAddNodeTail(reply_list, NULL); /* NULL is our placeholder. */
+    return listLast(reply_list);
 }
 
 void setDeferredReply(client *c, void *node, const char *s, size_t length) {
@@ -1125,6 +1146,11 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * we return NULL in addReplyDeferredLen() */
     if (node == NULL) return;
     serverAssert(!listNodeValue(ln));
+
+    /* The placeholder node may live in c->deferred_reply when the deferred
+     * reply buffer is active.  Use the same list for deletion/accounting. */
+    list *reply_list = clientGetReplyList(c);
+    unsigned long long *reply_bytes = clientGetReplyBytesPtr(c);
 
     /* Normally we fill this dummy NULL node, added by addReplyDeferredLen(),
      * with a new buffer structure containing the protocol needed to specify
@@ -1147,7 +1173,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         prev->used += len_to_copy;
         length -= len_to_copy;
         if (length == 0) {
-            listDelNode(c->reply, ln);
+            listDelNode(reply_list, ln);
             return;
         }
         s += len_to_copy;
@@ -1159,7 +1185,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         memcpy(next->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
         next->used += length;
-        listDelNode(c->reply, ln);
+        listDelNode(reply_list, ln);
     } else {
         /* Create a new node */
         size_t usable_size;
@@ -1171,7 +1197,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         memcpy(buf->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
         listNodeValue(ln) = buf;
-        c->reply_bytes += buf->size;
+        *reply_bytes += buf->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -6520,31 +6520,16 @@ void evictClients(void) {
     size_t client_eviction_limit = getClientEvictionLimit();
     if (client_eviction_limit == 0) return;
 
-    /* Variable to track memory of clients marked for close but not yet freed */
-    size_t pending_freed = 0;
-
     while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
-               server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] -
-               pending_freed >
+               server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] >
            client_eviction_limit) {
         listNode *ln = listNext(&bucket_iter);
         if (ln) {
             client *c = ln->value;
-            if (c->flag.close_asap) {
-                /* Already scheduled to close. Count memory as freed and skip. */
-                pending_freed += getClientMemoryUsage(c, NULL);
-                continue;
-            }
             sds ci = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
             serverLog(LL_NOTICE, "Evicting client: %s", ci);
+            if (freeClient(c)) server.stat_evictedclients++;
             sdsfree(ci);
-            server.stat_evictedclients++;
-
-            if (freeClient(c) == 0) {
-                /* Protected client (async close). Count memory as freed and skip. */
-                pending_freed += getClientMemoryUsage(c, NULL);
-                continue;
-            }
         } else {
             curr_bucket--;
             if (curr_bucket < 0) {

--- a/src/queues.c
+++ b/src/queues.c
@@ -4,24 +4,27 @@
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Implementation of MPSC, SPMC, and SPSC queues
- *
  */
 
 #include "queues.h"
 #include "zmalloc.h"
-inline void mpscInit(mpscQueue *q) {
-    q->buffer = (_Atomic(void *) *)zmalloc(sizeof(_Atomic(void *)) * MPSC_QUEUE_SIZE);
+
+void mpscInit(mpscQueue *q, size_t queue_size) {
+    /* Queue size must be a power of 2 (the masking logic relies on it) */
+    assert((queue_size & (queue_size - 1)) == 0);
+    q->buffer = (_Atomic(void *) *)zmalloc(sizeof(_Atomic(void *)) * queue_size);
+    q->queue_size = queue_size;
     atomic_init(&q->head, 0);
     atomic_init(&q->tail, 0);
     atomic_init(&q->head_cache, 0);
     q->tail_cache = 0;
 
-    for (size_t i = 0; i < MPSC_QUEUE_SIZE; ++i) {
+    for (size_t i = 0; i < q->queue_size; ++i) {
         atomic_init(&q->buffer[i], NULL);
     }
 }
 
-inline void mpscFree(mpscQueue *q) {
+void mpscFree(mpscQueue *q) {
     if (q->buffer) {
         zfree(q->buffer);
         q->buffer = NULL;
@@ -32,7 +35,7 @@ inline void mpscFree(mpscQueue *q) {
     q->tail_cache = 0;
 }
 
-inline bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
+bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
     size_t tail;
     assert(data);
 
@@ -45,12 +48,12 @@ inline bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
 
     /* Check limits (Fullness check) */
     size_t head = atomic_load_explicit(&q->head_cache, memory_order_acquire);
-    if ((tail - head) >= MPSC_QUEUE_SIZE) {
+    if ((tail - head) >= q->queue_size) {
         /* Cached limit reached, refresh from actual head */
         head = atomic_load_explicit(&q->head, memory_order_acquire);
         atomic_store_explicit(&q->head_cache, head, memory_order_release);
 
-        if (unlikely((tail - head) >= MPSC_QUEUE_SIZE)) {
+        if (unlikely((tail - head) >= q->queue_size)) {
             /* Queue is full - Persist reservation for retry */
             ticket->index = tail;
             ticket->has_reservation = true;
@@ -59,13 +62,13 @@ inline bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
     }
 
     /* Commit data */
-    atomic_store_explicit(&q->buffer[tail & MPSC_QUEUE_MASK], data, memory_order_release);
+    atomic_store_explicit(&q->buffer[tail & (q->queue_size - 1)], data, memory_order_release);
 
     ticket->has_reservation = false;
     return true;
 }
 
-inline size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
+size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
     size_t popped_count = 0;
     size_t head = atomic_load_explicit(&q->head, memory_order_relaxed);
     size_t tail = q->tail_cache;
@@ -81,13 +84,13 @@ inline size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
     if (limit > max_jobs) limit = max_jobs;
 
     for (size_t i = 0; i < limit; ++i) {
-        void *data = atomic_load_explicit(&q->buffer[head & MPSC_QUEUE_MASK], memory_order_relaxed);
+        void *data = atomic_load_explicit(&q->buffer[head & (q->queue_size - 1)], memory_order_relaxed);
 
         /* Stop if slot is reserved but data not yet written */
         if (!data) break;
 
         jobs_out[popped_count++] = data;
-        atomic_store_explicit(&q->buffer[head & MPSC_QUEUE_MASK], NULL, memory_order_relaxed);
+        atomic_store_explicit(&q->buffer[head & (q->queue_size - 1)], NULL, memory_order_relaxed);
         head++;
     }
 
@@ -103,19 +106,22 @@ inline size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
  * SPMC QUEUE (Single-Producer Multi-Consumer)
  * ========================================================================== */
 
-inline void spmcInit(spmcQueue *q) {
-    q->buffer = (spmcCell *)zmalloc_cache_aligned(sizeof(spmcCell) * SPMC_QUEUE_SIZE);
+inline void spmcInit(spmcQueue *q, size_t queue_size) {
+    /* Queue size must be a power of 2 (the masking logic relies on it) */
+    assert((queue_size & (queue_size - 1)) == 0);
+    q->buffer = (spmcCell *)zmalloc_cache_aligned(sizeof(spmcCell) * queue_size);
+    q->queue_size = queue_size;
     atomic_init(&q->head, 0);
     q->tail = 0;
     q->head_cache = 0;
 
-    for (size_t i = 0; i < SPMC_QUEUE_SIZE; i++) {
+    for (size_t i = 0; i < q->queue_size; i++) {
         atomic_init(&q->buffer[i].sequence, i);
         q->buffer[i].data = NULL;
     }
 }
 
-inline void spmcFree(spmcQueue *q) {
+void spmcFree(spmcQueue *q) {
     if (q->buffer) {
         zfree(q->buffer);
         q->buffer = NULL;
@@ -125,7 +131,7 @@ inline void spmcFree(spmcQueue *q) {
     q->head_cache = 0;
 }
 
-inline bool spmcIsEmpty(spmcQueue *q) {
+bool spmcIsEmpty(spmcQueue *q) {
     /* Fast path: Check against cached consumer position */
     if (q->tail == q->head_cache) {
         return true;
@@ -138,13 +144,13 @@ inline bool spmcIsEmpty(spmcQueue *q) {
     return q->tail == curr_head;
 }
 
-inline size_t spmcSize(spmcQueue *q) {
+size_t spmcSize(spmcQueue *q) {
     size_t head = atomic_load_explicit(&q->head, memory_order_relaxed);
     return (q->tail >= head) ? (q->tail - head) : 0;
 }
 
-inline bool spmcEnqueue(spmcQueue *q, void *data) {
-    spmcCell *cell = &q->buffer[q->tail & SPMC_QUEUE_MASK];
+bool spmcEnqueue(spmcQueue *q, void *data) {
+    spmcCell *cell = &q->buffer[q->tail & (q->queue_size - 1)];
     size_t seq = atomic_load_explicit(&cell->sequence, memory_order_acquire);
 
     /* Sequence Check:
@@ -163,13 +169,13 @@ inline bool spmcEnqueue(spmcQueue *q, void *data) {
     return true;
 }
 
-inline void *spmcDequeue(spmcQueue *q) {
+void *spmcDequeue(spmcQueue *q) {
     size_t head = atomic_load_explicit(&q->head, memory_order_relaxed);
     spmcCell *cell;
     void *data;
 
     while (1) {
-        cell = &q->buffer[head & SPMC_QUEUE_MASK];
+        cell = &q->buffer[head & (q->queue_size - 1)];
         size_t seq = atomic_load_explicit(&cell->sequence, memory_order_acquire);
 
         intptr_t diff = (intptr_t)seq - (intptr_t)(head + 1);
@@ -182,7 +188,7 @@ inline void *spmcDequeue(spmcQueue *q) {
                 data = cell->data;
 
                 /* Mark slot empty for next generation (pos + size) */
-                atomic_store_explicit(&cell->sequence, head + SPMC_QUEUE_SIZE, memory_order_release);
+                atomic_store_explicit(&cell->sequence, head + q->queue_size, memory_order_release);
                 return data;
             }
         } else if (diff < 0) {
@@ -199,8 +205,11 @@ inline void *spmcDequeue(spmcQueue *q) {
  * SPSC QUEUE (Single-Producer Single-Consumer)
  * ========================================================================== */
 
-inline void spscInit(spscQueue *q) {
-    q->buffer = (void **)zmalloc(sizeof(void *) * SPSC_QUEUE_SIZE);
+void spscInit(spscQueue *q, size_t queue_size) {
+    /* Queue size must be a power of 2 (the masking logic relies on it) */
+    assert((queue_size & (queue_size - 1)) == 0);
+    q->buffer = (void **)zmalloc(sizeof(void *) * queue_size);
+    q->queue_size = queue_size;
     atomic_init(&q->head, 0);
     atomic_init(&q->tail, 0);
     q->head_cache = 0;
@@ -208,7 +217,7 @@ inline void spscInit(spscQueue *q) {
     q->tail_local = 0;
 }
 
-inline void spscFree(spscQueue *q) {
+void spscFree(spscQueue *q) {
     if (q->buffer) {
         zfree(q->buffer);
         q->buffer = NULL;
@@ -220,13 +229,13 @@ inline void spscFree(spscQueue *q) {
     q->tail_local = 0;
 }
 
-inline bool spscIsFull(spscQueue *q) {
+bool spscIsFull(spscQueue *q) {
     const size_t curr_tail = q->tail_local;
 
-    if (curr_tail - q->head_cache >= SPSC_QUEUE_SIZE) {
+    if (curr_tail - q->head_cache >= q->queue_size) {
         q->head_cache = atomic_load_explicit(&q->head, memory_order_acquire);
 
-        if (curr_tail - q->head_cache >= SPSC_QUEUE_SIZE) {
+        if (curr_tail - q->head_cache >= q->queue_size) {
             /* Flush any local changes before reporting full */
             if (q->tail_local != q->tail) {
                 atomic_store_explicit(&q->tail, q->tail_local, memory_order_release);
@@ -237,8 +246,8 @@ inline bool spscIsFull(spscQueue *q) {
     return false;
 }
 
-inline void spscEnqueue(spscQueue *q, void *data, bool commit) {
-    q->buffer[q->tail_local & SPSC_QUEUE_MASK] = data;
+void spscEnqueue(spscQueue *q, void *data, bool commit) {
+    q->buffer[q->tail_local & (q->queue_size - 1)] = data;
     q->tail_local++;
 
     if (commit) {
@@ -246,13 +255,13 @@ inline void spscEnqueue(spscQueue *q, void *data, bool commit) {
     }
 }
 
-inline void spscCommit(spscQueue *q) {
+void spscCommit(spscQueue *q) {
     size_t tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
     if (q->tail_local == tail) return;
     atomic_store_explicit(&q->tail, q->tail_local, memory_order_release);
 }
 
-inline size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs) {
+size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs) {
     size_t curr_head = atomic_load_explicit(&q->head, memory_order_relaxed);
     size_t curr_tail_cache = q->tail_cache;
 
@@ -266,13 +275,13 @@ inline size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs) {
     size_t count = (num_jobs < available) ? num_jobs : available;
 
     for (size_t i = 0; i < count; ++i) {
-        jobs_out[i] = q->buffer[(curr_head + i) & SPSC_QUEUE_MASK];
+        jobs_out[i] = q->buffer[(curr_head + i) & (q->queue_size - 1)];
     }
     atomic_store_explicit(&q->head, curr_head + count, memory_order_release);
     return count;
 }
 
-inline bool spscIsEmpty(spscQueue *q) {
+bool spscIsEmpty(spscQueue *q) {
     /* Fast path */
     if (q->tail_local == q->head_cache) {
         return true;

--- a/src/queues.h
+++ b/src/queues.h
@@ -1,8 +1,4 @@
 /*
- * Copyright (c) Valkey Contributors
- * All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause
- *
  * Implements different types of queues
  *
  * 1. SPMC - Single Producer Multi Consumer
@@ -37,12 +33,6 @@
  * MPSC QUEUE (Multi-Producer Single-Consumer)
  * ========================================================================== */
 
-#define MPSC_QUEUE_SIZE 16384
-#define MPSC_QUEUE_MASK (MPSC_QUEUE_SIZE - 1)
-#ifndef __cplusplus
-static_assert((MPSC_QUEUE_SIZE & (MPSC_QUEUE_SIZE - 1)) == 0, "MPSC_QUEUE_SIZE must be power of 2");
-#endif
-
 typedef struct mpscTicket {
     size_t index;
     bool has_reservation;
@@ -59,9 +49,12 @@ typedef struct mpscQueue {
 
     /* Data buffer */
     _Alignas(CACHE_LINE_SIZE) _Atomic(void *) *buffer;
+    size_t queue_size;
 } mpscQueue;
 
-void mpscInit(mpscQueue *q);
+/* Initializes an MPSC queue with a size that must be a power of 2 */
+void mpscInit(mpscQueue *q, size_t queue_size);
+/* Frees the MPSC queue's internal buffer and resets its state */
 void mpscFree(mpscQueue *q);
 
 /* Pushes an item into the queue and returns true if the queue is not full.
@@ -76,12 +69,6 @@ size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs);
 /* ==========================================================================
  * SPMC QUEUE (Single-Producer Multi-Consumer)
  * ========================================================================== */
-
-#define SPMC_QUEUE_SIZE 4096
-#define SPMC_QUEUE_MASK (SPMC_QUEUE_SIZE - 1)
-#ifndef __cplusplus
-static_assert((SPMC_QUEUE_SIZE & (SPMC_QUEUE_SIZE - 1)) == 0, "SPMC_QUEUE_SIZE must be power of 2");
-#endif
 
 typedef struct spmcCell {
     _Alignas(CACHE_LINE_SIZE) _Atomic(size_t) sequence;
@@ -98,24 +85,25 @@ typedef struct spmcQueue {
 
     /* Data buffer */
     _Alignas(CACHE_LINE_SIZE) spmcCell *buffer;
+    size_t queue_size;
 } spmcQueue;
 
-void spmcInit(spmcQueue *q);
+/* Initializes an SPMC queue with a size that must be a power of 2 */
+void spmcInit(spmcQueue *q, size_t queue_size);
+/* Frees the SPMC queue's internal buffer and resets its state */
 void spmcFree(spmcQueue *q);
+/* Returns true if the SPMC queue has no items */
 bool spmcIsEmpty(spmcQueue *q);
+/* Returns an approximate number of items currently in the queue */
 size_t spmcSize(spmcQueue *q);
+/* Pushes an item to the SPMC queue. Returns true on success, false if the queue is full. */
 bool spmcEnqueue(spmcQueue *q, void *data);
+/* Pops and returns the next item from the queue, or NULL if the queue is empty */
 void *spmcDequeue(spmcQueue *q);
 
 /* ==========================================================================
  * SPSC QUEUE (Single-Producer Single-Consumer)
  * ========================================================================== */
-
-#define SPSC_QUEUE_SIZE 4096
-#define SPSC_QUEUE_MASK (SPSC_QUEUE_SIZE - 1)
-#ifndef __cplusplus
-static_assert((SPSC_QUEUE_SIZE & (SPSC_QUEUE_SIZE - 1)) == 0, "SPSC_QUEUE_SIZE must be power of 2");
-#endif
 
 typedef struct spscQueue {
     /* Consumer cache line */
@@ -129,16 +117,22 @@ typedef struct spscQueue {
 
     /* Dynamic buffer */
     _Alignas(CACHE_LINE_SIZE) void **buffer;
+    size_t queue_size;
 } spscQueue;
 
-void spscInit(spscQueue *q);
+/* Initializes an SPSC queue with a size that must be a power of 2 */
+void spscInit(spscQueue *q, size_t queue_size);
+/* Frees the SPSC queue's internal buffer and resets its state */
 void spscFree(spscQueue *q);
+/* Returns true if the queue is full, or false otherwise */
 bool spscIsFull(spscQueue *q);
 /* Push data to the queue. Caller must ensure queue is not full via spscIsFull().
  * If commit is true, the tail pointer is updated immediately (visible to consumer) else,
  * only local index is updated (batching). */
 void spscEnqueue(spscQueue *q, void *data, bool commit);
+/* Publishes any pending batched enqueues by advancing the shared tail pointer */
 void spscCommit(spscQueue *q);
+/* Pops up to num_jobs items from the queue and returns the actual number popped */
 size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs);
 /* Check if queue is empty from producer's perspective. */
 bool spscIsEmpty(spscQueue *q);

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -532,8 +532,10 @@ static int rdmaHandleDisconnect(aeEventLoop *el, struct rdma_cm_event *ev) {
     conn->state = CONN_STATE_CLOSED;
 
     /* we can't close connection now, let's mark this connection as closed state */
-    listAddNodeTail(pending_list, conn);
-    rdma_conn->pending_list_node = listLast(pending_list);
+    if (rdma_conn->pending_list_node == NULL) {
+        listAddNodeTail(pending_list, conn);
+        rdma_conn->pending_list_node = listLast(pending_list);
+    }
 
     return C_OK;
 }
@@ -953,8 +955,10 @@ static int connRdmaSetWriteHandler(connection *conn, ConnectionCallbackFunc func
 
     /* does this connection has pending write data? */
     if (func) {
-        listAddNodeTail(pending_list, conn);
-        rdma_conn->pending_list_node = listLast(pending_list);
+        if (rdma_conn->pending_list_node == NULL) {
+            listAddNodeTail(pending_list, conn);
+            rdma_conn->pending_list_node = listLast(pending_list);
+        }
     } else if (rdma_conn->pending_list_node) {
         listDelNode(pending_list, rdma_conn->pending_list_node);
         rdma_conn->pending_list_node = NULL;
@@ -1776,14 +1780,15 @@ static int rdmaProcessPendingData(void) {
         /* a connection can be disconnected by remote peer, CM event mark state as CONN_STATE_CLOSED, kick connection
          * read/write handler to close connection */
         if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
-            listDelNode(pending_list, rdma_conn->pending_list_node);
-            rdma_conn->pending_list_node = NULL;
             /* Invoke both read_handler and write_handler, unless read_handler
                returns 0, indicating the connection has closed, in which case
                write_handler will be skipped. */
             if (callHandler(conn, conn->read_handler)) {
                 callHandler(conn, conn->write_handler);
             }
+
+            listDelNode(pending_list, ln);
+            rdma_conn->pending_list_node = NULL;
 
             ++processed;
             continue;

--- a/src/server.h
+++ b/src/server.h
@@ -195,17 +195,16 @@ struct ValkeyModule;
 /* Instantaneous metrics tracking. */
 #define STATS_METRIC_SAMPLES 16 /* Number of samples per metric. */
 typedef enum {
-    STATS_METRIC_COMMAND = 0,            /* Number of commands executed. */
-    STATS_METRIC_NET_INPUT,              /* Bytes read from network. */
-    STATS_METRIC_NET_OUTPUT,             /* Bytes written to network. */
-    STATS_METRIC_NET_INPUT_REPLICATION,  /* Bytes read from network during replication. */
-    STATS_METRIC_NET_OUTPUT_REPLICATION, /* Bytes written to network during replication. */
-    STATS_METRIC_EL_CYCLE,               /* Number of eventloop cycled. */
-    STATS_METRIC_EL_DURATION,            /* Eventloop duration. */
-    STATS_METRIC_IO_WAIT,                /* IO queue size */
-    STATS_METRIC_MAIN_THREAD_CPU_SYS,    /* Main thread CPU sys time */
-    STATS_METRIC_MAIN_THREAD_CPU_USER,   /* Main thread CPU user time */
-    STATS_METRIC_COUNT                   /* Total count */
+    STATS_METRIC_COMMAND = 0,             /* Number of commands executed. */
+    STATS_METRIC_NET_INPUT,               /* Bytes read from network. */
+    STATS_METRIC_NET_OUTPUT,              /* Bytes written to network. */
+    STATS_METRIC_NET_INPUT_REPLICATION,   /* Bytes read from network during replication. */
+    STATS_METRIC_NET_OUTPUT_REPLICATION,  /* Bytes written to network during replication. */
+    STATS_METRIC_EL_CYCLE,                /* Number of eventloop cycled. */
+    STATS_METRIC_EL_DURATION,             /* Eventloop duration. */
+    STATS_METRIC_IO_WAIT,                 /* IO queue size */
+    STATS_METRIC_MAIN_THREAD_ACTIVE_TIME, /* Main-thread active time */
+    STATS_METRIC_COUNT                    /* Total count */
 } instantaneous_metric_type;
 
 /* Protocol and I/O related defines */

--- a/src/server.h
+++ b/src/server.h
@@ -2791,6 +2791,24 @@ typedef struct {
 
 } hashTypeIterator;
 
+typedef struct scanOptions {
+    long count;      /* COUNT option. */
+    sds pat;         /* MATCH pattern. */
+    long long type;  /* TYPE filter. */
+    int patlen;      /* MATCH pattern length. */
+    int use_pattern; /* MATCH is active. */
+    int only_keys;   /* NOVALUES/NOSCORES option. */
+    int input_slot;  /* SLOT option, or -1. */
+    int match_slot;  /* MATCH hashtag slot, or -1. */
+} scanOptions;
+
+typedef struct clusterScanCtx {
+    int slot;
+    int final_slot;
+    bool advance_to_next_slot;
+    const char *fp;
+} clusterScanCtx;
+
 #include "stream.h" /* Stream data type header file. */
 
 #define OBJ_HASH_FIELD 1
@@ -3761,7 +3779,9 @@ void discardTempDb(serverDb **tempDb);
 int selectDb(client *c, int id);
 void signalModifiedKey(client *c, serverDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, sds cursor_prefix, sds finished_cursor_prefix);
+int parseScanOptionsOrReply(client *c, robj *o, int start_idx, bool allow_slot, scanOptions *opts);
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor);
+void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor, const scanOptions *opts, const clusterScanCtx *cluster_ctx);
 int parseScanCursorOrReply(client *c, sds buf, unsigned long long *cursor);
 int dbAsyncDelete(serverDb *db, robj *key);
 void emptyDbAsync(serverDb *db);

--- a/src/socket.c
+++ b/src/socket.c
@@ -391,15 +391,27 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
  */
 
 static ssize_t connSocketSyncWrite(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    return syncWrite(conn->fd, ptr, size, timeout);
+    ssize_t ret = syncWrite(conn->fd, ptr, size, timeout);
+    if (ret == -1) {
+        conn->last_errno = errno;
+    }
+    return ret;
 }
 
 static ssize_t connSocketSyncRead(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    return syncRead(conn->fd, ptr, size, timeout);
+    ssize_t ret = syncRead(conn->fd, ptr, size, timeout);
+    if (ret == -1) {
+        conn->last_errno = errno;
+    }
+    return ret;
 }
 
 static ssize_t connSocketSyncReadLine(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    return syncReadLine(conn->fd, ptr, size, timeout);
+    ssize_t ret = syncReadLine(conn->fd, ptr, size, timeout);
+    if (ret == -1) {
+        conn->last_errno = errno;
+    }
+    return ret;
 }
 
 static int connSocketGetType(void) {

--- a/src/syncio.c
+++ b/src/syncio.c
@@ -94,7 +94,10 @@ ssize_t syncRead(int fd, char *ptr, ssize_t size, long long timeout) {
         /* Optimistically try to read before checking if the file descriptor
          * is actually readable. At worst we get EAGAIN. */
         nread = read(fd, ptr, size);
-        if (nread == 0) return -1; /* short read. */
+        if (nread == 0) {
+            errno = ECONNRESET;
+            return -1;
+        }
         if (nread == -1) {
             if (errno != EAGAIN) return -1;
         } else {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1823,7 +1823,7 @@ void hscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_HASH)) return;
-    scanGenericCommand(c, o, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, o, cursor);
 }
 
 static void hrandfieldReplyWithListpack(writePreparedClient *wpc, unsigned int count, listpackEntry *fields, listpackEntry *vals) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1655,5 +1655,5 @@ void sscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, set, OBJ_SET)) return;
-    scanGenericCommand(c, set, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, set, cursor);
 }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -819,12 +819,12 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
             /* Mark the entry as deleted. */
             if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
-                intptr_t delta = p - lp;
+                ptrdiff_t delta = p ? p - lp : 0;
                 flags |= STREAM_ITEM_FLAG_DELETED;
                 lp = lpReplaceInteger(lp, &pcopy, flags);
+                if (p) p = lp + delta;
                 deleted_from_lp++;
                 s->length--;
-                p = lp + delta;
             }
         }
         deleted += deleted_from_lp;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3830,7 +3830,7 @@ void zscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_ZSET)) return;
-    scanGenericCommand(c, o, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, o, cursor);
 }
 
 void addZpopInitialReply(client *c, int emitkey, int use_nested_array, long rangelen, robj *key) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -1127,7 +1127,7 @@ static void updatePendingData(tls_connection *conn) {
 }
 
 void updateSSLPendingFlag(tls_connection *conn) {
-    if (SSL_pending(conn->ssl) > 0) {
+    if (conn->ssl && SSL_pending(conn->ssl) > 0) {
         conn->flags |= TLS_CONN_FLAG_HAS_PENDING;
     } else {
         conn->flags &= ~TLS_CONN_FLAG_HAS_PENDING;

--- a/src/tls.c
+++ b/src/tls.c
@@ -1677,6 +1677,9 @@ static ssize_t connTLSSyncWrite(connection *conn_, char *ptr, ssize_t size, long
         unsetBlockingTimeout(conn);
     }
 
+    if (ret < 0) {
+        conn->c.last_errno = errno;
+    }
     return ret;
 }
 
@@ -1692,6 +1695,9 @@ static ssize_t connTLSSyncRead(connection *conn_, char *ptr, ssize_t size, long 
         unsetBlockingTimeout(conn);
     }
 
+    if (ret < 0) {
+        conn->c.last_errno = errno;
+    }
     return ret;
 }
 
@@ -1728,6 +1734,9 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
 exit:
     if (!blocking) {
         unsetBlockingTimeout(conn);
+    }
+    if (nread < 0) {
+        conn->c.last_errno = errno;
     }
     return nread;
 }

--- a/src/unit/test_queues.cpp
+++ b/src/unit/test_queues.cpp
@@ -22,6 +22,7 @@ extern "C" {
 class SpscQueueTest : public ::testing::Test {
   protected:
     spscQueue q;
+    static constexpr size_t SPSC_QUEUE_SIZE = 4096;
 
     struct ConsumerArg {
         spscQueue *q;
@@ -29,7 +30,7 @@ class SpscQueueTest : public ::testing::Test {
     };
 
     void SetUp() override {
-        spscInit(&q);
+        spscInit(&q, SPSC_QUEUE_SIZE);
     }
 
     void TearDown() override {
@@ -139,6 +140,7 @@ TEST_F(SpscQueueTest, TestSpscConcurrent) {
 class SpmcQueueTest : public ::testing::Test {
   protected:
     spmcQueue q;
+    static constexpr size_t SPMC_QUEUE_SIZE = 4096;
 
     struct ConsumerArg {
         spmcQueue *q;
@@ -147,7 +149,7 @@ class SpmcQueueTest : public ::testing::Test {
     };
 
     void SetUp() override {
-        spmcInit(&q);
+        spmcInit(&q, SPMC_QUEUE_SIZE);
         ASSERT_NE(q.buffer, nullptr);
         EXPECT_EQ(reinterpret_cast<uintptr_t>(q.buffer) % CACHE_LINE_SIZE, 0u);
     }
@@ -251,6 +253,7 @@ TEST_F(SpmcQueueTest, TestSpmcConcurrent) {
 class MpscQueueTest : public ::testing::Test {
   protected:
     mpscQueue q;
+    static constexpr size_t MPSC_QUEUE_SIZE = 16384;
 
     struct ProducerArg {
         mpscQueue *q;
@@ -259,7 +262,7 @@ class MpscQueueTest : public ::testing::Test {
     };
 
     void SetUp() override {
-        mpscInit(&q);
+        mpscInit(&q, MPSC_QUEUE_SIZE);
     }
 
     void TearDown() override {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -4285,7 +4285,6 @@ static void clusterManagerOptimizeAntiAffinity(clusterManagerNodeArray *ipnodes,
                           "for anti-affinity\n");
     int node_len = cluster_manager.nodes->len;
     int maxiter = 500 * node_len; // Effort is proportional to cluster size...
-    srand(time(NULL));
     while (maxiter > 0) {
         int offending_len = 0;
         if (offenders != NULL) {
@@ -6204,7 +6203,6 @@ static clusterManagerNode *clusterManagerNodePrimaryRandom(void) {
     }
 
     assert(primary_count > 0);
-    srand(time(NULL));
     idx = rand() % primary_count;
     listRewind(cluster_manager.nodes, &li);
     while ((ln = listNext(&li)) != NULL) {
@@ -8961,8 +8959,6 @@ static void pipeMode(void) {
     char magic[20]; /* Special reply we recognize. */
     time_t last_read_time = time(NULL);
 
-    srand(time(NULL));
-
     /* Use non blocking I/O. */
     if (anetNonBlock(aneterr, context->fd) == ANET_ERR) {
         fprintf(stderr, "Can't set the socket in non blocking mode: %s\n", aneterr);
@@ -9816,7 +9812,6 @@ static void LRUTestMode(void) {
     long long start_cycle;
     int j;
 
-    srand(time(NULL) ^ getpid());
     while (1) {
         /* Perform cycles of 1 second with 50% writes and 50% reads.
          * We use pipelining batching writes / reads N times per cycle in order
@@ -10035,6 +10030,8 @@ void testHintSuite(char *filename) {
 int main(int argc, char **argv) {
     int firstarg;
     struct timeval tv;
+
+    srand(time(NULL) ^ getpid());
 
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));
     config.ct = VALKEY_CONN_TCP;

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -70,7 +70,8 @@ TEST_MODULES = \
     crash.so \
     cluster.so \
     helloscripting.so \
-    unsupported_features.so
+    unsupported_features.so \
+    deferred_reply.so
 
 .PHONY: all
 

--- a/tests/modules/deferred_reply.c
+++ b/tests/modules/deferred_reply.c
@@ -1,0 +1,91 @@
+/* Test module to verify that addReplyDeferredLen / setDeferredReply work
+ * correctly when the deferred reply buffer is active.
+ *
+ * The module subscribes to NOTIFY_STRING keyspace notifications.  When armed,
+ * the notification callback blocks the client with a reply callback that
+ * builds a nested array using VALKEYMODULE_POSTPONED_LEN (which internally
+ * calls addReplyDeferredLen).
+ *
+ * Without the fix in networking.c the placeholder node for the inner array
+ * ends up in c->reply while the outer array header and elements live in
+ * c->deferred_reply, producing a malformed response after
+ * commitDeferredReplyBuffer joins the two lists. */
+
+#include "valkeymodule.h"
+#include <pthread.h>
+#include <unistd.h>
+
+static int armed = 0;
+
+static void *UnblockThread(void *arg) {
+    ValkeyModuleBlockedClient *bc = arg;
+    usleep(100000); /* 100 ms */
+    ValkeyModule_UnblockClient(bc, NULL);
+    return NULL;
+}
+
+/* Reply callback – builds a two-element array where the second element is
+ * itself an array whose length is set via POSTPONED_LEN.
+ * Expected response: ["first", ["a", "b"]] */
+static int ReplyCallback(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(ctx);
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    ValkeyModule_ReplyWithArray(ctx, 2);
+    ValkeyModule_ReplyWithSimpleString(ctx, "first");
+    ValkeyModule_ReplyWithArray(ctx, VALKEYMODULE_POSTPONED_LEN);
+    ValkeyModule_ReplyWithSimpleString(ctx, "a");
+    ValkeyModule_ReplyWithSimpleString(ctx, "b");
+    ValkeyModule_ReplySetArrayLength(ctx, 2);
+    return VALKEYMODULE_OK;
+}
+
+static int OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
+                                  const char *event, ValkeyModuleString *key) {
+    VALKEYMODULE_NOT_USED(type);
+    VALKEYMODULE_NOT_USED(event);
+    VALKEYMODULE_NOT_USED(key);
+
+    if (!armed) return VALKEYMODULE_OK;
+    armed = 0;
+
+    ValkeyModuleBlockedClient *bc =
+        ValkeyModule_BlockClient(ctx, ReplyCallback, NULL, NULL, 0);
+    if (!bc) return VALKEYMODULE_OK;
+
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, UnblockThread, bc) != 0) {
+        ValkeyModule_UnblockClient(bc, NULL);
+    } else {
+        pthread_detach(tid);
+    }
+    return VALKEYMODULE_OK;
+}
+
+/* DEFERRED_REPLY.ARM – arms the notification handler so the next
+ * NOTIFY_STRING event blocks the client. */
+static int CmdArm(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    armed = 1;
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    return VALKEYMODULE_OK;
+}
+
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    if (ValkeyModule_Init(ctx, "deferred_reply", 1, VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_STRING,
+                                               OnKeyspaceNotification) != VALKEYMODULE_OK)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "deferred_reply.arm", CmdArm, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    return VALKEYMODULE_OK;
+}

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -200,6 +200,7 @@ int test_getlru(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lru;
     ValkeyModule_GetLRU(key, &lru);
     ValkeyModule_ReplyWithLongLong(ctx, lru);
@@ -214,6 +215,7 @@ int test_setlru(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lru;
     if (ValkeyModule_StringToLongLong(argv[2], &lru) != VALKEYMODULE_OK) {
         ValkeyModule_ReplyWithError(ctx, "invalid idle time");
@@ -232,6 +234,7 @@ int test_getlfu(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lfu;
     ValkeyModule_GetLFU(key, &lfu);
     ValkeyModule_ReplyWithLongLong(ctx, lfu);
@@ -246,6 +249,7 @@ int test_setlfu(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         return VALKEYMODULE_OK;
     }
     ValkeyModuleKey *key = open_key_or_reply(ctx, argv[1], VALKEYMODULE_READ|VALKEYMODULE_OPEN_KEY_NOTOUCH);
+    if (!key) return VALKEYMODULE_OK;
     mstime_t lfu;
     if (ValkeyModule_StringToLongLong(argv[2], &lfu) != VALKEYMODULE_OK) {
         ValkeyModule_ReplyWithError(ctx, "invalid freq");

--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -30,10 +30,14 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         assert_error "*Invalid cursor*" {R 0 clusterscan "0-{0}"}
     }
 
-    test "CLUSTERSCAN rejects unknown options" {
+    test "CLUSTERSCAN rejects invalid options" {
         set valid_cursor "0-{06S}-0"
         assert_error "*syntax*" {R 0 clusterscan $valid_cursor UNKNOWNOPTION}
         assert_error "*syntax*" {R 0 clusterscan $valid_cursor COUNT 10 BADOPTION}
+        assert_error "*syntax*" {R 0 clusterscan 0 COUNT 0}
+        assert_error "*syntax*" {R 0 clusterscan 0 COUNT -1}
+        assert_error "*value is not an integer or out of range*" {R 0 clusterscan 0 COUNT not-an-integer}
+        assert_error "*unknown type name*" {R 0 clusterscan 0 TYPE notatype}
     }
 
     test "CLUSTERSCAN with SLOT restricts to single slot" {
@@ -346,51 +350,61 @@ start_cluster 3 0 {tags {external:skip cluster}} {
 
     test "CLUSTERSCAN fingerprint validation" {
         set cluster [valkey_cluster 127.0.0.1:[srv 0 port]]
-        
-        set 0_slot_tag "{06S}"
-        set 1_slot_tag "{Qi}"
 
-
-        # Load keys into slot 0
+        # slot 0, 8192, 16000 are the three slots we will use for this test
         for {set i 0} {$i < 50} {incr i} {
-            $cluster set "$0_slot_tag:$i" "value:$i"
-            $cluster set "$1_slot_tag:$i" "value:$i" 
+            $cluster set "fingerprint:{06S}:$i" "value:$i"
+            $cluster set "fingerprint:{8YG}:$i" "value:$i"
+            $cluster set "fingerprint:{he}:$i" "value:$i"
         }
 
-        set res [$cluster clusterscan 0]
-        set cursor [lindex $res 0]
-
-        # Assert that fp is 0
-        assert_match "0-*-*" $cursor
-
-        # Assert to scan slot 0 only and assert that fp reset upon slot 1
-        set max_loops 10000
-        set iterations 0
-        while {$cursor ne "0-{Qi}-0" && $iterations < $max_loops} {
-            set res [$cluster clusterscan $cursor]
-            set cursor [lindex $res 0]
-            incr iterations
-        }
-        assert {$iterations < $max_loops} 
-
-         # Ensure that local cursor is ignored when fp is 0
-        set cursor "0-{Qi}-09393399393"
+        set max_loops 1000
+        set cursor "0"
         set keys {}
-        set max_loops 10000
+        set fps {}
         set iterations 0
-        while {$cursor ne "0" && $iterations < $max_loops} {
-            set res [$cluster clusterscan $cursor slot 1]
+        while {$iterations < $max_loops} {
+            set res [$cluster clusterscan $cursor match "fingerprint:*" ]
             set cursor [lindex $res 0]
             foreach k [lindex $res 1] {
                lappend keys $k
             }
             incr iterations
+            set fp [string range $cursor 0 [expr {[string first "-" $cursor] - 1}]]
+            if {$fp ne "0"} {
+                lappend fps $fp
+            }
+
+            if {$cursor eq "0"} {
+                break
+            }
         }
         assert {$iterations < $max_loops}
 
-        assert {[llength $keys] > 1}
-        assert {[llength $keys] < 300}
+        # Assert all keys are returned
+        assert_equal [llength $keys] 150
 
+        # Assert different finger print for different slots
+        set fps [lsort -unique $fps]
+        assert {[llength $fps] >= 3}
+
+        # Assert that the local cursor is ignored when finger print is 0
+        set cursor "0-{he}-09393399393"
+        set res [$cluster clusterscan $cursor match "fingerprint:*" count 100]
+        set keys [lindex $res 1]
+        assert_equal [llength $keys] 50
+
+        $cluster close
+    }
+
+    # Verify CLUSTERSCAN range end at non 64-bit aligned slot boundary.
+    # With 3 shards slot ownership is 0-5461, 5462-10922, 10923-16383.
+    test "CLUSTERSCAN cursor advances to next shard at non 64 bit aligned boundary" {
+        set cluster [valkey_cluster 127.0.0.1:[srv 0 port]]
+
+        set res [$cluster clusterscan 0-{06S}-0 COUNT 20000]
+        set cur [lindex $res 0]
+        assert_equal [$cluster cluster keyslot $cur] 5462
         $cluster close
     }
 }
@@ -502,6 +516,69 @@ start_cluster 2 0 {tags {external:skip cluster}} {
 
         # CLUSTERSCAN with two SLOT option should result in error
         assert_error "*SLOT option can only be specified once*" {R $slot0_node clusterscan 0-{06S}-0 SLOT 0 SLOT 0}
+    }
+
+    test "CLUSTERSCAN range scanning and cursor hashtag correctness" {
+        # slot 50 = {4ZG}, slot 100 = {0or} — both on node 0.
+        R 0 set "{4ZG}:key" "value"
+        R 0 set "{0or}:key" "value"
+
+        # Both slots scanned in single call (range scan, default count > 2 keys)
+        set res [R 0 clusterscan "0-{4ZG}-0"]
+        set keys [lsort [lindex $res 1]]
+        set cursor [lindex $res 0]
+
+        # Both keys from slot 50 and 100 returned in one call
+        assert_equal [llength $keys] 2
+        assert_equal [lindex $keys 0] "{0or}:key"
+        assert_equal [lindex $keys 1] "{4ZG}:key"
+
+        # Cursor is cross-node transition
+        assert_match "0-*-0" $cursor
+
+        # Now scan happens one slot at a time
+        set res [R 0 clusterscan "0-{4ZG}-0" COUNT 1]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+
+        # Found key from slot 50
+        assert_equal [lindex $keys 0] "{4ZG}:key"
+
+        # Cursor jumped to slot 100 (next non-empty slot), not slot 51.
+        assert_match "*-{0or}-*" $cursor
+        assert_not_equal $cursor "0"
+
+        # Continue: scan slot 100
+        set res [R 0 clusterscan $cursor]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+
+        assert_equal [lindex $keys 0] "{0or}:key"
+
+        # Migrate slot 51 this breaks contiguous range at slot 50
+        set source_id [R 0 cluster myid]
+        set target_id [R 1 cluster myid]
+        R 0 cluster setslot 51 migrating $target_id
+        R 1 cluster setslot 51 importing $source_id
+        R 0 cluster setslot 51 node $target_id
+        R 1 cluster setslot 51 node $target_id
+
+        # Re-scan from slot 50 — range now ends at 50 (slot 51 on node 1)
+        set res [R 0 clusterscan "0-{4ZG}-0"]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+
+        assert_equal [lindex $keys 0] "{4ZG}:key"
+        # Cross-node transition to slot 51 ({6od})
+        assert_equal $cursor "0-{6od}-0"
+
+        # Validate final slot of the cluster
+        R 1 set "{6ZJ}:key" "value"
+        set res [R 1 clusterscan "0-{6ZJ}-0"]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+        assert_equal [lindex $keys 0] "{6ZJ}:key"
+        assert_equal $cursor "0"
     }
 }
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -453,9 +453,13 @@ start_server {tags {"dump"}} {
         #   6a6b6c          - "jkl"
         #   ff              - ZIPMAP_END
         #
+        # Pre-patch: validation passes (overlong encoding walks in-bounds),
+        # then zipmapNext() misaligns by 4 bytes, interpreting 0x61 ('a') as a
+        # 97-byte field length → heap buffer over-read / crash.
+        #
         # Post-patch: zipmapValidateIntegrity() rejects (l < 254 && s != 1).
         #
-        # RESTORE payload: <type=09><rdb-string-len=18><zipmap><rdb-ver=80><crc=0>
+        # RESTORE payload: <type=09><rdb-string-len=18><zipmap><rdb-ver=5000><crc=0>
 
         r debug set-skip-checksum-validation 1
         set payload "\x09\x18\x02\xfe\x03\x00\x00\x00\x61\x62\x63\x03\x00\x64\x65\x66\x03\x67\x68\x69\x03\x00\x6a\x6b\x6c\xff\x50\x00\x00\x00\x00\x00\x00\x00\x00\x00"

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -561,6 +561,18 @@ start_server {tags {"geo"}} {
         assert_equal {{1 0.0001} {2 9.8182}} [r GEORADIUS points -122.407107 37.794300 30 mi ASC WITHDIST]
     }
 
+    test {GEOSEARCH BYPOLYGON with invalid COUNT} {
+        r del points
+        r geoadd points 151.2093 -33.8688 "Sydney"
+
+        assert_error {ERR value is not an integer or out of range} {
+            r GEOSEARCH points BYPOLYGON 3 151.2039 -33.8744 151.2132 -33.8829 151.2229 -33.8839 COUNT notanumber
+        }
+        assert_error {ERR COUNT must be > 0} {
+            r GEOSEARCH points BYPOLYGON 3 151.2039 -33.8744 151.2132 -33.8829 151.2229 -33.8839 COUNT -1
+        }
+    }
+
     test {GEOSEARCH BYPOLYGON standard operations} {
         r geoadd points 151.20932132005692 -33.877723137822436 "146, Elizabeth Street, Koreatown, Sydney, Sydney CBD, Sydney, Council of the City of Sydney, New South Wales, 2000, Australia"
         r geoadd points 151.2119820713997 -33.87697539508043 "Connaught Centre, 187, Liverpool Street, Koreatown, Sydney, Sydney CBD, Sydney, Council of the City of Sydney, New South Wales, 2000, Australia"

--- a/tests/unit/moduleapi/deferred_reply.tcl
+++ b/tests/unit/moduleapi/deferred_reply.tcl
@@ -1,0 +1,40 @@
+set testmodule [file normalize tests/modules/deferred_reply.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {Deferred reply with postponed array length during active deferred reply buffer} {
+        r deferred_reply.arm
+
+        set rd [valkey_deferring_client]
+        # SET triggers NOTIFY_STRING.  The module callback blocks the client;
+        # the reply callback builds a nested array using POSTPONED_LEN while
+        # the deferred reply buffer is active.
+        $rd set testkey testval
+
+        wait_for_blocked_clients_count 1
+        wait_for_blocked_clients_count 0
+
+        set set_reply [$rd read]
+        set cb_reply [$rd read]
+
+        # Drain any extra data so we can report it on failure.
+        $rd ping diag
+        set extra {}
+        set tok [$rd read]
+        while {$tok ne "diag"} {
+            lappend extra $tok
+            set tok [$rd read]
+        }
+
+        if {$set_reply ne "OK" || $cb_reply ne "first {a b}" || $extra ne {}} {
+            fail "Malformed deferred reply output: set_reply='$set_reply' cb_reply='$cb_reply' extra='$extra'"
+        }
+
+        $rd close
+    }
+
+    test "Unload the module - deferred_reply" {
+        assert_equal {OK} [r module unload deferred_reply]
+    }
+}

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -83,6 +83,13 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
     }
     r config set maxmemory-policy allkeys-lru
 
+    test {test module lru/lfu api with nonexistent key} {
+        assert_error {*key not found*} {r test.getlru nonexistent_key}
+        assert_error {*key not found*} {r test.setlru nonexistent_key 100}
+        assert_error {*key not found*} {r test.getlfu nonexistent_key}
+        assert_error {*key not found*} {r test.setlfu nonexistent_key 100}
+    }
+
     test {test module lfu api} {
         r config set maxmemory-policy allkeys-lfu
         r set x foo

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -233,6 +233,7 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         } {} {resp3}
     }
 
+
     test {test module get/set client name by id api} {
         catch { r test.getname } e
         assert_equal "-ERR No name" $e

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -772,6 +772,35 @@ start_server {
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] == 0}
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 2] == 2}
     }
+
+    test {XTRIM MINID marking last entry in listpack as deleted} {
+        # Regression test: when XTRIM marks the last entry in a listpack
+        # node as deleted, the pointer past the lp-count field is NULL
+        # (EOF). The delta recalculation after lpReplaceInteger must
+        # handle this to avoid listpack corruption.
+        r del mystream
+        r config set stream-node-max-entries 3
+
+        # Add 4 entries: first 3 go into node 1, 4th into node 2.
+        r XADD mystream 1-0 f v
+        r XADD mystream 2-0 f v
+        r XADD mystream 3-0 f v
+        r XADD mystream 4-0 f v
+
+        # Exact MINID trim: marks entries 1-0 and 2-0 as deleted inside
+        # node 1. Entry 3-0 is the last entry in that node, so after
+        # skipping its lp-count the pointer hits EOF (NULL).
+        r XTRIM mystream MINID = 4-0
+
+        # Verify the stream is intact and XREAD works.
+        assert_equal [r XLEN mystream] 1
+        set result [r XRANGE mystream - +]
+        assert_equal $result {{4-0 {f v}}}
+        set result [r XREAD COUNT 10 STREAMS mystream 0-0]
+        assert_equal $result {{mystream {{4-0 {f v}}}}}
+
+        r config set stream-node-max-entries 100
+    }
 }
 
 start_server {tags {"stream needs:debug"} overrides {appendonly yes}} {


### PR DESCRIPTION
# Weekly backport sweep for 9.1

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| `#3544` | IO-Threads redesign cleanup work |  |

<details><summary>Skipped / unresolved (44)</summary>

| Source PR | Title | Reason |
|---|---|---|
| `#2227` | Do the failover immediately if the replica is the best ranked replica | skipped-existing: resolution was already satisfied on target branch |
| `#3122` | Adds new (hidden) ValkeyModule_CallArgv API functions | skipped-existing: already on backport branch |
| `#2936` | Module command result callback addition | skipped-existing: resolution was already satisfied on target branch |
| `#2811` | Enhance cluster stale packet detection to prevent sub-replica and empty primary | skipped-existing: already applied or empty cherry-pick |
| `#3306` | Improve COB memory tracking with copy avoidance | skipped-existing: already applied or empty cherry-pick |
| `#3359` | Fix incorrect memory overhead calculation for watched keys | skipped-conflict: unresolved: src/multi.c |
| `#3368` | Make scripting debug test skippable | skipped-existing: already applied or empty cherry-pick |
| `#3372` | Add cluster-config-save-behavior option to control nodes.conf save behavior | skipped-existing: already applied or empty cherry-pick |
| `#3281` | Fix use zfree in cli --eval path  | skipped-existing: already applied or empty cherry-pick |
| `#3209` | Fix `valkey-cli --cluster del-node` for unreachable nodes | skipped-existing: already applied or empty cherry-pick |
| `#3392` | Add Static Module Support | skipped-conflict: unresolved: src/server.c |
| `#3033` | ARM NEON SIMD optimization for pvFind() in vset.c | skipped-existing: already applied or empty cherry-pick |
| `#3401` | Big endian bitmap byte order mismatch fix | skipped-existing: already applied or empty cherry-pick |
| `#3360` | Optimize WATCH duplicate key check from O(N) to O(1) using per-db hashtable | skipped-existing: already applied or empty cherry-pick |
| `#3443` | Fix slot-migration-max-failover-repl-bytes unable to accept -1 | skipped-existing: resolution was already satisfied on target branch |
| `#3420` | Avoid having server.h being included by cli and benchmark | skipped-existing: already applied or empty cherry-pick |
| `#3397` | Increase embedded string threshold from 64 to 128 bytes | skipped-existing: already applied or empty cherry-pick |
| `#3391` | CLUSTERSCAN range bounded scanning across contiguous slots | skipped-existing: already on backport branch |
| `#3380` | CLUSTERSCAN MATCH pattern maps to a specific slot optimizations | skipped-conflict: unresolved: src/cluster.c |
| `#3444` | Skip faster-failover test under TLS  | skipped-existing: resolution was already satisfied on target branch |
| `#3452` | Fix some flaky tests using CLIENT REPLY OFF | skipped-existing: already applied or empty cherry-pick |
| `#3461` | Attempt to deflake 'diskless no replicas drop during rdb pipe' | skipped-existing: resolution was already satisfied on target branch |
| `#3471` | Defer argument redaction by storing indices instead of rewriting argv | skipped-existing: already applied or empty cherry-pick |
| `#3440` | Fix config rewrite producing negative values for unsigned memory configs | skipped-existing: already applied or empty cherry-pick |
| `#3458` | Fix race condition during async client freeing with IO threading enabled | skipped-existing: already applied or empty cherry-pick |
| `#3498` | Fix double free in stream consumer PEL loading with corrupt RDB data | skipped-existing: already applied or empty cherry-pick |
| `#3448` | Fixes server crash when RDMA benchmark clients disconnect | skipped-existing: already on backport branch |
| `#3495` | Rewrite the faster failover test case | skipped-existing: already applied or empty cherry-pick |
| `#3516` | Fix HPERSIST RESP protocol violation on wrong-type key | skipped-existing: already applied or empty cherry-pick |
| `#3541` | Fix FD leak in connSocketBlockingConnect on timeout | skipped-existing: already applied or empty cherry-pick |
| `#3548` | Fix lua-enable-insecure-api default value cannot be changed to yes | skipped-existing: already applied or empty cherry-pick |
| `#3554` | Ensure client slot migration pointer is cleared during reset | skipped-existing: already applied or empty cherry-pick |
| `#3503` | Fix remove cached eval scripts on engine unregister | skipped-existing: already applied or empty cherry-pick |
| `#3568` | Fix GEOSEARCH BYPOLYGON leak on invalid COUNT | skipped-existing: already on backport branch |
| `#3580` | fix(syncio): Set errno on EOF in syncRead and propagate to conn->last… | skipped-existing: already on backport branch |
| `#3586` | fix(cluster): Remove per-call srand in clusterManagerNodePrimaryRandom | skipped-existing: already on backport branch |
| `#3591` | Handle NULL pointer in streamTrim listpack delta calculation | skipped-existing: already on backport branch |
| `#3596` | Fix: prevent NULL dereference crash in connectSlotExportJob when target node disappears | skipped-existing: already on backport branch |
| `#3578` | Fix Deferred Reply Placeholders in Active Deferred Buffers | skipped-existing: already on backport branch |
| `#3610` | Fix SIGSEGV in VM_GetLRU/SetLRU/GetLFU/SetLFU on NULL key | skipped-existing: already on backport branch |
| `#3641` | Add null check in updateSSLPendingFlag | skipped-existing: already on backport branch |
| `#3613` | Fix UAF in unblockClientOnKey when reprocessed command frees the client (CVE-2026-23479) | skipped-existing: already applied or empty cherry-pick |
| `#3625` | Delay full sync during yielding Lua scripts to prevent use-after-free (CVE-2026-23631) | skipped-existing: already applied or empty cherry-pick |
| `#3619` | Fix invalid memory access in RESTORE with malformed zipmap (CVE-2026-25243) | skipped-existing: already on backport branch |

</details>

---
*Generated by valkey-ci-agent using Claude Code.*