### PR TITLE
[codex] Fix streaming compression review issues

### DIFF
--- a/deps/lz4/Makefile
+++ b/deps/lz4/Makefile
@@ -9,7 +9,7 @@ DEBUG= -g
 R_CC=$(CC) $(R_CFLAGS)
 R_LD=$(CC) $(R_LDFLAGS)
 
-AR= ar
+AR ?= ar
 ARFLAGS= rcs
 
 liblz4.a: lz4.o lz4hc.o lz4frame.o xxhash.o

--- a/src/compression.c
+++ b/src/compression.c
@@ -136,6 +136,10 @@ bool streamDecompressorFrameDone(const streamDecompressor *sd) {
     return sd && sd->frame_done;
 }
 
+size_t streamDecompressorInputHint(const streamDecompressor *sd) {
+    return sd ? sd->input_hint : 0;
+}
+
 size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len) {
     if (!sc) return 0;
     const compressionCodecImpl *codec_impl = compressionCodecImplForAlgo(sc->algo);
@@ -170,6 +174,10 @@ ssize_t streamDecompressFeed(streamDecompressor *sd,
     if (sd->errored) return -1;
     *input_consumed = 0;
     if (sd->frame_done) return 0;
+    if (input_len > 0 && !input) {
+        sd->errored = true;
+        return -1;
+    }
     /* Zero output capacity is a caller bug — returning 0 with no progress
      * would cause streaming loops to spin forever. */
     if (!output || output_capacity == 0) {

--- a/src/compression.h
+++ b/src/compression.h
@@ -46,13 +46,14 @@ typedef struct {
 /* --- Streaming decompressor context --- */
 typedef struct {
     compressionAlgo algo;
-    void *ctx;       /* Private codec-specific decompressor context. */
-    bool errored;    /* Permanently failed — algorithm state is undefined after
-                      * an error. All subsequent streamDecompressFeed calls
-                      * return -1 immediately until reinitialized. */
-    bool frame_done; /* Set when the codec frame is fully decoded.
-                      * Subsequent streamDecompressFeed calls return 0
-                      * immediately (no more output). */
+    void *ctx;         /* Private codec-specific decompressor context. */
+    bool errored;      /* Permanently failed — algorithm state is undefined after
+                        * an error. All subsequent streamDecompressFeed calls
+                        * return -1 immediately until reinitialized. */
+    bool frame_done;   /* Set when the codec frame is fully decoded.
+                        * Subsequent streamDecompressFeed calls return 0
+                        * immediately (no more output). */
+    size_t input_hint; /* Preferred compressed bytes for next feed when known. */
 } streamDecompressor;
 
 /* Returns true if the algorithm supports streaming codec framing. */
@@ -73,6 +74,9 @@ void streamDecompressorDestroy(streamDecompressor *sd);
 
 /* Returns true when the codec frame has been fully decoded. */
 bool streamDecompressorFrameDone(const streamDecompressor *sd);
+/* Returns the preferred compressed input size for the next decoder feed, or 0
+ * when the codec has no current hint. */
+size_t streamDecompressorInputHint(const streamDecompressor *sd);
 
 /* Return upper bound on compressed output size.
  * The bound is conservative: it includes frame header, data, and flush/end

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -56,6 +56,7 @@ int compressionLz4DecompressorInit(streamDecompressor *sd) {
     if (LZ4F_isError(err)) return -1;
 
     sd->ctx = dctx;
+    sd->input_hint = LZ4F_HEADER_SIZE_MIN;
     return 0;
 }
 
@@ -177,6 +178,7 @@ ssize_t compressionLz4DecompressFeed(streamDecompressor *sd,
         return -1;
     }
     *input_consumed = src_size;
+    sd->input_hint = ret;
     if (ret == 0) sd->frame_done = true;
     if (dst_size > (size_t)SSIZE_MAX) {
         sd->errored = true;

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -605,16 +605,19 @@ static int streamReaderDrainCompressedBuf(streamReader *t,
     *out_written = 0;
     while (t->compressed_buf_len > 0 && *out_written < out_size) {
         size_t consumed = 0;
+        size_t feed_len = t->compressed_buf_len;
+        size_t input_hint = streamDecompressorInputHint(&t->decompressor);
+        if (input_hint > 0 && feed_len > input_hint) feed_len = input_hint;
         ssize_t produced = streamDecompressFeed(
             &t->decompressor,
             out + *out_written, out_size - *out_written,
             t->compressed_buf + t->compressed_buf_pos,
-            t->compressed_buf_len, &consumed);
+            feed_len, &consumed);
         if (produced < 0) {
             streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
             return -1;
         }
-        if (consumed > t->compressed_buf_len ||
+        if (consumed > feed_len ||
             (size_t)produced > out_size - *out_written) {
             streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
             return -1;
@@ -622,6 +625,7 @@ static int streamReaderDrainCompressedBuf(streamReader *t,
         *out_written += (size_t)produced;
         t->compressed_buf_pos += consumed;
         t->compressed_buf_len -= consumed;
+        if (streamDecompressorFrameDone(&t->decompressor)) break;
         if (consumed == 0 && produced == 0) break;
     }
     if (t->compressed_buf_len == 0) t->compressed_buf_pos = 0;
@@ -652,7 +656,11 @@ static size_t streamReaderCompressedBufTailSpace(streamReader *t) {
 }
 
 static int streamReaderRefillCompressedBuf(streamReader *t) {
+    if (streamDecompressorFrameDone(&t->decompressor)) return 0;
+
     size_t read_size = streamReaderCompressedBufTailSpace(t);
+    size_t input_hint = streamDecompressorInputHint(&t->decompressor);
+    if (input_hint > 0 && read_size > input_hint) read_size = input_hint;
     if (read_size > (size_t)SSIZE_MAX) read_size = (size_t)SSIZE_MAX;
     if (read_size == 0) return -1;
 
@@ -780,6 +788,10 @@ int streamReaderValidateEnd(streamReader *t) {
     if (!t) return -1;
     if (streamReaderProbe(t) != 0) return -1;
     if (!t->probe.compressed) return 0;
+    if (streamReaderDecompressedBufAvail(t) > 0) {
+        streamReaderSetError(t, STREAM_READER_ERROR_CORRUPT);
+        return -1;
+    }
 
     while (!streamDecompressorFrameDone(&t->decompressor)) {
         ssize_t nread = streamReaderRead(t, buf, sizeof(buf));

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -31,7 +31,6 @@
 #define __RDB_H
 
 #include <stdio.h>
-#include <string.h>
 #include "compression_rio.h"
 #include "rio.h"
 
@@ -72,17 +71,6 @@ static inline bool rdbIsForeignVersion(int rdbver) {
 
 static inline bool rdbUseValkeyMagic(int rdbver) {
     return rdbver > RDB_FOREIGN_VERSION_MAX;
-}
-
-/* Check whether a buffer starts with a recognized RDB magic prefix.
- * "VALKEY" is the exact 6-byte magic for Valkey-format RDB (e.g. "VALKEY080").
- * "REDIS" + digit matches the legacy format (e.g. "REDIS0080") for all
- * versions 0000-9999, avoiding a forward-compatibility cliff at version 1000.
- * Matches the same checks used in rdbLoadRio() (rdb.c). */
-static inline bool rdbIsValidMagic(const uint8_t *header, size_t len) {
-    if (len < 6) return false;
-    if (memcmp(header, "VALKEY", 6) == 0) return true;
-    return memcmp(header, "REDIS", 5) == 0 && header[5] >= '0' && header[5] <= '9';
 }
 
 /* Defines related to the dump file format. To store 32 bits lengths for short

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -1124,7 +1124,7 @@ TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
-    ASSERT_EQ(((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM, 0);
+    ASSERT_FALSE(((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM);
 
     const char *payload = "skip-checksum-payload";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
@@ -1382,7 +1382,7 @@ TEST_F(CompressionTest, rdbLoadProgressCallbackStreamingGuard) {
     const char sample[] = "progress-guard";
     rdbLoadProgressCallback((rio *)&cr, sample, sizeof(sample) - 1);
 
-    ASSERT_EQ(cr.base.flags & RIO_FLAG_READ_ERROR, 0) << "write-side streaming rio must not set read error";
+    ASSERT_FALSE(cr.base.flags & RIO_FLAG_READ_ERROR) << "write-side streaming rio must not set read error";
 
     compressRioDestroy(&cr);
     sdsfree(inner.io.buffer.ptr);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -184,7 +184,7 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)input, input_len,
                                                 FLUSH_END);
-    ASSERT_GT(compressed_len, 0u) << "compress should succeed";
+    ASSERT_GT(compressed_len, 0) << "compress should succeed";
     ASSERT_EQ(sc.stream_started, false) << "frame should be closed after FLUSH_END";
     streamCompressorDestroy(&sc);
 
@@ -294,7 +294,7 @@ TEST_F(CompressionTest, streamDecompressFeedErrors) {
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)payload, strlen(payload),
                                                 FLUSH_END);
-    ASSERT_GT(compressed_len, 0u);
+    ASSERT_GT(compressed_len, 0);
     streamCompressorDestroy(&sc);
 
     ASSERT_TRUE(streamDecompressFeed(&sd, out, sizeof(out),
@@ -1044,7 +1044,7 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
     /* Get the compressed output from the buffer rio */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
-    ASSERT_GT(compressed_len, VKCS_ENVELOPE_SIZE) << "compressed output should exist";
+    ASSERT_GT(compressed_len, (size_t)VKCS_ENVELOPE_SIZE) << "compressed output should exist";
 
     /* Verify VKCS envelope */
     ASSERT_EQ(compressed[0], (char)VKCS_MAGIC_0) << "magic V";
@@ -1323,7 +1323,7 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
     /* Verify the entire stream decompresses correctly */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
-    ASSERT_GT(compressed_len, VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(compressed_len, (size_t)VKCS_ENVELOPE_SIZE);
 
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -199,7 +199,7 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
                                                     &input_consumed);
     ASSERT_GT(decompressed_len, 0) << "decompress should succeed";
     ASSERT_EQ((size_t)decompressed_len, input_len) << "decompressed length should match input";
-    ASSERT_TRUE(memcmp(decompressed, input, input_len) == 0) << "decompressed content should match input";
+    ASSERT_EQ(memcmp(decompressed, input, input_len), 0) << "decompressed content should match input";
     ASSERT_EQ(input_consumed, (size_t)compressed_len) << "all compressed input should be consumed";
 
     streamDecompressorDestroy(&sd);
@@ -220,8 +220,9 @@ TEST_F(CompressionTest, streamCompressOutputBound) {
     size_t b_before = streamCompressOutputBound(&sc, 1024);
     uint8_t *seed_buf = (uint8_t *)zmalloc(b_before);
     ASSERT_NE(seed_buf, nullptr);
-    ASSERT_TRUE(streamCompressFeed(&sc, seed_buf, b_before,
-                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) >= 0)
+    ASSERT_GE(streamCompressFeed(&sc, seed_buf, b_before,
+                                 (const uint8_t *)"x", 1, FLUSH_CONTINUE),
+              0)
         << "seed write should start the frame";
     size_t b_after = streamCompressOutputBound(&sc, 1024);
     ASSERT_EQ(b_before, b_after) << "bound should be the same before and after frame start";
@@ -238,15 +239,17 @@ TEST_F(CompressionTest, streamCompressOutputBound) {
 TEST_F(CompressionTest, streamCompressFeedErrors) {
     uint8_t buf[64];
     /* nullptr compressor */
-    ASSERT_TRUE(streamCompressFeed(nullptr, buf, sizeof(buf),
-                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
+    ASSERT_EQ(streamCompressFeed(nullptr, buf, sizeof(buf),
+                                 (const uint8_t *)"x", 1, FLUSH_CONTINUE),
+              -1)
         << "nullptr sc should return -1";
 
     /* nullptr output buffer */
     streamCompressor sc;
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
-    ASSERT_TRUE(streamCompressFeed(&sc, nullptr, sizeof(buf),
-                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
+    ASSERT_EQ(streamCompressFeed(&sc, nullptr, sizeof(buf),
+                                 (const uint8_t *)"x", 1, FLUSH_CONTINUE),
+              -1)
         << "nullptr output should return -1";
     streamCompressorDestroy(&sc);
 }
@@ -259,29 +262,33 @@ TEST_F(CompressionTest, streamDecompressFeedErrors) {
     size_t consumed = 0;
 
     /* nullptr decompressor */
-    ASSERT_TRUE(streamDecompressFeed(nullptr, buf, sizeof(buf),
-                                     (const uint8_t *)"x", 1, &consumed) == -1)
+    ASSERT_EQ(streamDecompressFeed(nullptr, buf, sizeof(buf),
+                                   (const uint8_t *)"x", 1, &consumed),
+              -1)
         << "nullptr sd should return -1";
 
     /* nullptr input_consumed */
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
-    ASSERT_TRUE(streamDecompressFeed(&sd, buf, sizeof(buf),
-                                     (const uint8_t *)"x", 1, nullptr) == -1)
+    ASSERT_EQ(streamDecompressFeed(&sd, buf, sizeof(buf),
+                                   (const uint8_t *)"x", 1, nullptr),
+              -1)
         << "nullptr input_consumed should return -1";
     ASSERT_EQ(sd.errored, false) << "decompressor should not be errored by nullptr bookkeeping arg";
 
     streamDecompressor sd_null_input;
     ASSERT_EQ(streamDecompressorInit(&sd_null_input, ALGO_LZ4), 0);
-    ASSERT_TRUE(streamDecompressFeed(&sd_null_input, buf, sizeof(buf),
-                                     nullptr, 1, &consumed) == -1)
+    ASSERT_EQ(streamDecompressFeed(&sd_null_input, buf, sizeof(buf),
+                                   nullptr, 1, &consumed),
+              -1)
         << "nullptr input with non-zero input_len should return -1";
     ASSERT_EQ(sd_null_input.errored, true) << "nullptr input should latch a sticky decompressor error";
     streamDecompressorDestroy(&sd_null_input);
 
     /* Zero output capacity should return -1 (no-progress prevention) */
-    ASSERT_TRUE(streamDecompressFeed(&sd, buf, 0,
-                                     (const uint8_t *)"x", 1, &consumed) == -1)
+    ASSERT_EQ(streamDecompressFeed(&sd, buf, 0,
+                                   (const uint8_t *)"x", 1, &consumed),
+              -1)
         << "zero output capacity should return -1";
     ASSERT_EQ(sd.errored, true) << "decompressor should enter sticky errored state";
 
@@ -297,9 +304,10 @@ TEST_F(CompressionTest, streamDecompressFeedErrors) {
     ASSERT_GT(compressed_len, 0);
     streamCompressorDestroy(&sc);
 
-    ASSERT_TRUE(streamDecompressFeed(&sd, out, sizeof(out),
-                                     compressed, (size_t)compressed_len,
-                                     &consumed) == -1)
+    ASSERT_EQ(streamDecompressFeed(&sd, out, sizeof(out),
+                                   compressed, (size_t)compressed_len,
+                                   &consumed),
+              -1)
         << "errored decompressor should fail even with valid input";
     zfree(compressed);
 
@@ -430,15 +438,15 @@ TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
             uint8_t out[16] = {0};
             ASSERT_EQ(streamReaderRead(t, out, cases[i].expected_read_len), (ssize_t)cases[i].expected_read_len)
                 << cases[i].name;
-            ASSERT_TRUE(memcmp(out, cases[i].input, cases[i].expected_read_len) == 0) << cases[i].name;
-            ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == 0) << cases[i].name;
+            ASSERT_EQ(memcmp(out, cases[i].input, cases[i].expected_read_len), 0) << cases[i].name;
+            ASSERT_EQ(streamReaderRead(t, out, sizeof(out)), 0) << cases[i].name;
         } else {
             ASSERT_EQ(streamReaderProbe(t), -1) << cases[i].name;
             ASSERT_EQ(streamReaderGetInfo(t, &info), -1) << cases[i].name;
-            ASSERT_TRUE(streamReaderGetError(t) == cases[i].expected_error) << cases[i].name;
+            ASSERT_EQ(streamReaderGetError(t), cases[i].expected_error) << cases[i].name;
 
             uint8_t out[8] = {0};
-            ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == -1) << cases[i].name;
+            ASSERT_EQ(streamReaderRead(t, out, sizeof(out)), -1) << cases[i].name;
         }
 
         streamReaderDestroy(t);
@@ -466,8 +474,8 @@ TEST_F(CompressionTest, streamReaderRejectsOversizedReadRequest) {
         << "oversized read failure should not poison the reader";
     ASSERT_FALSE(info.compressed) << "plain input should still probe as passthrough";
 
-    ASSERT_TRUE(streamReaderRead(t, out, sizeof(input)) == (ssize_t)sizeof(input));
-    ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
+    ASSERT_EQ(streamReaderRead(t, out, sizeof(input)), (ssize_t)sizeof(input));
+    ASSERT_EQ(memcmp(out, input, sizeof(input)), 0) << "subsequent valid read should still succeed";
 
     streamReaderDestroy(t);
 }
@@ -553,7 +561,7 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
         streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
         streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
         ASSERT_NE(w, nullptr) << cases[i].name;
-        ASSERT_TRUE(streamWriterWrite(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
+        ASSERT_GE(streamWriterWrite(w, cases[i].payload, payload_len), 0) << cases[i].name;
         ASSERT_EQ(streamWriterFinish(w), 0) << cases[i].name;
         streamWriterDestroy(w);
 
@@ -575,15 +583,15 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
 
             uint8_t out[64] = {0};
             ASSERT_EQ(streamReaderRead(r, out, payload_len), (ssize_t)payload_len) << cases[i].name;
-            ASSERT_TRUE(memcmp(out, cases[i].payload, payload_len) == 0) << cases[i].name;
-            ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0) << cases[i].name;
+            ASSERT_EQ(memcmp(out, cases[i].payload, payload_len), 0) << cases[i].name;
+            ASSERT_EQ(streamReaderRead(r, out, sizeof(out)), 0) << cases[i].name;
         } else {
             ASSERT_EQ(streamReaderProbe(r), -1) << cases[i].name;
             ASSERT_EQ(streamReaderGetInfo(r, &info), -1) << cases[i].name;
             ASSERT_EQ(streamReaderGetError(r), STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
 
             uint8_t out[32] = {0};
-            ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == -1) << cases[i].name;
+            ASSERT_EQ(streamReaderRead(r, out, sizeof(out)), -1) << cases[i].name;
         }
 
         streamReaderDestroy(r);
@@ -611,10 +619,10 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr) << "streamWriterCreate should succeed";
     const size_t first_chunk_len = 4 * 1024;
-    ASSERT_TRUE(streamWriterWrite(w, payload, first_chunk_len) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, first_chunk_len), 0);
     ASSERT_EQ(streamWriterFlush(w), 0);
     size_t fail_after_pos = sdslen((const char *)db.data);
-    ASSERT_TRUE(streamWriterWrite(w, payload + first_chunk_len, payload_len - first_chunk_len) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload + first_chunk_len, payload_len - first_chunk_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
 
@@ -634,7 +642,7 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     ssize_t n1 = streamReaderRead(r, out, out_len);
     ASSERT_GT(n1, 0) << "first read should return partial output";
     ASSERT_LT(n1, (ssize_t)out_len) << "injected read error should stop the first read early";
-    ASSERT_TRUE(memcmp(out, payload, (size_t)n1) == 0);
+    ASSERT_EQ(memcmp(out, payload, (size_t)n1), 0);
     ASSERT_EQ(streamReaderRead(r, out, out_len), -1) << "second read should fail immediately";
 
     streamReaderDestroy(r);
@@ -654,8 +662,9 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     uint8_t pass_out[64];
     ssize_t p1 = streamReaderRead(rp, pass_out, sizeof(pass_out));
     ASSERT_GT(p1, 0) << "passthrough first read should return partial output";
-    ASSERT_TRUE(memcmp(pass_out, plain, (size_t)p1) == 0) << "passthrough partial bytes should match input prefix";
-    ASSERT_TRUE(streamReaderRead(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
+    ASSERT_EQ(memcmp(pass_out, plain, (size_t)p1), 0) << "passthrough partial bytes should match input prefix";
+    ASSERT_EQ(streamReaderRead(rp, pass_out, sizeof(pass_out)), -1)
+        << "passthrough second read should fail immediately";
     streamReaderDestroy(rp);
     zfree(out);
 
@@ -677,16 +686,16 @@ TEST_F(CompressionTest, streamWriterCreateDestroy) {
     dynamicBufFree(&db);
 
     /* nullptr config should fail */
-    ASSERT_TRUE(streamWriterCreate(nullptr, emitToDynamicBuf, &db) == nullptr) << "nullptr config should return nullptr";
+    ASSERT_EQ(streamWriterCreate(nullptr, emitToDynamicBuf, &db), nullptr) << "nullptr config should return nullptr";
 
     /* nullptr emit_cb should fail */
-    ASSERT_TRUE(streamWriterCreate(&cfg, nullptr, nullptr) == nullptr) << "nullptr emit_cb should return nullptr";
+    ASSERT_EQ(streamWriterCreate(&cfg, nullptr, nullptr), nullptr) << "nullptr emit_cb should return nullptr";
 
     /* ALGO_NONE should fail */
     streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == nullptr) << "ALGO_NONE should return nullptr";
+    ASSERT_EQ(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db), nullptr) << "ALGO_NONE should return nullptr";
     bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == nullptr) << "ALGO_LZF should return nullptr";
+    ASSERT_EQ(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db), nullptr) << "ALGO_LZF should return nullptr";
 
     /* Concrete stream kinds outside the currently named ones are valid. */
     streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
@@ -710,16 +719,17 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
     /* Write some data */
     const char *test_data = "Hello, compression world! This is a test of the stream writer API.";
     size_t data_len = strlen(test_data);
-    ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
+    ASSERT_GE(streamWriterWrite(t, test_data, data_len), 0);
     ASSERT_EQ(streamWriterIsErrored(t), 0) << "should not be errored after write";
-    ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "write should emit envelope";
+    ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE) << "write should emit envelope";
 
     /* Finalize */
     ASSERT_EQ(streamWriterFinish(t), 0);
     ASSERT_EQ(streamWriterIsErrored(t), 0) << "should not be errored after finish";
 
     /* Verify output starts with VKCS envelope */
-    ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "output should have at least envelope size";
+    ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE)
+        << "output should have at least envelope size";
     ASSERT_EQ(db.data[0], VKCS_MAGIC_0) << "magic byte 0";
     ASSERT_EQ(db.data[1], VKCS_MAGIC_1) << "magic byte 1";
     ASSERT_EQ(db.data[2], VKCS_MAGIC_2) << "magic byte 2";
@@ -753,7 +763,7 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
     }
 
     ASSERT_EQ(total_decompressed, data_len) << "decompressed length should match original";
-    ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match original";
+    ASSERT_EQ(memcmp(decompressed, test_data, data_len), 0) << "decompressed data should match original";
 
     streamDecompressorDestroy(&sd);
     streamWriterDestroy(t);
@@ -775,7 +785,7 @@ TEST_F(CompressionTest, streamWriterLargeSingleWrite) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(t, nullptr);
-    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(t, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
@@ -794,7 +804,7 @@ TEST_F(CompressionTest, streamWriterLargeSingleWrite) {
         ASSERT_GT(nread, 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
-    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+    ASSERT_EQ(memcmp(out, payload, payload_len), 0);
     ASSERT_EQ(streamReaderRead(r, out, 1), 0) << "reader should stop at frame end";
 
     zfree(out);
@@ -819,7 +829,7 @@ TEST_F(CompressionTest, streamReaderSmallReadsRoundTrip) {
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr);
-    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
 
@@ -842,7 +852,7 @@ TEST_F(CompressionTest, streamReaderSmallReadsRoundTrip) {
         total += (size_t)nread;
     }
 
-    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+    ASSERT_EQ(memcmp(out, payload, payload_len), 0);
     ASSERT_EQ(streamReaderRead(r, out, 1), 0) << "reader should stop at frame end";
 
     zfree(out);
@@ -861,14 +871,14 @@ TEST_F(CompressionTest, streamWriterFlushBehavior) {
     ASSERT_NE(t, nullptr);
 
     ASSERT_EQ(streamWriterFlush(t), 0) << "flush before write should be no-op success";
-    ASSERT_TRUE(sdslen((const char *)db.data) == 0) << "flush before write should not emit bytes";
+    ASSERT_EQ(sdslen((const char *)db.data), 0u) << "flush before write should not emit bytes";
 
-    ASSERT_TRUE(streamWriterWrite(t, "first chunk", 11) >= 0);
+    ASSERT_GE(streamWriterWrite(t, "first chunk", 11), 0);
     ASSERT_EQ(streamWriterFlush(t), 0);
-    ASSERT_TRUE(streamWriterWrite(t, "second chunk", 12) >= 0);
+    ASSERT_GE(streamWriterWrite(t, "second chunk", 12), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
 
-    ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
@@ -892,7 +902,7 @@ TEST_F(CompressionTest, streamWriterFlushBehavior) {
     }
 
     ASSERT_EQ(total_decompressed, 23u);
-    ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0);
+    ASSERT_EQ(memcmp(decompressed, "first chunksecond chunk", 23), 0);
 
     streamDecompressorDestroy(&sd);
     streamWriterDestroy(t);
@@ -907,12 +917,12 @@ TEST_F(CompressionTest, streamWriterFlushAfterFinishIsNoop) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(t, nullptr);
 
-    ASSERT_TRUE(streamWriterWrite(t, "payload", 7) >= 0);
+    ASSERT_GE(streamWriterWrite(t, "payload", 7), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
     ASSERT_EQ(streamWriterFlush(t), 0) << "flush after finish should be a no-op success";
-    ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "flush after finish should not emit bytes";
+    ASSERT_EQ(sdslen((const char *)db.data), len_after_finish) << "flush after finish should not emit bytes";
 
     streamWriterDestroy(t);
     dynamicBufFree(&db);
@@ -929,12 +939,13 @@ TEST_F(CompressionTest, streamWriterCodecChecksumToggle) {
                                                   codec_checksum);
         streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
         ASSERT_NE(t, nullptr);
-        ASSERT_TRUE(streamWriterWrite(t, payload, strlen(payload)) >= 0);
+        ASSERT_GE(streamWriterWrite(t, payload, strlen(payload)), 0);
         ASSERT_EQ(streamWriterFinish(t), 0);
 
-        ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
-        ASSERT_TRUE(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
-                                             sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE) == codec_checksum)
+        ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
+        ASSERT_EQ(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
+                                           sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE),
+                  codec_checksum)
             << "LZ4 frame should reflect configured codec checksum setting";
 
         streamWriterDestroy(t);
@@ -950,7 +961,7 @@ TEST_F(CompressionTest, streamReaderValidateEndAcceptsClosedFrame) {
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr);
-    ASSERT_TRUE(streamWriterWrite(w, payload, strlen(payload)) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, strlen(payload)), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
 
     MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 7};
@@ -959,8 +970,8 @@ TEST_F(CompressionTest, streamReaderValidateEndAcceptsClosedFrame) {
     ASSERT_NE(reader, nullptr);
 
     char out[64];
-    ASSERT_TRUE(streamReaderRead(reader, out, strlen(payload)) == (ssize_t)strlen(payload));
-    ASSERT_TRUE(memcmp(out, payload, strlen(payload)) == 0);
+    ASSERT_EQ(streamReaderRead(reader, out, strlen(payload)), (ssize_t)strlen(payload));
+    ASSERT_EQ(memcmp(out, payload, strlen(payload)), 0);
     ASSERT_EQ(streamReaderValidateEnd(reader), 0);
 
     streamReaderDestroy(reader);
@@ -976,7 +987,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsTrailingBytes) {
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr);
-    ASSERT_TRUE(streamWriterWrite(w, payload, strlen(payload)) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, strlen(payload)), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
     db.data = (uint8_t *)sdscatlen((sds)db.data, "x", 1);
 
@@ -986,7 +997,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsTrailingBytes) {
     ASSERT_NE(reader, nullptr);
 
     char out[64];
-    ASSERT_TRUE(streamReaderRead(reader, out, strlen(payload)) == (ssize_t)strlen(payload));
+    ASSERT_EQ(streamReaderRead(reader, out, strlen(payload)), (ssize_t)strlen(payload));
     ASSERT_EQ(streamReaderValidateEnd(reader), -1);
     ASSERT_EQ(streamReaderGetError(reader), STREAM_READER_ERROR_CORRUPT);
 
@@ -1004,7 +1015,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsUnreadDecodedBytes) {
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr);
-    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
 
     MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
@@ -1013,8 +1024,8 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsUnreadDecodedBytes) {
     ASSERT_NE(reader, nullptr);
 
     char out[8];
-    ASSERT_TRUE(streamReaderRead(reader, out, sizeof(out)) == (ssize_t)sizeof(out));
-    ASSERT_TRUE(memcmp(out, payload, sizeof(out)) == 0);
+    ASSERT_EQ(streamReaderRead(reader, out, sizeof(out)), (ssize_t)sizeof(out));
+    ASSERT_EQ(memcmp(out, payload, sizeof(out)), 0);
     ASSERT_EQ(streamReaderValidateEnd(reader), -1);
     ASSERT_EQ(streamReaderGetError(reader), STREAM_READER_ERROR_CORRUPT);
 
@@ -1036,7 +1047,7 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
                             "Pack my box with five dozen liquor jugs.";
     size_t data_len = strlen(test_data);
-    ASSERT_TRUE(rioWrite((rio *)&cr, test_data, data_len) != 0) << "rioWrite should succeed";
+    ASSERT_NE(rioWrite((rio *)&cr, test_data, data_len), 0u) << "rioWrite should succeed";
 
     /* Finalize and destroy */
     ASSERT_EQ(compressRioFinish(&cr), 0);
@@ -1076,7 +1087,7 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
     }
 
     ASSERT_EQ(total_decompressed, data_len) << "decompressed length should match";
-    ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match";
+    ASSERT_EQ(memcmp(decompressed, test_data, data_len), 0) << "decompressed data should match";
 
     streamDecompressorDestroy(&sd);
     compressRioDestroy(&cr);
@@ -1095,7 +1106,7 @@ TEST_F(CompressionTest, compressRioDoesNotInstallRdbChecksum) {
 
     const char *payload = "checksum-payload-for-compressed-rio";
     size_t payload_len = strlen(payload);
-    ASSERT_TRUE(rioWrite((rio *)&cr, payload, payload_len) != 0);
+    ASSERT_NE(rioWrite((rio *)&cr, payload, payload_len), 0u);
 
     ASSERT_EQ(cr.base.cksum, 0u) << "compress_rio should not own RDB checksum policy";
 
@@ -1113,10 +1124,10 @@ TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
-    ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) == 0);
+    ASSERT_EQ(((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM, 0);
 
     const char *payload = "skip-checksum-payload";
-    ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
+    ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
     ASSERT_EQ(cr.base.cksum, 0u) << "compress_rio should not inspect RDB checksum flags";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
@@ -1134,7 +1145,7 @@ TEST_F(CompressionTest, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
     ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
 
     const char *payload = "codec-checksum-enabled";
-    ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
+    ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
     ASSERT_EQ(cr.base.cksum, 0u)
         << "codec checksums should not control standard RDB checksum tracking";
 
@@ -1153,7 +1164,7 @@ TEST_F(CompressionTest, rioDecoratorsPreserveInnerType) {
     ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &wcfg), 0);
     /* Decorators preserve the inner backend type via the type field.
      * Verify the decorator reports the same type as the wrapped rio. */
-    ASSERT_TRUE(rioCheckType((rio *)&cr) == RIO_TYPE_BUFFER);
+    ASSERT_EQ(rioCheckType((rio *)&cr), (uint8_t)RIO_TYPE_BUFFER);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 
@@ -1163,7 +1174,7 @@ TEST_F(CompressionTest, rioDecoratorsPreserveInnerType) {
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
     decompressRio dr;
     ASSERT_EQ(rioInitWithDecompress(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
-    ASSERT_TRUE(rioCheckType((rio *)&dr) == RIO_TYPE_BUFFER);
+    ASSERT_EQ(rioCheckType((rio *)&dr), (uint8_t)RIO_TYPE_BUFFER);
     decompressRioDestroy(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
 }
@@ -1181,7 +1192,7 @@ TEST_F(CompressionTest, decompressRioRoundTrip) {
     const char *test_data = "Decompression rio test data. "
                             "This should round-trip through compress then decompress.";
     size_t data_len = strlen(test_data);
-    ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
+    ASSERT_GE(streamWriterWrite(t, test_data, data_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
@@ -1197,8 +1208,8 @@ TEST_F(CompressionTest, decompressRioRoundTrip) {
     /* Read decompressed data */
     char result[256];
     memset(result, 0, sizeof(result));
-    ASSERT_TRUE(rioRead((rio *)&dr, result, data_len) != 0) << "rioRead should succeed";
-    ASSERT_TRUE(memcmp(result, test_data, data_len) == 0) << "decompressed data should match original";
+    ASSERT_NE(rioRead((rio *)&dr, result, data_len), 0u) << "rioRead should succeed";
+    ASSERT_EQ(memcmp(result, test_data, data_len), 0) << "decompressed data should match original";
 
     decompressRioDestroy(&dr);
     sdsfree(comp_sds);
@@ -1213,7 +1224,7 @@ TEST_F(CompressionTest, decompressRioTellTracksSourceProgress) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(t, nullptr);
-    ASSERT_TRUE(streamWriterWrite(t, payload.data(), payload.size()) >= 0);
+    ASSERT_GE(streamWriterWrite(t, payload.data(), payload.size()), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
@@ -1225,9 +1236,9 @@ TEST_F(CompressionTest, decompressRioTellTracksSourceProgress) {
     ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     char out[2048];
-    ASSERT_TRUE(rioRead((rio *)&dr, out, sizeof(out)) != 0);
-    ASSERT_TRUE(rioTell((rio *)&dr) == rioTell(&buffer_rio));
-    ASSERT_TRUE((size_t)rioTell((rio *)&dr) < sizeof(out))
+    ASSERT_NE(rioRead((rio *)&dr, out, sizeof(out)), 0u);
+    ASSERT_EQ(rioTell((rio *)&dr), rioTell(&buffer_rio));
+    ASSERT_LT((size_t)rioTell((rio *)&dr), sizeof(out))
         << "decompress rio tell should track source bytes, not logical output bytes";
 
     decompressRioDestroy(&dr);
@@ -1251,8 +1262,8 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
 
         char result[64];
         memset(result, 0, sizeof(result));
-        ASSERT_TRUE(rioRead((rio *)&dr, result, payload_len) != 0) << "rioRead should succeed";
-        ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "payload should be replayed exactly";
+        ASSERT_NE(rioRead((rio *)&dr, result, payload_len), 0u) << "rioRead should succeed";
+        ASSERT_EQ(memcmp(result, payload, payload_len), 0) << "payload should be replayed exactly";
 
         decompressRioDestroy(&dr);
         sdsfree(buf);
@@ -1268,8 +1279,8 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
 
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
         decompressRio dr;
-        ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, nullptr) ==
-                    DECOMPRESS_RIO_INIT_INCOMPATIBLE);
+        ASSERT_EQ(rioInitWithDecompress(&dr, &buffer_rio, &cfg, nullptr),
+                  DECOMPRESS_RIO_INIT_INCOMPATIBLE);
 
         sdsfree(buf);
     }
@@ -1285,7 +1296,7 @@ TEST_F(CompressionTest, compressRioFinishIdempotent) {
     compressRio cr;
     ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
 
-    ASSERT_TRUE(rioWrite((rio *)&cr, "test", 4) != 0);
+    ASSERT_NE(rioWrite((rio *)&cr, "test", 4), 0u);
     ASSERT_EQ(compressRioFinish(&cr), 0);
     size_t len_after_first = sdslen(buffer_rio.io.buffer.ptr);
 
@@ -1309,13 +1320,13 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
     ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
 
     /* Write some data */
-    ASSERT_TRUE(rioWrite((rio *)&cr, "first chunk", 11) != 0);
+    ASSERT_NE(rioWrite((rio *)&cr, "first chunk", 11), 0u);
 
     /* Flush mid-stream — should NOT end the frame */
-    ASSERT_TRUE(rioFlush((rio *)&cr) != 0) << "flush should succeed";
+    ASSERT_NE(rioFlush((rio *)&cr), 0) << "flush should succeed";
 
     /* Write more data — should succeed because frame is still open */
-    ASSERT_TRUE(rioWrite((rio *)&cr, "second chunk", 12) != 0) << "write after flush should succeed";
+    ASSERT_NE(rioWrite((rio *)&cr, "second chunk", 12), 0u) << "write after flush should succeed";
 
     /* Now finalize */
     ASSERT_EQ(compressRioFinish(&cr), 0);
@@ -1348,7 +1359,8 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
     }
 
     ASSERT_EQ(total_decompressed, 23u) << "total decompressed should be 23 bytes";
-    ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0) << "decompressed should match concatenated input";
+    ASSERT_EQ(memcmp(decompressed, "first chunksecond chunk", 23), 0)
+        << "decompressed should match concatenated input";
 
     streamDecompressorDestroy(&sd);
     compressRioDestroy(&cr);
@@ -1370,7 +1382,7 @@ TEST_F(CompressionTest, rdbLoadProgressCallbackStreamingGuard) {
     const char sample[] = "progress-guard";
     rdbLoadProgressCallback((rio *)&cr, sample, sizeof(sample) - 1);
 
-    ASSERT_TRUE((cr.base.flags & RIO_FLAG_READ_ERROR) == 0) << "write-side streaming rio must not set read error";
+    ASSERT_EQ(cr.base.flags & RIO_FLAG_READ_ERROR, 0) << "write-side streaming rio must not set read error";
 
     compressRioDestroy(&cr);
     sdsfree(inner.io.buffer.ptr);
@@ -1398,7 +1410,7 @@ TEST_F(CompressionTest, decompressRioLargePayload) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(t, nullptr);
 
-    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(t, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
@@ -1422,7 +1434,7 @@ TEST_F(CompressionTest, decompressRioLargePayload) {
         total_read += chunk;
     }
 
-    ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
+    ASSERT_EQ(memcmp(result, payload, payload_len), 0) << "decompressed data should match original";
 
     decompressRioDestroy(&dr);
     sdsfree(comp_sds);
@@ -1449,7 +1461,7 @@ TEST_F(CompressionTest, decompressRioDirectPath) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(t, nullptr);
 
-    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(t, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
@@ -1464,7 +1476,7 @@ TEST_F(CompressionTest, decompressRioDirectPath) {
     uint8_t *result = (uint8_t *)zmalloc(payload_len);
     size_t ret = rioRead((rio *)&dr, result, payload_len);
     ASSERT_NE(ret, 0u) << "single large rioRead should succeed";
-    ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
+    ASSERT_EQ(memcmp(result, payload, payload_len), 0) << "decompressed data should match original";
 
     decompressRioDestroy(&dr);
     sdsfree(comp_sds);
@@ -1488,7 +1500,7 @@ TEST_F(CompressionTest, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr);
-    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
     size_t frame_len = sdslen((const char *)db.data);
@@ -1507,11 +1519,11 @@ TEST_F(CompressionTest, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     char out[128];
     memset(out, 0, sizeof(out));
     ASSERT_EQ(streamReaderRead(r, out, payload_len), (ssize_t)payload_len);
-    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
+    ASSERT_EQ(memcmp(out, payload, payload_len), 0);
 
     /* The reader must stop cleanly at frame end instead of trying to decode
      * trailing bytes as part of the same compressed frame. */
-    ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0);
+    ASSERT_EQ(streamReaderRead(r, out, sizeof(out)), 0);
     ASSERT_EQ(mr.pos, frame_len) << "streamReader must not consume bytes after the LZ4 frame";
 
     streamReaderDestroy(r);
@@ -1532,11 +1544,11 @@ TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(w, nullptr);
-    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
 
-    ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE + 1);
+    ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE + 1);
     MemReader mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data) - 1;
@@ -1547,8 +1559,8 @@ TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
 
     uint8_t out[payload_len];
     ASSERT_EQ(streamReaderRead(r, out, payload_len), (ssize_t)payload_len);
-    ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(streamReaderRead(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
+    ASSERT_EQ(memcmp(out, payload, payload_len), 0);
+    ASSERT_LT(streamReaderRead(r, out, 1), 0) << "EOF before frame end should be treated as corruption";
     ASSERT_EQ(streamReaderGetError(r), STREAM_READER_ERROR_CORRUPT)
         << "truncated compressed frame should latch corruption, not I/O";
 
@@ -1566,20 +1578,20 @@ TEST_F(CompressionTest, streamWriterWriteAfterFinish) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_NE(t, nullptr);
 
-    ASSERT_TRUE(streamWriterWrite(t, "hello", 5) >= 0);
+    ASSERT_GE(streamWriterWrite(t, "hello", 5), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
     /* Write after finish must fail and emit no output. */
-    ASSERT_TRUE(streamWriterWrite(t, "world", 5) < 0);
-    ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "write after finish should not produce output";
+    ASSERT_LT(streamWriterWrite(t, "world", 5), 0);
+    ASSERT_EQ(sdslen((const char *)db.data), len_after_finish) << "write after finish should not produce output";
 
     /* Second finish — should also be a no-op */
     ASSERT_EQ(streamWriterFinish(t), 0);
-    ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "second finish should not produce output";
+    ASSERT_EQ(sdslen((const char *)db.data), len_after_finish) << "second finish should not produce output";
 
     /* Verify the stream is still valid: one envelope + one frame */
-    ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
@@ -1599,7 +1611,8 @@ TEST_F(CompressionTest, streamWriterWriteAfterFinish) {
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_TRUE(total == 5 && memcmp(decompressed, "hello", 5) == 0) << "should decompress to 'hello' only";
+    ASSERT_EQ(total, 5u);
+    ASSERT_EQ(memcmp(decompressed, "hello", 5), 0) << "should decompress to 'hello' only";
 
     streamDecompressorDestroy(&sd);
     streamWriterDestroy(t);
@@ -1617,16 +1630,17 @@ TEST_F(CompressionTest, independentStreamsCoexist) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t1 = streamWriterCreate(&cfg, emitToDynamicBuf, &db1);
     streamWriter *t2 = streamWriterCreate(&cfg, emitToDynamicBuf, &db2);
-    ASSERT_TRUE(t1 != nullptr && t2 != nullptr);
+    ASSERT_NE(t1, nullptr);
+    ASSERT_NE(t2, nullptr);
 
     const char *data1 = "Stream one data - unique content for first stream AAAA";
     const char *data2 = "Stream two data - different content for second stream BBBB";
 
     /* Interleave writes to both streams */
-    ASSERT_TRUE(streamWriterWrite(t1, data1, strlen(data1)) >= 0);
-    ASSERT_TRUE(streamWriterWrite(t2, data2, strlen(data2)) >= 0);
-    ASSERT_TRUE(streamWriterWrite(t1, data1, strlen(data1)) >= 0); /* write again to stream 1 */
-    ASSERT_TRUE(streamWriterWrite(t2, data2, strlen(data2)) >= 0); /* write again to stream 2 */
+    ASSERT_GE(streamWriterWrite(t1, data1, strlen(data1)), 0);
+    ASSERT_GE(streamWriterWrite(t2, data2, strlen(data2)), 0);
+    ASSERT_GE(streamWriterWrite(t1, data1, strlen(data1)), 0); /* write again to stream 1 */
+    ASSERT_GE(streamWriterWrite(t2, data2, strlen(data2)), 0); /* write again to stream 2 */
 
     ASSERT_EQ(streamWriterFinish(t1), 0);
     ASSERT_EQ(streamWriterFinish(t2), 0);
@@ -1646,9 +1660,9 @@ TEST_F(CompressionTest, independentStreamsCoexist) {
 
         char result[256];
         memset(result, 0, sizeof(result));
-        ASSERT_TRUE(rioRead((rio *)&dr, result, expected_len) != 0) << "rioRead should succeed for coexisting stream";
-        ASSERT_TRUE(memcmp(result, expected, strlen(expected)) == 0) << "first half should match";
-        ASSERT_TRUE(memcmp(result + strlen(expected), expected, strlen(expected)) == 0) << "second half should match";
+        ASSERT_NE(rioRead((rio *)&dr, result, expected_len), 0u) << "rioRead should succeed for coexisting stream";
+        ASSERT_EQ(memcmp(result, expected, strlen(expected)), 0) << "first half should match";
+        ASSERT_EQ(memcmp(result + strlen(expected), expected, strlen(expected)), 0) << "second half should match";
 
         decompressRioDestroy(&dr);
         sdsfree(comp);
@@ -1674,7 +1688,7 @@ TEST_F(CompressionTest, streamWriterRepetitivePayloadRoundTrip) {
     char pattern[4096];
     memset(pattern, 'X', sizeof(pattern));
     for (int i = 0; i < 32; i++) {
-        ASSERT_TRUE(streamWriterWrite(t, pattern, sizeof(pattern)) >= 0);
+        ASSERT_GE(streamWriterWrite(t, pattern, sizeof(pattern)), 0);
     }
     ASSERT_EQ(streamWriterFinish(t), 0);
     ASSERT_TRUE(lz4FrameUsesIndependentBlocks(db.data + VKCS_ENVELOPE_SIZE,
@@ -1690,7 +1704,7 @@ TEST_F(CompressionTest, streamWriterRepetitivePayloadRoundTrip) {
 
     size_t total_len = sizeof(pattern) * 32;
     char *result = (char *)zmalloc(total_len);
-    ASSERT_TRUE(rioRead((rio *)&dr, result, total_len) != 0) << "repetitive payload decompression should succeed";
+    ASSERT_NE(rioRead((rio *)&dr, result, total_len), 0u) << "repetitive payload decompression should succeed";
 
     /* Verify all bytes match */
     for (size_t i = 0; i < total_len; i++) {

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -177,14 +177,14 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
     size_t bound = streamCompressOutputBound(&sc, input_len);
-    ASSERT_GT(bound, 0) << "bound should be > 0";
+    ASSERT_GT(bound, 0u) << "bound should be > 0";
 
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
     ASSERT_NE(compressed, nullptr);
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)input, input_len,
                                                 FLUSH_END);
-    ASSERT_GT(compressed_len, 0) << "compress should succeed";
+    ASSERT_GT(compressed_len, 0u) << "compress should succeed";
     ASSERT_EQ(sc.stream_started, false) << "frame should be closed after FLUSH_END";
     streamCompressorDestroy(&sc);
 
@@ -213,7 +213,7 @@ TEST_F(CompressionTest, streamCompressOutputBound) {
 
     /* Basic: bound for 1KB input should be > 0 */
     size_t b1 = streamCompressOutputBound(&sc, 1024);
-    ASSERT_GT(b1, 0) << "bound for 1KB should be > 0";
+    ASSERT_GT(b1, 0u) << "bound for 1KB should be > 0";
 
     /* Bound is always conservative (includes frame header + flush overhead),
      * so it should be stable regardless of frame state. */
@@ -228,7 +228,7 @@ TEST_F(CompressionTest, streamCompressOutputBound) {
 
     /* Zero input should still return > 0 (frame header + flush overhead) */
     size_t b_zero = streamCompressOutputBound(&sc, 0);
-    ASSERT_GT(b_zero, 0) << "zero input bound should be > 0";
+    ASSERT_GT(b_zero, 0u) << "zero input bound should be > 0";
 
     zfree(seed_buf);
     streamCompressorDestroy(&sc);
@@ -294,7 +294,7 @@ TEST_F(CompressionTest, streamDecompressFeedErrors) {
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)payload, strlen(payload),
                                                 FLUSH_END);
-    ASSERT_GT(compressed_len, 0);
+    ASSERT_GT(compressed_len, 0u);
     streamCompressorDestroy(&sc);
 
     ASSERT_TRUE(streamDecompressFeed(&sd, out, sizeof(out),
@@ -425,7 +425,7 @@ TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
         if (cases[i].expect_probe_ok) {
             ASSERT_EQ(streamReaderProbe(t), 0) << cases[i].name;
             ASSERT_EQ(streamReaderGetInfo(t, &info), 0) << cases[i].name;
-            ASSERT_EQ(info.compressed, 0) << cases[i].name;
+            ASSERT_FALSE(info.compressed) << cases[i].name;
 
             uint8_t out[16] = {0};
             ASSERT_EQ(streamReaderRead(t, out, cases[i].expected_read_len), (ssize_t)cases[i].expected_read_len)
@@ -464,7 +464,7 @@ TEST_F(CompressionTest, streamReaderRejectsOversizedReadRequest) {
     streamReaderInfo info;
     ASSERT_EQ(streamReaderGetInfo(t, &info), 0)
         << "oversized read failure should not poison the reader";
-    ASSERT_EQ(info.compressed, 0) << "plain input should still probe as passthrough";
+    ASSERT_FALSE(info.compressed) << "plain input should still probe as passthrough";
 
     ASSERT_TRUE(streamReaderRead(t, out, sizeof(input)) == (ssize_t)sizeof(input));
     ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
@@ -726,7 +726,7 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
     ASSERT_EQ(db.data[3], VKCS_MAGIC_3) << "magic byte 3";
     ASSERT_EQ(db.data[4], VKCS_VERSION) << "version";
     ASSERT_EQ(db.data[5], VKCS_CODEC_LZ4) << "codec_id";
-    ASSERT_EQ(db.data[6], 0) << "flags should be clear when checksum is disabled";
+    ASSERT_EQ(db.data[6], (uint8_t)0) << "flags should be clear when checksum is disabled";
     ASSERT_EQ(db.data[7], STREAM_KIND_RDB) << "stream_kind RDB";
 
     /* Decompress and verify round-trip */
@@ -891,7 +891,7 @@ TEST_F(CompressionTest, streamWriterFlushBehavior) {
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_EQ(total_decompressed, 23);
+    ASSERT_EQ(total_decompressed, 23u);
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0);
 
     streamDecompressorDestroy(&sd);
@@ -1097,7 +1097,7 @@ TEST_F(CompressionTest, compressRioDoesNotInstallRdbChecksum) {
     size_t payload_len = strlen(payload);
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, payload_len) != 0);
 
-    ASSERT_EQ(cr.base.cksum, 0) << "compress_rio should not own RDB checksum policy";
+    ASSERT_EQ(cr.base.cksum, 0u) << "compress_rio should not own RDB checksum policy";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
     compressRioDestroy(&cr);
@@ -1117,7 +1117,7 @@ TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
 
     const char *payload = "skip-checksum-payload";
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
-    ASSERT_EQ(cr.base.cksum, 0) << "compress_rio should not inspect RDB checksum flags";
+    ASSERT_EQ(cr.base.cksum, 0u) << "compress_rio should not inspect RDB checksum flags";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
     compressRioDestroy(&cr);
@@ -1135,7 +1135,7 @@ TEST_F(CompressionTest, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
 
     const char *payload = "codec-checksum-enabled";
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
-    ASSERT_EQ(cr.base.cksum, 0)
+    ASSERT_EQ(cr.base.cksum, 0u)
         << "codec checksums should not control standard RDB checksum tracking";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
@@ -1247,7 +1247,7 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         decompressRio dr;
         streamReaderInfo info;
         ASSERT_EQ(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info), DECOMPRESS_RIO_INIT_OK);
-        ASSERT_EQ(info.compressed, 0) << "passthrough stream should not be compressed";
+        ASSERT_FALSE(info.compressed) << "passthrough stream should not be compressed";
 
         char result[64];
         memset(result, 0, sizeof(result));
@@ -1347,7 +1347,7 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_EQ(total_decompressed, 23) << "total decompressed should be 23 bytes";
+    ASSERT_EQ(total_decompressed, 23u) << "total decompressed should be 23 bytes";
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0) << "decompressed should match concatenated input";
 
     streamDecompressorDestroy(&sd);
@@ -1418,7 +1418,7 @@ TEST_F(CompressionTest, decompressRioLargePayload) {
         size_t chunk = 4096;
         if (chunk > payload_len - total_read) chunk = payload_len - total_read;
         size_t ret = rioRead((rio *)&dr, result + total_read, chunk);
-        ASSERT_NE(ret, 0) << "rioRead should succeed for large payload";
+        ASSERT_NE(ret, 0u) << "rioRead should succeed for large payload";
         total_read += chunk;
     }
 
@@ -1463,7 +1463,7 @@ TEST_F(CompressionTest, decompressRioDirectPath) {
 
     uint8_t *result = (uint8_t *)zmalloc(payload_len);
     size_t ret = rioRead((rio *)&dr, result, payload_len);
-    ASSERT_NE(ret, 0) << "single large rioRead should succeed";
+    ASSERT_NE(ret, 0u) << "single large rioRead should succeed";
     ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
 
     decompressRioDestroy(&dr);
@@ -1617,7 +1617,7 @@ TEST_F(CompressionTest, independentStreamsCoexist) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t1 = streamWriterCreate(&cfg, emitToDynamicBuf, &db1);
     streamWriter *t2 = streamWriterCreate(&cfg, emitToDynamicBuf, &db2);
-    ASSERT_NE(t1, nullptr && t2 != nullptr);
+    ASSERT_TRUE(t1 != nullptr && t2 != nullptr);
 
     const char *data1 = "Stream one data - unique content for first stream AAAA";
     const char *data2 = "Stream two data - different content for second stream BBBB";

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -29,12 +29,14 @@ extern "C" {
 #undef __str
 #endif
 
+class CompressionTest : public ::testing::Test {};
+
 typedef struct {
     const uint8_t *data;
     size_t len;
     size_t pos;
     size_t max_chunk; /* 0 => unbounded */
-} mem_reader_t;
+} MemReader;
 
 typedef struct {
     const uint8_t *data;
@@ -44,7 +46,7 @@ typedef struct {
     size_t fail_after_pos;
     int fail_after_success_reads;
     int success_reads;
-} flaky_reader_t;
+} FlakyReader;
 
 static streamReaderConfig makeReaderConfig(uint8_t expected_stream_kind,
                                            bool allow_passthrough,
@@ -69,9 +71,9 @@ static streamWriterConfig makeWriterConfig(compressionAlgo algo,
 }
 
 static bool lz4FrameHasBlockChecksum(const uint8_t *data, size_t len) {
-    LZ4F_dctx *dctx = NULL;
+    LZ4F_dctx *dctx = nullptr;
     EXPECT_FALSE(LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION)));
-    if (dctx == NULL) return false;
+    if (dctx == nullptr) return false;
 
     LZ4F_frameInfo_t frame_info = {};
     size_t src_size = len;
@@ -83,9 +85,9 @@ static bool lz4FrameHasBlockChecksum(const uint8_t *data, size_t len) {
 }
 
 static bool lz4FrameUsesIndependentBlocks(const uint8_t *data, size_t len) {
-    LZ4F_dctx *dctx = NULL;
+    LZ4F_dctx *dctx = nullptr;
     EXPECT_FALSE(LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION)));
-    if (dctx == NULL) return false;
+    if (dctx == nullptr) return false;
 
     LZ4F_frameInfo_t frame_info = {};
     size_t src_size = len;
@@ -97,7 +99,7 @@ static bool lz4FrameUsesIndependentBlocks(const uint8_t *data, size_t len) {
 }
 
 static ssize_t memReaderRead(void *ctx, void *buf, size_t len) {
-    mem_reader_t *r = (mem_reader_t *)ctx;
+    MemReader *r = (MemReader *)ctx;
     if (!r || !buf) return -1;
     if (r->pos >= r->len) return 0;
 
@@ -111,7 +113,7 @@ static ssize_t memReaderRead(void *ctx, void *buf, size_t len) {
 }
 
 static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
-    flaky_reader_t *r = (flaky_reader_t *)ctx;
+    FlakyReader *r = (FlakyReader *)ctx;
     if (!r || !buf) return -1;
     if (r->success_reads >= r->fail_after_success_reads) return -1;
     if (r->fail_after_pos > 0 && r->pos >= r->fail_after_pos) return -1;
@@ -136,163 +138,163 @@ static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
  * =================================================================== */
 
 /* --- Test: LZ4 compressor init/destroy lifecycle --- */
-TEST(compression, streamCompressorInitDestroy) {
+TEST_F(CompressionTest, streamCompressorInitDestroy) {
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0) << "LZ4 init should succeed";
-    ASSERT_TRUE(sc.algo == ALGO_LZ4) << "algo should be LZ4";
-    ASSERT_TRUE(sc.stream_started == false) << "stream_started should be false";
-    ASSERT_TRUE(sc.ctx != NULL) << "ctx should be non-NULL";
+    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0) << "LZ4 init should succeed";
+    ASSERT_EQ(sc.algo, ALGO_LZ4) << "algo should be LZ4";
+    ASSERT_EQ(sc.stream_started, false) << "stream_started should be false";
+    ASSERT_NE(sc.ctx, nullptr) << "ctx should be non-nullptr";
     streamCompressorDestroy(&sc);
-    ASSERT_TRUE(sc.ctx == NULL) << "ctx should be NULL after destroy";
-    ASSERT_TRUE(sc.algo == ALGO_NONE) << "algo should be NONE after destroy";
+    ASSERT_EQ(sc.ctx, nullptr) << "ctx should be nullptr after destroy";
+    ASSERT_EQ(sc.algo, ALGO_NONE) << "algo should be NONE after destroy";
 
     /* ALGO_NONE should fail */
     streamCompressor sc3;
-    ASSERT_TRUE(streamCompressorInit(&sc3, ALGO_NONE, 0) == -1) << "NONE init should fail";
+    ASSERT_EQ(streamCompressorInit(&sc3, ALGO_NONE, 0), -1) << "NONE init should fail";
 
-    /* NULL should fail */
-    ASSERT_TRUE(streamCompressorInit(NULL, ALGO_LZ4, 0) == -1) << "NULL init should fail";
+    /* nullptr should fail */
+    ASSERT_EQ(streamCompressorInit(nullptr, ALGO_LZ4, 0), -1) << "nullptr init should fail";
 }
 
 /* --- Test: LZ4 decompressor init/destroy lifecycle --- */
-TEST(compression, streamDecompressorInitDestroy) {
+TEST_F(CompressionTest, streamDecompressorInitDestroy) {
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0) << "LZ4 decomp init should succeed";
-    ASSERT_TRUE(sd.algo == ALGO_LZ4) << "algo should be LZ4";
-    ASSERT_TRUE(sd.ctx != NULL) << "ctx should be non-NULL";
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0) << "LZ4 decomp init should succeed";
+    ASSERT_EQ(sd.algo, ALGO_LZ4) << "algo should be LZ4";
+    ASSERT_NE(sd.ctx, nullptr) << "ctx should be non-nullptr";
     streamDecompressorDestroy(&sd);
-    ASSERT_TRUE(sd.ctx == NULL) << "ctx should be NULL after destroy";
-    ASSERT_TRUE(sd.algo == ALGO_NONE) << "algo should be NONE after destroy";
+    ASSERT_EQ(sd.ctx, nullptr) << "ctx should be nullptr after destroy";
+    ASSERT_EQ(sd.algo, ALGO_NONE) << "algo should be NONE after destroy";
 }
 
 /* --- Test: LZ4 compress → decompress round-trip --- */
-TEST(compression, streamCompressDecompressRoundTrip) {
+TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
     const char *input = "Hello, Valkey compression module! This is a test payload.";
     size_t input_len = strlen(input);
 
     /* Compress */
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
     size_t bound = streamCompressOutputBound(&sc, input_len);
-    ASSERT_TRUE(bound > 0) << "bound should be > 0";
+    ASSERT_GT(bound, 0) << "bound should be > 0";
 
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
-    ASSERT_TRUE(compressed != NULL);
+    ASSERT_NE(compressed, nullptr);
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)input, input_len,
                                                 FLUSH_END);
-    ASSERT_TRUE(compressed_len > 0) << "compress should succeed";
-    ASSERT_TRUE(sc.stream_started == false) << "frame should be closed after FLUSH_END";
+    ASSERT_GT(compressed_len, 0) << "compress should succeed";
+    ASSERT_EQ(sc.stream_started, false) << "frame should be closed after FLUSH_END";
     streamCompressorDestroy(&sc);
 
     /* Decompress */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[256];
     size_t input_consumed = 0;
     ssize_t decompressed_len = streamDecompressFeed(&sd, decompressed, sizeof(decompressed),
                                                     compressed, (size_t)compressed_len,
                                                     &input_consumed);
-    ASSERT_TRUE(decompressed_len > 0) << "decompress should succeed";
-    ASSERT_TRUE((size_t)decompressed_len == input_len) << "decompressed length should match input";
+    ASSERT_GT(decompressed_len, 0) << "decompress should succeed";
+    ASSERT_EQ((size_t)decompressed_len, input_len) << "decompressed length should match input";
     ASSERT_TRUE(memcmp(decompressed, input, input_len) == 0) << "decompressed content should match input";
-    ASSERT_TRUE(input_consumed == (size_t)compressed_len) << "all compressed input should be consumed";
+    ASSERT_EQ(input_consumed, (size_t)compressed_len) << "all compressed input should be consumed";
 
     streamDecompressorDestroy(&sd);
     zfree(compressed);
 }
 
 /* --- Test: streamCompressOutputBound returns sane values --- */
-TEST(compression, streamCompressOutputBound) {
+TEST_F(CompressionTest, streamCompressOutputBound) {
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
     /* Basic: bound for 1KB input should be > 0 */
     size_t b1 = streamCompressOutputBound(&sc, 1024);
-    ASSERT_TRUE(b1 > 0) << "bound for 1KB should be > 0";
+    ASSERT_GT(b1, 0) << "bound for 1KB should be > 0";
 
     /* Bound is always conservative (includes frame header + flush overhead),
      * so it should be stable regardless of frame state. */
     size_t b_before = streamCompressOutputBound(&sc, 1024);
     uint8_t *seed_buf = (uint8_t *)zmalloc(b_before);
-    ASSERT_TRUE(seed_buf != NULL);
+    ASSERT_NE(seed_buf, nullptr);
     ASSERT_TRUE(streamCompressFeed(&sc, seed_buf, b_before,
                                    (const uint8_t *)"x", 1, FLUSH_CONTINUE) >= 0)
         << "seed write should start the frame";
     size_t b_after = streamCompressOutputBound(&sc, 1024);
-    ASSERT_TRUE(b_before == b_after) << "bound should be the same before and after frame start";
+    ASSERT_EQ(b_before, b_after) << "bound should be the same before and after frame start";
 
     /* Zero input should still return > 0 (frame header + flush overhead) */
     size_t b_zero = streamCompressOutputBound(&sc, 0);
-    ASSERT_TRUE(b_zero > 0) << "zero input bound should be > 0";
+    ASSERT_GT(b_zero, 0) << "zero input bound should be > 0";
 
     zfree(seed_buf);
     streamCompressorDestroy(&sc);
 }
 
 /* --- Test: streamCompressFeed error paths --- */
-TEST(compression, streamCompressFeedErrors) {
+TEST_F(CompressionTest, streamCompressFeedErrors) {
     uint8_t buf[64];
-    /* NULL compressor */
-    ASSERT_TRUE(streamCompressFeed(NULL, buf, sizeof(buf),
+    /* nullptr compressor */
+    ASSERT_TRUE(streamCompressFeed(nullptr, buf, sizeof(buf),
                                    (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
-        << "NULL sc should return -1";
+        << "nullptr sc should return -1";
 
-    /* NULL output buffer */
+    /* nullptr output buffer */
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
-    ASSERT_TRUE(streamCompressFeed(&sc, NULL, sizeof(buf),
+    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
+    ASSERT_TRUE(streamCompressFeed(&sc, nullptr, sizeof(buf),
                                    (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
-        << "NULL output should return -1";
+        << "nullptr output should return -1";
     streamCompressorDestroy(&sc);
 }
 
 /* --- Test: streamDecompressFeed error paths --- */
-TEST(compression, streamDecompressFeedErrors) {
+TEST_F(CompressionTest, streamDecompressFeedErrors) {
     const char *payload = "decompress sticky error";
     uint8_t buf[64];
     uint8_t out[128];
     size_t consumed = 0;
 
-    /* NULL decompressor */
-    ASSERT_TRUE(streamDecompressFeed(NULL, buf, sizeof(buf),
+    /* nullptr decompressor */
+    ASSERT_TRUE(streamDecompressFeed(nullptr, buf, sizeof(buf),
                                      (const uint8_t *)"x", 1, &consumed) == -1)
-        << "NULL sd should return -1";
+        << "nullptr sd should return -1";
 
-    /* NULL input_consumed */
+    /* nullptr input_consumed */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
     ASSERT_TRUE(streamDecompressFeed(&sd, buf, sizeof(buf),
-                                     (const uint8_t *)"x", 1, NULL) == -1)
-        << "NULL input_consumed should return -1";
-    ASSERT_TRUE(sd.errored == false) << "decompressor should not be errored by NULL bookkeeping arg";
+                                     (const uint8_t *)"x", 1, nullptr) == -1)
+        << "nullptr input_consumed should return -1";
+    ASSERT_EQ(sd.errored, false) << "decompressor should not be errored by nullptr bookkeeping arg";
 
     streamDecompressor sd_null_input;
-    ASSERT_TRUE(streamDecompressorInit(&sd_null_input, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd_null_input, ALGO_LZ4), 0);
     ASSERT_TRUE(streamDecompressFeed(&sd_null_input, buf, sizeof(buf),
-                                     NULL, 1, &consumed) == -1)
-        << "NULL input with non-zero input_len should return -1";
-    ASSERT_TRUE(sd_null_input.errored == true) << "NULL input should latch a sticky decompressor error";
+                                     nullptr, 1, &consumed) == -1)
+        << "nullptr input with non-zero input_len should return -1";
+    ASSERT_EQ(sd_null_input.errored, true) << "nullptr input should latch a sticky decompressor error";
     streamDecompressorDestroy(&sd_null_input);
 
     /* Zero output capacity should return -1 (no-progress prevention) */
     ASSERT_TRUE(streamDecompressFeed(&sd, buf, 0,
                                      (const uint8_t *)"x", 1, &consumed) == -1)
         << "zero output capacity should return -1";
-    ASSERT_TRUE(sd.errored == true) << "decompressor should enter sticky errored state";
+    ASSERT_EQ(sd.errored, true) << "decompressor should enter sticky errored state";
 
     /* Once errored, all subsequent feeds fail immediately. */
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
     size_t bound = streamCompressOutputBound(&sc, strlen(payload));
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
-    ASSERT_TRUE(compressed != NULL);
+    ASSERT_NE(compressed, nullptr);
     ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
                                                 (const uint8_t *)payload, strlen(payload),
                                                 FLUSH_END);
-    ASSERT_TRUE(compressed_len > 0);
+    ASSERT_GT(compressed_len, 0);
     streamCompressorDestroy(&sc);
 
     ASSERT_TRUE(streamDecompressFeed(&sd, out, sizeof(out),
@@ -305,60 +307,60 @@ TEST(compression, streamDecompressFeedErrors) {
 }
 
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
-TEST(compression, streamCompressFeedErrorRecovery) {
+TEST_F(CompressionTest, streamCompressFeedErrorRecovery) {
     streamCompressor sc;
-    ASSERT_TRUE(streamCompressorInit(&sc, ALGO_LZ4, 0) == 0);
+    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
     /* Pre-frame error: compressBegin fails with tiny buffer, but no frame
      * bytes have been emitted yet — this is recoverable. */
     uint8_t tiny[1];
     ssize_t ret = streamCompressFeed(&sc, tiny, 1,
                                      (const uint8_t *)"test data", 9, FLUSH_END);
-    ASSERT_TRUE(ret == -1) << "should fail with tiny buffer";
-    ASSERT_TRUE(sc.errored == false) << "errored should NOT be set (pre-frame failure)";
-    ASSERT_TRUE(sc.stream_started == false) << "stream_started should still be false";
+    ASSERT_EQ(ret, -1) << "should fail with tiny buffer";
+    ASSERT_EQ(sc.errored, false) << "errored should NOT be set (pre-frame failure)";
+    ASSERT_EQ(sc.stream_started, false) << "stream_started should still be false";
 
     /* Retry with a proper buffer — should succeed */
     size_t bound = streamCompressOutputBound(&sc, 9);
     uint8_t *buf = (uint8_t *)zmalloc(bound);
     ssize_t ret2 = streamCompressFeed(&sc, buf, bound,
                                       (const uint8_t *)"test data", 9, FLUSH_END);
-    ASSERT_TRUE(ret2 > 0) << "retry after pre-frame error should succeed";
+    ASSERT_GT(ret2, 0) << "retry after pre-frame error should succeed";
     zfree(buf);
     streamCompressorDestroy(&sc);
 
     /* Mid-frame error: start a frame, then force an error — this is permanent. */
     streamCompressor sc2;
-    ASSERT_TRUE(streamCompressorInit(&sc2, ALGO_LZ4, 0) == 0);
+    ASSERT_EQ(streamCompressorInit(&sc2, ALGO_LZ4, 0), 0);
 
     /* First call with enough space to start the frame */
     size_t bound2 = streamCompressOutputBound(&sc2, 5);
     uint8_t *buf2 = (uint8_t *)zmalloc(bound2);
     ssize_t ret3 = streamCompressFeed(&sc2, buf2, bound2,
                                       (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
-    ASSERT_TRUE(ret3 >= 0) << "first write should succeed";
-    ASSERT_TRUE(sc2.stream_started == true) << "stream should be started";
+    ASSERT_GE(ret3, 0) << "first write should succeed";
+    ASSERT_EQ(sc2.stream_started, true) << "stream should be started";
 
     /* Now force a mid-frame error with a tiny buffer */
     uint8_t tiny2[1];
     ssize_t ret4 = streamCompressFeed(&sc2, tiny2, 1,
                                       (const uint8_t *)"more data to compress", 21,
                                       FLUSH_END);
-    ASSERT_TRUE(ret4 == -1) << "mid-frame error should fail";
-    ASSERT_TRUE(sc2.errored == true) << "errored should be set (mid-frame failure)";
+    ASSERT_EQ(ret4, -1) << "mid-frame error should fail";
+    ASSERT_EQ(sc2.errored, true) << "errored should be set (mid-frame failure)";
 
     /* Subsequent calls must fail immediately */
     size_t bound3 = streamCompressOutputBound(&sc2, 5);
     uint8_t *buf3 = (uint8_t *)zmalloc(bound3);
     ssize_t ret5 = streamCompressFeed(&sc2, buf3, bound3,
                                       (const uint8_t *)"hello", 5, FLUSH_END);
-    ASSERT_TRUE(ret5 == -1) << "must fail on errored compressor";
+    ASSERT_EQ(ret5, -1) << "must fail on errored compressor";
     zfree(buf3);
     zfree(buf2);
     streamCompressorDestroy(&sc2);
 }
 
-TEST(compression, streamReaderClassifiesProbeInputs) {
+TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
     static const uint8_t plain_input[] = {'H', 'E', 'L', 'L', 'O'};
     static const uint8_t truncated_vkcs[] = {'V', 'K', 'C'};
     static const uint8_t invalid_vkcs[VKCS_ENVELOPE_SIZE] = {
@@ -411,28 +413,28 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
     };
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
-        mem_reader_t mr = {};
+        MemReader mr = {};
         mr.data = cases[i].input;
         mr.len = cases[i].input_len;
         mr.max_chunk = cases[i].max_chunk;
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
         streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
-        ASSERT_TRUE(t != NULL) << cases[i].name;
+        ASSERT_NE(t, nullptr) << cases[i].name;
 
         streamReaderInfo info;
         if (cases[i].expect_probe_ok) {
-            ASSERT_TRUE(streamReaderProbe(t) == 0) << cases[i].name;
-            ASSERT_TRUE(streamReaderGetInfo(t, &info) == 0) << cases[i].name;
-            ASSERT_TRUE(info.compressed == 0) << cases[i].name;
+            ASSERT_EQ(streamReaderProbe(t), 0) << cases[i].name;
+            ASSERT_EQ(streamReaderGetInfo(t, &info), 0) << cases[i].name;
+            ASSERT_EQ(info.compressed, 0) << cases[i].name;
 
             uint8_t out[16] = {0};
-            ASSERT_TRUE(streamReaderRead(t, out, cases[i].expected_read_len) == (ssize_t)cases[i].expected_read_len)
+            ASSERT_EQ(streamReaderRead(t, out, cases[i].expected_read_len), (ssize_t)cases[i].expected_read_len)
                 << cases[i].name;
             ASSERT_TRUE(memcmp(out, cases[i].input, cases[i].expected_read_len) == 0) << cases[i].name;
             ASSERT_TRUE(streamReaderRead(t, out, sizeof(out)) == 0) << cases[i].name;
         } else {
-            ASSERT_TRUE(streamReaderProbe(t) == -1) << cases[i].name;
-            ASSERT_TRUE(streamReaderGetInfo(t, &info) == -1) << cases[i].name;
+            ASSERT_EQ(streamReaderProbe(t), -1) << cases[i].name;
+            ASSERT_EQ(streamReaderGetInfo(t, &info), -1) << cases[i].name;
             ASSERT_TRUE(streamReaderGetError(t) == cases[i].expected_error) << cases[i].name;
 
             uint8_t out[8] = {0};
@@ -443,26 +445,26 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
     }
 }
 
-TEST(compression, streamReaderRejectsOversizedReadRequest) {
+TEST_F(CompressionTest, streamReaderRejectsOversizedReadRequest) {
     const uint8_t input[] = {'H', 'E', 'L', 'L', 'O'};
-    mem_reader_t mr = {};
+    MemReader mr = {};
     mr.data = input;
     mr.len = sizeof(input);
     mr.max_chunk = 2;
     streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
 
     streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
-    ASSERT_TRUE(t != NULL) << "streamReaderCreate should succeed";
+    ASSERT_NE(t, nullptr) << "streamReaderCreate should succeed";
 
     uint8_t out[8] = {0};
     size_t oversized = (size_t)(std::numeric_limits<ssize_t>::max)() + 1;
-    ASSERT_TRUE(streamReaderRead(t, out, oversized) == -1)
+    ASSERT_EQ(streamReaderRead(t, out, oversized), -1)
         << "oversized reads should fail before touching stream state";
 
     streamReaderInfo info;
-    ASSERT_TRUE(streamReaderGetInfo(t, &info) == 0)
+    ASSERT_EQ(streamReaderGetInfo(t, &info), 0)
         << "oversized read failure should not poison the reader";
-    ASSERT_TRUE(info.compressed == 0) << "plain input should still probe as passthrough";
+    ASSERT_EQ(info.compressed, 0) << "plain input should still probe as passthrough";
 
     ASSERT_TRUE(streamReaderRead(t, out, sizeof(input)) == (ssize_t)sizeof(input));
     ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
@@ -481,29 +483,29 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
 /* --- Emit callback that appends to a dynamically growing buffer --- */
 typedef struct {
     uint8_t *data;
-} dynamic_buf_t;
+} DynamicBuf;
 
-static void dynamicBufInit(dynamic_buf_t *db) {
+static void dynamicBufInit(DynamicBuf *db) {
     db->data = (uint8_t *)sdsempty();
 }
 
-static void dynamicBufFree(dynamic_buf_t *db) {
+static void dynamicBufFree(DynamicBuf *db) {
     if (db->data) sdsfree((sds)db->data);
-    db->data = NULL;
+    db->data = nullptr;
 }
 
 static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
-    dynamic_buf_t *db = (dynamic_buf_t *)ctx;
+    DynamicBuf *db = (DynamicBuf *)ctx;
     db->data = (uint8_t *)sdscatlen((sds)db->data, data, len);
-    return db->data != NULL ? 0 : -1;
+    return db->data != nullptr ? 0 : -1;
 }
 
 static int initVkcsRdbDecompressRio(decompressRio *dr, rio *inner) {
     streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
-    return rioInitWithDecompress(dr, inner, &cfg, NULL) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
+    return rioInitWithDecompress(dr, inner, &cfg, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
 
-TEST(compression, streamReaderValidatesCompressedStreamKinds) {
+TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
     struct {
         const char *name;
         const char *payload;
@@ -545,40 +547,40 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
         size_t payload_len = strlen(cases[i].payload);
-        dynamic_buf_t db;
+        DynamicBuf db;
         dynamicBufInit(&db);
 
         streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, cases[i].writer_kind);
         streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
-        ASSERT_TRUE(w != NULL) << cases[i].name;
+        ASSERT_NE(w, nullptr) << cases[i].name;
         ASSERT_TRUE(streamWriterWrite(w, cases[i].payload, payload_len) >= 0) << cases[i].name;
-        ASSERT_TRUE(streamWriterFinish(w) == 0) << cases[i].name;
+        ASSERT_EQ(streamWriterFinish(w), 0) << cases[i].name;
         streamWriterDestroy(w);
 
-        mem_reader_t mr = {};
+        MemReader mr = {};
         mr.data = db.data;
         mr.len = sdslen((const char *)db.data);
         mr.max_chunk = cases[i].max_chunk;
         streamReaderConfig rcfg = makeReaderConfig(cases[i].expected_kind, true, cases[i].buffer_size);
         streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
-        ASSERT_TRUE(r != NULL) << cases[i].name;
+        ASSERT_NE(r, nullptr) << cases[i].name;
 
         streamReaderInfo info;
         if (cases[i].expect_ok) {
-            ASSERT_TRUE(streamReaderProbe(r) == 0) << cases[i].name;
-            ASSERT_TRUE(streamReaderGetInfo(r, &info) == 0) << cases[i].name;
+            ASSERT_EQ(streamReaderProbe(r), 0) << cases[i].name;
+            ASSERT_EQ(streamReaderGetInfo(r, &info), 0) << cases[i].name;
             ASSERT_TRUE(info.compressed) << cases[i].name;
-            ASSERT_TRUE(info.algo == ALGO_LZ4) << cases[i].name;
-            ASSERT_TRUE(info.stream_kind == cases[i].expected_kind) << cases[i].name;
+            ASSERT_EQ(info.algo, ALGO_LZ4) << cases[i].name;
+            ASSERT_EQ(info.stream_kind, cases[i].expected_kind) << cases[i].name;
 
             uint8_t out[64] = {0};
-            ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len) << cases[i].name;
+            ASSERT_EQ(streamReaderRead(r, out, payload_len), (ssize_t)payload_len) << cases[i].name;
             ASSERT_TRUE(memcmp(out, cases[i].payload, payload_len) == 0) << cases[i].name;
             ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0) << cases[i].name;
         } else {
-            ASSERT_TRUE(streamReaderProbe(r) == -1) << cases[i].name;
-            ASSERT_TRUE(streamReaderGetInfo(r, &info) == -1) << cases[i].name;
-            ASSERT_TRUE(streamReaderGetError(r) == STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
+            ASSERT_EQ(streamReaderProbe(r), -1) << cases[i].name;
+            ASSERT_EQ(streamReaderGetInfo(r, &info), -1) << cases[i].name;
+            ASSERT_EQ(streamReaderGetError(r), STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
 
             uint8_t out[32] = {0};
             ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == -1) << cases[i].name;
@@ -592,7 +594,7 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
 /* --- Test: stream_reader marks errored on partial output + read error.
  * Regression for direct-path error accounting (partial bytes were returned
  * without sticky errored state). */
-TEST(compression, streamReaderPartialThenErrorSetsErrored) {
+TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     const size_t payload_len = 64 * 1024;
     uint8_t *payload = (uint8_t *)zmalloc(payload_len);
     uint32_t x = 0x12345678u;
@@ -603,20 +605,20 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
         payload[i] = (uint8_t)(x & 0xFF);
     }
 
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL) << "streamWriterCreate should succeed";
+    ASSERT_NE(w, nullptr) << "streamWriterCreate should succeed";
     const size_t first_chunk_len = 4 * 1024;
     ASSERT_TRUE(streamWriterWrite(w, payload, first_chunk_len) >= 0);
-    ASSERT_TRUE(streamWriterFlush(w) == 0);
+    ASSERT_EQ(streamWriterFlush(w), 0);
     size_t fail_after_pos = sdslen((const char *)db.data);
     ASSERT_TRUE(streamWriterWrite(w, payload + first_chunk_len, payload_len - first_chunk_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
 
-    flaky_reader_t fr = {};
+    FlakyReader fr = {};
     fr.data = db.data;
     fr.len = sdslen((const char *)db.data);
     fr.max_chunk = 4096;
@@ -624,34 +626,34 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     fr.fail_after_success_reads = (std::numeric_limits<int>::max)();
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
     streamReader *r = streamReaderCreate(&rcfg, flakyReaderRead, &fr);
-    ASSERT_TRUE(r != NULL) << "streamReaderCreate should succeed";
+    ASSERT_NE(r, nullptr) << "streamReaderCreate should succeed";
 
     const size_t out_len = 16 * 1024;
     uint8_t *out = (uint8_t *)zmalloc(out_len);
-    ASSERT_TRUE(out != NULL);
+    ASSERT_NE(out, nullptr);
     ssize_t n1 = streamReaderRead(r, out, out_len);
-    ASSERT_TRUE(n1 > 0) << "first read should return partial output";
-    ASSERT_TRUE(n1 < (ssize_t)out_len) << "injected read error should stop the first read early";
+    ASSERT_GT(n1, 0) << "first read should return partial output";
+    ASSERT_LT(n1, (ssize_t)out_len) << "injected read error should stop the first read early";
     ASSERT_TRUE(memcmp(out, payload, (size_t)n1) == 0);
-    ASSERT_TRUE(streamReaderRead(r, out, out_len) == -1) << "second read should fail immediately";
+    ASSERT_EQ(streamReaderRead(r, out, out_len), -1) << "second read should fail immediately";
 
     streamReaderDestroy(r);
 
     /* Passthrough mode should also preserve partial bytes when source read
      * fails after probe/prefix buffering, then latch sticky error state. */
     const uint8_t plain[] = "NOTVKCS-passthrough-regression";
-    flaky_reader_t fr_passthrough = {};
+    FlakyReader fr_passthrough = {};
     fr_passthrough.data = plain;
     fr_passthrough.len = sizeof(plain) - 1;
     fr_passthrough.max_chunk = 0;
     fr_passthrough.fail_after_success_reads = 1; /* probe succeeds, next read fails */
     streamReaderConfig pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
     streamReader *rp = streamReaderCreate(&pass_cfg, flakyReaderRead, &fr_passthrough);
-    ASSERT_TRUE(rp != NULL) << "passthrough reader create should succeed";
+    ASSERT_NE(rp, nullptr) << "passthrough reader create should succeed";
 
     uint8_t pass_out[64];
     ssize_t p1 = streamReaderRead(rp, pass_out, sizeof(pass_out));
-    ASSERT_TRUE(p1 > 0) << "passthrough first read should return partial output";
+    ASSERT_GT(p1, 0) << "passthrough first read should return partial output";
     ASSERT_TRUE(memcmp(pass_out, plain, (size_t)p1) == 0) << "passthrough partial bytes should match input prefix";
     ASSERT_TRUE(streamReaderRead(rp, pass_out, sizeof(pass_out)) == -1) << "passthrough second read should fail immediately";
     streamReaderDestroy(rp);
@@ -662,74 +664,74 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
 }
 
 /* --- Test: streamWriterCreate/destroy --- */
-TEST(compression, streamWriterCreateDestroy) {
-    dynamic_buf_t db;
+TEST_F(CompressionTest, streamWriterCreateDestroy) {
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL) << "create should succeed for LZ4";
-    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored";
+    ASSERT_NE(t, nullptr) << "create should succeed for LZ4";
+    ASSERT_EQ(streamWriterIsErrored(t), 0) << "should not be errored";
 
     streamWriterDestroy(t);
     dynamicBufFree(&db);
 
-    /* NULL config should fail */
-    ASSERT_TRUE(streamWriterCreate(NULL, emitToDynamicBuf, &db) == NULL) << "NULL config should return NULL";
+    /* nullptr config should fail */
+    ASSERT_TRUE(streamWriterCreate(nullptr, emitToDynamicBuf, &db) == nullptr) << "nullptr config should return nullptr";
 
-    /* NULL emit_cb should fail */
-    ASSERT_TRUE(streamWriterCreate(&cfg, NULL, NULL) == NULL) << "NULL emit_cb should return NULL";
+    /* nullptr emit_cb should fail */
+    ASSERT_TRUE(streamWriterCreate(&cfg, nullptr, nullptr) == nullptr) << "nullptr emit_cb should return nullptr";
 
     /* ALGO_NONE should fail */
     streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_NONE should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == nullptr) << "ALGO_NONE should return nullptr";
     bad_cfg = makeWriterConfig(ALGO_LZF, 0, STREAM_KIND_RDB);
-    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == NULL) << "ALGO_LZF should return NULL";
+    ASSERT_TRUE(streamWriterCreate(&bad_cfg, emitToDynamicBuf, &db) == nullptr) << "ALGO_LZF should return nullptr";
 
     /* Concrete stream kinds outside the currently named ones are valid. */
     streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
     streamWriter *future_t = streamWriterCreate(&future_kind_cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(future_t != NULL) << "custom stream_kind should succeed with envelope";
+    ASSERT_NE(future_t, nullptr) << "custom stream_kind should succeed with envelope";
     streamWriterDestroy(future_t);
 
-    /* destroy NULL should be safe */
-    streamWriterDestroy(NULL);
+    /* destroy nullptr should be safe */
+    streamWriterDestroy(nullptr);
 }
 
 /* --- Test: stream_writer write + finish round-trip --- */
-TEST(compression, streamWriterRoundTrip) {
-    dynamic_buf_t db;
+TEST_F(CompressionTest, streamWriterRoundTrip) {
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     /* Write some data */
     const char *test_data = "Hello, compression world! This is a test of the stream writer API.";
     size_t data_len = strlen(test_data);
     ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
-    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored after write";
+    ASSERT_EQ(streamWriterIsErrored(t), 0) << "should not be errored after write";
     ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "write should emit envelope";
 
     /* Finalize */
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
-    ASSERT_TRUE(streamWriterIsErrored(t) == 0) << "should not be errored after finish";
+    ASSERT_EQ(streamWriterFinish(t), 0);
+    ASSERT_EQ(streamWriterIsErrored(t), 0) << "should not be errored after finish";
 
     /* Verify output starts with VKCS envelope */
     ASSERT_TRUE(sdslen((const char *)db.data) >= VKCS_ENVELOPE_SIZE) << "output should have at least envelope size";
-    ASSERT_TRUE(db.data[0] == VKCS_MAGIC_0) << "magic byte 0";
-    ASSERT_TRUE(db.data[1] == VKCS_MAGIC_1) << "magic byte 1";
-    ASSERT_TRUE(db.data[2] == VKCS_MAGIC_2) << "magic byte 2";
-    ASSERT_TRUE(db.data[3] == VKCS_MAGIC_3) << "magic byte 3";
-    ASSERT_TRUE(db.data[4] == VKCS_VERSION) << "version";
-    ASSERT_TRUE(db.data[5] == VKCS_CODEC_LZ4) << "codec_id";
-    ASSERT_TRUE(db.data[6] == 0) << "flags should be clear when checksum is disabled";
-    ASSERT_TRUE(db.data[7] == STREAM_KIND_RDB) << "stream_kind RDB";
+    ASSERT_EQ(db.data[0], VKCS_MAGIC_0) << "magic byte 0";
+    ASSERT_EQ(db.data[1], VKCS_MAGIC_1) << "magic byte 1";
+    ASSERT_EQ(db.data[2], VKCS_MAGIC_2) << "magic byte 2";
+    ASSERT_EQ(db.data[3], VKCS_MAGIC_3) << "magic byte 3";
+    ASSERT_EQ(db.data[4], VKCS_VERSION) << "version";
+    ASSERT_EQ(db.data[5], VKCS_CODEC_LZ4) << "codec_id";
+    ASSERT_EQ(db.data[6], 0) << "flags should be clear when checksum is disabled";
+    ASSERT_EQ(db.data[7], STREAM_KIND_RDB) << "stream_kind RDB";
 
     /* Decompress and verify round-trip */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
@@ -744,13 +746,13 @@ TEST(compression, streamWriterRoundTrip) {
             sizeof(decompressed) - total_decompressed,
             compressed_data + src_offset,
             compressed_len - src_offset, &consumed);
-        ASSERT_TRUE(produced >= 0) << "decompression should not fail";
+        ASSERT_GE(produced, 0) << "decompression should not fail";
         total_decompressed += (size_t)produced;
         src_offset += consumed;
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_TRUE(total_decompressed == data_len) << "decompressed length should match original";
+    ASSERT_EQ(total_decompressed, data_len) << "decompressed length should match original";
     ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match original";
 
     streamDecompressorDestroy(&sd);
@@ -760,40 +762,40 @@ TEST(compression, streamWriterRoundTrip) {
 
 /* --- Test: a single large write is chunked internally without changing
  * the logical stream. This exercises the bounded scratch-buffer path. --- */
-TEST(compression, streamWriterLargeSingleWrite) {
+TEST_F(CompressionTest, streamWriterLargeSingleWrite) {
     const size_t payload_len = (1024 * 1024) + 4096;
     uint8_t *payload = (uint8_t *)zmalloc(payload_len);
     for (size_t i = 0; i < payload_len; i++) {
         payload[i] = (uint8_t)((i * 17 + 11) % 251);
     }
 
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
     ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
-    mem_reader_t mr = {};
+    MemReader mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 0;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
     streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
-    ASSERT_TRUE(r != NULL);
+    ASSERT_NE(r, nullptr);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
     size_t total = 0;
     while (total < payload_len) {
         ssize_t nread = streamReaderRead(r, out + total, payload_len - total);
-        ASSERT_TRUE(nread > 0) << "streamReaderRead should keep making progress";
+        ASSERT_GT(nread, 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(streamReaderRead(r, out, 1) == 0) << "reader should stop at frame end";
+    ASSERT_EQ(streamReaderRead(r, out, 1), 0) << "reader should stop at frame end";
 
     zfree(out);
     zfree(payload);
@@ -803,45 +805,45 @@ TEST(compression, streamWriterLargeSingleWrite) {
 
 /* --- Test: small caller reads should still drain a compressed stream
  * correctly. This exercises the buffered decompressed window path. --- */
-TEST(compression, streamReaderSmallReadsRoundTrip) {
+TEST_F(CompressionTest, streamReaderSmallReadsRoundTrip) {
     const size_t payload_len = 256 * 1024;
     uint8_t *payload = (uint8_t *)zmalloc(payload_len);
-    ASSERT_TRUE(payload != NULL);
+    ASSERT_NE(payload, nullptr);
     for (size_t i = 0; i < payload_len; i++) {
         payload[i] = (uint8_t)((i * 29 + 7) % 251);
     }
 
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, -5, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL);
+    ASSERT_NE(w, nullptr);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
 
-    mem_reader_t mr = {};
+    MemReader mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data);
     mr.max_chunk = 4096;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 64 * 1024);
     streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
-    ASSERT_TRUE(r != NULL);
+    ASSERT_NE(r, nullptr);
 
     uint8_t *out = (uint8_t *)zmalloc(payload_len);
-    ASSERT_TRUE(out != NULL);
+    ASSERT_NE(out, nullptr);
     size_t total = 0;
     while (total < payload_len) {
         size_t step = payload_len - total;
         if (step > 17) step = 17;
         ssize_t nread = streamReaderRead(r, out + total, step);
-        ASSERT_TRUE(nread > 0) << "streamReaderRead should keep making progress";
+        ASSERT_GT(nread, 0) << "streamReaderRead should keep making progress";
         total += (size_t)nread;
     }
 
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
-    ASSERT_TRUE(streamReaderRead(r, out, 1) == 0) << "reader should stop at frame end";
+    ASSERT_EQ(streamReaderRead(r, out, 1), 0) << "reader should stop at frame end";
 
     zfree(out);
     zfree(payload);
@@ -850,25 +852,25 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
 }
 
 /* --- Test: streamWriterFlush semantics (no-op before writes, valid mid-stream) --- */
-TEST(compression, streamWriterFlushBehavior) {
-    dynamic_buf_t db;
+TEST_F(CompressionTest, streamWriterFlushBehavior) {
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
-    ASSERT_TRUE(streamWriterFlush(t) == 0) << "flush before write should be no-op success";
+    ASSERT_EQ(streamWriterFlush(t), 0) << "flush before write should be no-op success";
     ASSERT_TRUE(sdslen((const char *)db.data) == 0) << "flush before write should not emit bytes";
 
     ASSERT_TRUE(streamWriterWrite(t, "first chunk", 11) >= 0);
-    ASSERT_TRUE(streamWriterFlush(t) == 0);
+    ASSERT_EQ(streamWriterFlush(t), 0);
     ASSERT_TRUE(streamWriterWrite(t, "second chunk", 12) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
@@ -883,13 +885,13 @@ TEST(compression, streamWriterFlushBehavior) {
             sizeof(decompressed) - total_decompressed,
             comp_data + src_offset,
             comp_len - src_offset, &consumed);
-        ASSERT_TRUE(produced >= 0);
+        ASSERT_GE(produced, 0);
         total_decompressed += (size_t)produced;
         src_offset += consumed;
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_TRUE(total_decompressed == 23);
+    ASSERT_EQ(total_decompressed, 23);
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0);
 
     streamDecompressorDestroy(&sd);
@@ -897,38 +899,38 @@ TEST(compression, streamWriterFlushBehavior) {
     dynamicBufFree(&db);
 }
 
-TEST(compression, streamWriterFlushAfterFinishIsNoop) {
-    dynamic_buf_t db;
+TEST_F(CompressionTest, streamWriterFlushAfterFinishIsNoop) {
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     ASSERT_TRUE(streamWriterWrite(t, "payload", 7) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
-    ASSERT_TRUE(streamWriterFlush(t) == 0) << "flush after finish should be a no-op success";
+    ASSERT_EQ(streamWriterFlush(t), 0) << "flush after finish should be a no-op success";
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "flush after finish should not emit bytes";
 
     streamWriterDestroy(t);
     dynamicBufFree(&db);
 }
 
-TEST(compression, streamWriterCodecChecksumToggle) {
+TEST_F(CompressionTest, streamWriterCodecChecksumToggle) {
     const char *payload = "block checksum payload block checksum payload";
 
     for (bool codec_checksum : {false, true}) {
-        dynamic_buf_t db;
+        DynamicBuf db;
         dynamicBufInit(&db);
 
         streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB,
                                                   codec_checksum);
         streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-        ASSERT_TRUE(t != NULL);
+        ASSERT_NE(t, nullptr);
         ASSERT_TRUE(streamWriterWrite(t, payload, strlen(payload)) >= 0);
-        ASSERT_TRUE(streamWriterFinish(t) == 0);
+        ASSERT_EQ(streamWriterFinish(t), 0);
 
         ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
         ASSERT_TRUE(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
@@ -940,81 +942,81 @@ TEST(compression, streamWriterCodecChecksumToggle) {
     }
 }
 
-TEST(compression, streamReaderValidateEndAcceptsClosedFrame) {
+TEST_F(CompressionTest, streamReaderValidateEndAcceptsClosedFrame) {
     const char *payload = "validate frame end payload";
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL);
+    ASSERT_NE(w, nullptr);
     ASSERT_TRUE(streamWriterWrite(w, payload, strlen(payload)) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
 
-    mem_reader_t reader_ctx = {db.data, sdslen((const char *)db.data), 0, 7};
+    MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 7};
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
     streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
-    ASSERT_TRUE(reader != NULL);
+    ASSERT_NE(reader, nullptr);
 
     char out[64];
     ASSERT_TRUE(streamReaderRead(reader, out, strlen(payload)) == (ssize_t)strlen(payload));
     ASSERT_TRUE(memcmp(out, payload, strlen(payload)) == 0);
-    ASSERT_TRUE(streamReaderValidateEnd(reader) == 0);
+    ASSERT_EQ(streamReaderValidateEnd(reader), 0);
 
     streamReaderDestroy(reader);
     streamWriterDestroy(w);
     dynamicBufFree(&db);
 }
 
-TEST(compression, streamReaderValidateEndRejectsTrailingBytes) {
+TEST_F(CompressionTest, streamReaderValidateEndRejectsTrailingBytes) {
     const char *payload = "payload with trailing compressed bytes";
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL);
+    ASSERT_NE(w, nullptr);
     ASSERT_TRUE(streamWriterWrite(w, payload, strlen(payload)) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
     db.data = (uint8_t *)sdscatlen((sds)db.data, "x", 1);
 
-    mem_reader_t reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
+    MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
     streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
-    ASSERT_TRUE(reader != NULL);
+    ASSERT_NE(reader, nullptr);
 
     char out[64];
     ASSERT_TRUE(streamReaderRead(reader, out, strlen(payload)) == (ssize_t)strlen(payload));
-    ASSERT_TRUE(streamReaderValidateEnd(reader) == -1);
-    ASSERT_TRUE(streamReaderGetError(reader) == STREAM_READER_ERROR_CORRUPT);
+    ASSERT_EQ(streamReaderValidateEnd(reader), -1);
+    ASSERT_EQ(streamReaderGetError(reader), STREAM_READER_ERROR_CORRUPT);
 
     streamReaderDestroy(reader);
     streamWriterDestroy(w);
     dynamicBufFree(&db);
 }
 
-TEST(compression, streamReaderValidateEndRejectsUnreadDecodedBytes) {
+TEST_F(CompressionTest, streamReaderValidateEndRejectsUnreadDecodedBytes) {
     const char *payload = "payload with unread decoded suffix";
     const size_t payload_len = strlen(payload);
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL);
+    ASSERT_NE(w, nullptr);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
 
-    mem_reader_t reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
+    MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
     streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
-    ASSERT_TRUE(reader != NULL);
+    ASSERT_NE(reader, nullptr);
 
     char out[8];
     ASSERT_TRUE(streamReaderRead(reader, out, sizeof(out)) == (ssize_t)sizeof(out));
     ASSERT_TRUE(memcmp(out, payload, sizeof(out)) == 0);
-    ASSERT_TRUE(streamReaderValidateEnd(reader) == -1);
-    ASSERT_TRUE(streamReaderGetError(reader) == STREAM_READER_ERROR_CORRUPT);
+    ASSERT_EQ(streamReaderValidateEnd(reader), -1);
+    ASSERT_EQ(streamReaderGetError(reader), STREAM_READER_ERROR_CORRUPT);
 
     streamReaderDestroy(reader);
     streamWriterDestroy(w);
@@ -1022,7 +1024,7 @@ TEST(compression, streamReaderValidateEndRejectsUnreadDecodedBytes) {
 }
 
 /* --- Test: compressRio write + finish round-trip --- */
-TEST(compression, compressRioRoundTrip) {
+TEST_F(CompressionTest, compressRioRoundTrip) {
     /* Use a buffer rio as the inner rio */
     sds buf = sdsempty();
     rio buffer_rio;
@@ -1030,29 +1032,29 @@ TEST(compression, compressRioRoundTrip) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
                             "Pack my box with five dozen liquor jugs.";
     size_t data_len = strlen(test_data);
     ASSERT_TRUE(rioWrite((rio *)&cr, test_data, data_len) != 0) << "rioWrite should succeed";
 
     /* Finalize and destroy */
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
 
     /* Get the compressed output from the buffer rio */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
-    ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE) << "compressed output should exist";
+    ASSERT_GT(compressed_len, VKCS_ENVELOPE_SIZE) << "compressed output should exist";
 
     /* Verify VKCS envelope */
-    ASSERT_TRUE(compressed[0] == (char)VKCS_MAGIC_0) << "magic V";
-    ASSERT_TRUE(compressed[1] == (char)VKCS_MAGIC_1) << "magic K";
-    ASSERT_TRUE(compressed[2] == (char)VKCS_MAGIC_2) << "magic C";
-    ASSERT_TRUE(compressed[3] == (char)VKCS_MAGIC_3) << "magic S";
+    ASSERT_EQ(compressed[0], (char)VKCS_MAGIC_0) << "magic V";
+    ASSERT_EQ(compressed[1], (char)VKCS_MAGIC_1) << "magic K";
+    ASSERT_EQ(compressed[2], (char)VKCS_MAGIC_2) << "magic C";
+    ASSERT_EQ(compressed[3], (char)VKCS_MAGIC_3) << "magic S";
 
     /* Decompress and verify */
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[512];
     size_t total_decompressed = 0;
@@ -1067,13 +1069,13 @@ TEST(compression, compressRioRoundTrip) {
             sizeof(decompressed) - total_decompressed,
             comp_data + src_offset,
             comp_len - src_offset, &consumed);
-        ASSERT_TRUE(produced >= 0) << "decompression should not fail";
+        ASSERT_GE(produced, 0) << "decompression should not fail";
         total_decompressed += (size_t)produced;
         src_offset += consumed;
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_TRUE(total_decompressed == data_len) << "decompressed length should match";
+    ASSERT_EQ(total_decompressed, data_len) << "decompressed length should match";
     ASSERT_TRUE(memcmp(decompressed, test_data, data_len) == 0) << "decompressed data should match";
 
     streamDecompressorDestroy(&sd);
@@ -1081,28 +1083,28 @@ TEST(compression, compressRioRoundTrip) {
     sdsfree(compressed);
 }
 
-TEST(compression, compressRioDoesNotInstallRdbChecksum) {
+TEST_F(CompressionTest, compressRioDoesNotInstallRdbChecksum) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
-    ASSERT_TRUE(cr.base.update_cksum == NULL);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(cr.base.update_cksum, nullptr);
 
     const char *payload = "checksum-payload-for-compressed-rio";
     size_t payload_len = strlen(payload);
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, payload_len) != 0);
 
-    ASSERT_TRUE(cr.base.cksum == 0) << "compress_rio should not own RDB checksum policy";
+    ASSERT_EQ(cr.base.cksum, 0) << "compress_rio should not own RDB checksum policy";
 
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
-TEST(compression, compressRioDoesNotCopyRdbChecksumFlags) {
+TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
@@ -1110,45 +1112,45 @@ TEST(compression, compressRioDoesNotCopyRdbChecksumFlags) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
     ASSERT_TRUE((((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) == 0);
 
     const char *payload = "skip-checksum-payload";
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
-    ASSERT_TRUE(cr.base.cksum == 0) << "compress_rio should not inspect RDB checksum flags";
+    ASSERT_EQ(cr.base.cksum, 0) << "compress_rio should not inspect RDB checksum flags";
 
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
-TEST(compression, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
+TEST_F(CompressionTest, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
 
     const char *payload = "codec-checksum-enabled";
     ASSERT_TRUE(rioWrite((rio *)&cr, payload, strlen(payload)) != 0);
-    ASSERT_TRUE(cr.base.cksum == 0)
+    ASSERT_EQ(cr.base.cksum, 0)
         << "codec checksums should not control standard RDB checksum tracking";
 
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
-TEST(compression, rioDecoratorsPreserveInnerType) {
+TEST_F(CompressionTest, rioDecoratorsPreserveInnerType) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &wcfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &wcfg), 0);
     /* Decorators preserve the inner backend type via the type field.
      * Verify the decorator reports the same type as the wrapped rio. */
     ASSERT_TRUE(rioCheckType((rio *)&cr) == RIO_TYPE_BUFFER);
@@ -1160,27 +1162,27 @@ TEST(compression, rioDecoratorsPreserveInnerType) {
     rioInitWithBuffer(&raw_rio, raw);
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
     decompressRio dr;
-    ASSERT_TRUE(rioInitWithDecompress(&dr, &raw_rio, &rcfg, NULL) == DECOMPRESS_RIO_INIT_OK);
+    ASSERT_EQ(rioInitWithDecompress(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
     ASSERT_TRUE(rioCheckType((rio *)&dr) == RIO_TYPE_BUFFER);
     decompressRioDestroy(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
 }
 
 /* --- Test: decompressRio read round-trip --- */
-TEST(compression, decompressRioRoundTrip) {
+TEST_F(CompressionTest, decompressRioRoundTrip) {
     /* First, produce compressed data using stream writer */
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     const char *test_data = "Decompression rio test data. "
                             "This should round-trip through compress then decompress.";
     size_t data_len = strlen(test_data);
     ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
     /* Create a buffer rio with the full VKCS-wrapped stream. */
@@ -1190,7 +1192,7 @@ TEST(compression, decompressRioRoundTrip) {
 
     /* Create decompress rio */
     decompressRio dr;
-    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     /* Read decompressed data */
     char result[256];
@@ -1203,16 +1205,16 @@ TEST(compression, decompressRioRoundTrip) {
     dynamicBufFree(&db);
 }
 
-TEST(compression, decompressRioTellTracksSourceProgress) {
-    dynamic_buf_t db;
+TEST_F(CompressionTest, decompressRioTellTracksSourceProgress) {
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     std::string payload(4096, 'A');
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
     ASSERT_TRUE(streamWriterWrite(t, payload.data(), payload.size()) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1220,7 +1222,7 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     decompressRio dr;
-    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     char out[2048];
     ASSERT_TRUE(rioRead((rio *)&dr, out, sizeof(out)) != 0);
@@ -1233,7 +1235,7 @@ TEST(compression, decompressRioTellTracksSourceProgress) {
     dynamicBufFree(&db);
 }
 
-TEST(compression, decompressRioClassifiesInput) {
+TEST_F(CompressionTest, decompressRioClassifiesInput) {
     {
         const char *payload = "REDIS001remaining data after prefix";
         size_t payload_len = strlen(payload);
@@ -1244,8 +1246,8 @@ TEST(compression, decompressRioClassifiesInput) {
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
         decompressRio dr;
         streamReaderInfo info;
-        ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info) == DECOMPRESS_RIO_INIT_OK);
-        ASSERT_TRUE(info.compressed == 0) << "passthrough stream should not be compressed";
+        ASSERT_EQ(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info), DECOMPRESS_RIO_INIT_OK);
+        ASSERT_EQ(info.compressed, 0) << "passthrough stream should not be compressed";
 
         char result[64];
         memset(result, 0, sizeof(result));
@@ -1266,7 +1268,7 @@ TEST(compression, decompressRioClassifiesInput) {
 
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
         decompressRio dr;
-        ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, NULL) ==
+        ASSERT_TRUE(rioInitWithDecompress(&dr, &buffer_rio, &cfg, nullptr) ==
                     DECOMPRESS_RIO_INIT_INCOMPATIBLE);
 
         sdsfree(buf);
@@ -1274,37 +1276,37 @@ TEST(compression, decompressRioClassifiesInput) {
 }
 
 /* --- Test: compressRioFinish is idempotent --- */
-TEST(compression, compressRioFinishIdempotent) {
+TEST_F(CompressionTest, compressRioFinishIdempotent) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
 
     ASSERT_TRUE(rioWrite((rio *)&cr, "test", 4) != 0);
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
     size_t len_after_first = sdslen(buffer_rio.io.buffer.ptr);
 
     /* Second finish should be a no-op */
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
     size_t len_after_second = sdslen(buffer_rio.io.buffer.ptr);
-    ASSERT_TRUE(len_after_first == len_after_second) << "second finish should not produce more output";
+    ASSERT_EQ(len_after_first, len_after_second) << "second finish should not produce more output";
 
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
 /* --- Test: compress_rio flush mid-stream does not end frame --- */
-TEST(compression, compressRioFlushMidStream) {
+TEST_F(CompressionTest, compressRioFlushMidStream) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
 
     /* Write some data */
     ASSERT_TRUE(rioWrite((rio *)&cr, "first chunk", 11) != 0);
@@ -1316,15 +1318,15 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(rioWrite((rio *)&cr, "second chunk", 12) != 0) << "write after flush should succeed";
 
     /* Now finalize */
-    ASSERT_TRUE(compressRioFinish(&cr) == 0);
+    ASSERT_EQ(compressRioFinish(&cr), 0);
 
     /* Verify the entire stream decompresses correctly */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
-    ASSERT_TRUE(compressed_len > VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(compressed_len, VKCS_ENVELOPE_SIZE);
 
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
@@ -1339,13 +1341,13 @@ TEST(compression, compressRioFlushMidStream) {
             sizeof(decompressed) - total_decompressed,
             comp_data + src_offset,
             comp_len - src_offset, &consumed);
-        ASSERT_TRUE(produced >= 0) << "decompression should not fail";
+        ASSERT_GE(produced, 0) << "decompression should not fail";
         total_decompressed += (size_t)produced;
         src_offset += consumed;
         if (consumed == 0 && produced == 0) break;
     }
 
-    ASSERT_TRUE(total_decompressed == 23) << "total decompressed should be 23 bytes";
+    ASSERT_EQ(total_decompressed, 23) << "total decompressed should be 23 bytes";
     ASSERT_TRUE(memcmp(decompressed, "first chunksecond chunk", 23) == 0) << "decompressed should match concatenated input";
 
     streamDecompressorDestroy(&sd);
@@ -1356,14 +1358,14 @@ TEST(compression, compressRioFlushMidStream) {
 /* --- Test: rdbLoadProgressCallback does not cast write-side streaming rios
  * to decompressRio. This protects save/async paths that also use
  * RIO_FLAG_STREAMING_COMPRESSION. --- */
-TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
+TEST_F(CompressionTest, rdbLoadProgressCallbackStreamingGuard) {
     sds buf = sdsempty();
     rio inner;
     rioInitWithBuffer(&inner, buf);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_TRUE(rioInitWithCompress(&cr, &inner, &cfg) == 0);
+    ASSERT_EQ(rioInitWithCompress(&cr, &inner, &cfg), 0);
 
     const char sample[] = "progress-guard";
     rdbLoadProgressCallback((rio *)&cr, sample, sizeof(sample) - 1);
@@ -1378,7 +1380,7 @@ TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
  * consume in the large-chunk read path. Before the fix, unconsumed
  * compressed bytes were dropped between iterations, causing false EOF
  * or data corruption. --- */
-TEST(compression, decompressRioLargePayload) {
+TEST_F(CompressionTest, decompressRioLargePayload) {
     /* Generate a large payload (256KB) with a repeating pattern so
      * it's compressible but large enough to require multiple
      * decompression iterations. */
@@ -1389,15 +1391,15 @@ TEST(compression, decompressRioLargePayload) {
     }
 
     /* Compress via stream_writer */
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
     /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
@@ -1406,7 +1408,7 @@ TEST(compression, decompressRioLargePayload) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     decompressRio dr;
-    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     /* Read in small chunks (4KB) to force multiple iterations through
      * the decompression state machine. */
@@ -1416,7 +1418,7 @@ TEST(compression, decompressRioLargePayload) {
         size_t chunk = 4096;
         if (chunk > payload_len - total_read) chunk = payload_len - total_read;
         size_t ret = rioRead((rio *)&dr, result + total_read, chunk);
-        ASSERT_TRUE(ret != 0) << "rioRead should succeed for large payload";
+        ASSERT_NE(ret, 0) << "rioRead should succeed for large payload";
         total_read += chunk;
     }
 
@@ -1431,7 +1433,7 @@ TEST(compression, decompressRioLargePayload) {
 
 /* --- Test: decompressRioRead handles a large single rioRead request.
  * Verifies correctness for a single 128KB read through the buffered path. --- */
-TEST(compression, decompressRioDirectPath) {
+TEST_F(CompressionTest, decompressRioDirectPath) {
     /* Generate a large payload (128KB). */
     const size_t payload_len = 128 * 1024;
     uint8_t *payload = (uint8_t *)zmalloc(payload_len);
@@ -1440,15 +1442,15 @@ TEST(compression, decompressRioDirectPath) {
     }
 
     /* Compress */
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     streamWriterDestroy(t);
 
     /* Decompress via decompress_rio with a single large read. */
@@ -1457,11 +1459,11 @@ TEST(compression, decompressRioDirectPath) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     decompressRio dr;
-    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buffer_rio) == 0);
+    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     uint8_t *result = (uint8_t *)zmalloc(payload_len);
     size_t ret = rioRead((rio *)&dr, result, payload_len);
-    ASSERT_TRUE(ret != 0) << "single large rioRead should succeed";
+    ASSERT_NE(ret, 0) << "single large rioRead should succeed";
     ASSERT_TRUE(memcmp(result, payload, payload_len) == 0) << "decompressed data should match original";
 
     decompressRioDestroy(&dr);
@@ -1474,80 +1476,80 @@ TEST(compression, decompressRioDirectPath) {
 /* --- Test: stream_reader stops at the end of the compressed frame even if
  * the underlying source still has trailing bytes. This keeps caller-managed
  * framing viable on long-lived streams. --- */
-TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
+TEST_F(CompressionTest, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     const char *payload = "stream-reader-frame-end";
     const size_t payload_len = strlen(payload);
     const char *trailer = "TRAILER-BYTES-AFTER-FRAME";
     const size_t trailer_len = strlen(trailer);
 
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL);
+    ASSERT_NE(w, nullptr);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
     size_t frame_len = sdslen((const char *)db.data);
 
     sds input = sdsnewlen(db.data, sdslen((const char *)db.data));
     input = sdscatlen(input, trailer, trailer_len);
 
-    mem_reader_t mr = {};
+    MemReader mr = {};
     mr.data = (const uint8_t *)input;
     mr.len = sdslen(input);
     mr.max_chunk = 3;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
     streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
-    ASSERT_TRUE(r != NULL);
+    ASSERT_NE(r, nullptr);
 
     char out[128];
     memset(out, 0, sizeof(out));
-    ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_EQ(streamReaderRead(r, out, payload_len), (ssize_t)payload_len);
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
 
     /* The reader must stop cleanly at frame end instead of trying to decode
      * trailing bytes as part of the same compressed frame. */
     ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0);
-    ASSERT_TRUE(mr.pos == frame_len) << "streamReader must not consume bytes after the LZ4 frame";
+    ASSERT_EQ(mr.pos, frame_len) << "streamReader must not consume bytes after the LZ4 frame";
 
     streamReaderDestroy(r);
     sdsfree(input);
     dynamicBufFree(&db);
 }
 
-TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
+TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
     const size_t payload_len = 256;
     uint8_t payload[payload_len];
     for (size_t i = 0; i < payload_len; i++) {
         payload[i] = (uint8_t)(i & 0xFF);
     }
 
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(w != NULL);
+    ASSERT_NE(w, nullptr);
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
-    ASSERT_TRUE(streamWriterFinish(w) == 0);
+    ASSERT_EQ(streamWriterFinish(w), 0);
     streamWriterDestroy(w);
 
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE + 1);
-    mem_reader_t mr = {};
+    MemReader mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data) - 1;
     mr.max_chunk = 7;
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8);
     streamReader *r = streamReaderCreate(&rcfg, memReaderRead, &mr);
-    ASSERT_TRUE(r != NULL);
+    ASSERT_NE(r, nullptr);
 
     uint8_t out[payload_len];
-    ASSERT_TRUE(streamReaderRead(r, out, payload_len) == (ssize_t)payload_len);
+    ASSERT_EQ(streamReaderRead(r, out, payload_len), (ssize_t)payload_len);
     ASSERT_TRUE(memcmp(out, payload, payload_len) == 0);
     ASSERT_TRUE(streamReaderRead(r, out, 1) < 0) << "EOF before frame end should be treated as corruption";
-    ASSERT_TRUE(streamReaderGetError(r) == STREAM_READER_ERROR_CORRUPT)
+    ASSERT_EQ(streamReaderGetError(r), STREAM_READER_ERROR_CORRUPT)
         << "truncated compressed frame should latch corruption, not I/O";
 
     streamReaderDestroy(r);
@@ -1556,16 +1558,16 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
 
 /* --- Test: streamWriterWrite after finish is rejected.
  * Writes after finish must fail and must not emit bytes. --- */
-TEST(compression, streamWriterWriteAfterFinish) {
-    dynamic_buf_t db;
+TEST_F(CompressionTest, streamWriterWriteAfterFinish) {
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     ASSERT_TRUE(streamWriterWrite(t, "hello", 5) >= 0);
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
     /* Write after finish must fail and emit no output. */
@@ -1573,13 +1575,13 @@ TEST(compression, streamWriterWriteAfterFinish) {
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "write after finish should not produce output";
 
     /* Second finish — should also be a no-op */
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "second finish should not produce output";
 
     /* Verify the stream is still valid: one envelope + one frame */
     ASSERT_TRUE(sdslen((const char *)db.data) > VKCS_ENVELOPE_SIZE);
     streamDecompressor sd;
-    ASSERT_TRUE(streamDecompressorInit(&sd, ALGO_LZ4) == 0);
+    ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[64];
     size_t total = 0;
@@ -1591,7 +1593,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
         ssize_t produced = streamDecompressFeed(
             &sd, decompressed + total, sizeof(decompressed) - total,
             cdata + off, comp_len - off, &consumed);
-        ASSERT_TRUE(produced >= 0);
+        ASSERT_GE(produced, 0);
         total += (size_t)produced;
         off += consumed;
         if (consumed == 0 && produced == 0) break;
@@ -1606,16 +1608,16 @@ TEST(compression, streamWriterWriteAfterFinish) {
 
 /* Test that two independent compress/decompress streams can coexist
  * without interfering with each other. Verifies no shared mutable state. */
-TEST(compression, independentStreamsCoexist) {
+TEST_F(CompressionTest, independentStreamsCoexist) {
     /* Create two independent compress streams with different data */
-    dynamic_buf_t db1, db2;
+    DynamicBuf db1, db2;
     dynamicBufInit(&db1);
     dynamicBufInit(&db2);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t1 = streamWriterCreate(&cfg, emitToDynamicBuf, &db1);
     streamWriter *t2 = streamWriterCreate(&cfg, emitToDynamicBuf, &db2);
-    ASSERT_TRUE(t1 != NULL && t2 != NULL);
+    ASSERT_NE(t1, nullptr && t2 != nullptr);
 
     const char *data1 = "Stream one data - unique content for first stream AAAA";
     const char *data2 = "Stream two data - different content for second stream BBBB";
@@ -1626,12 +1628,12 @@ TEST(compression, independentStreamsCoexist) {
     ASSERT_TRUE(streamWriterWrite(t1, data1, strlen(data1)) >= 0); /* write again to stream 1 */
     ASSERT_TRUE(streamWriterWrite(t2, data2, strlen(data2)) >= 0); /* write again to stream 2 */
 
-    ASSERT_TRUE(streamWriterFinish(t1) == 0);
-    ASSERT_TRUE(streamWriterFinish(t2) == 0);
+    ASSERT_EQ(streamWriterFinish(t1), 0);
+    ASSERT_EQ(streamWriterFinish(t2), 0);
 
     /* Decompress both and verify independently */
     for (int i = 0; i < 2; i++) {
-        dynamic_buf_t *db = (i == 0) ? &db1 : &db2;
+        DynamicBuf *db = (i == 0) ? &db1 : &db2;
         const char *expected = (i == 0) ? data1 : data2;
         size_t expected_len = strlen(expected) * 2; /* written twice */
 
@@ -1640,7 +1642,7 @@ TEST(compression, independentStreamsCoexist) {
         rioInitWithBuffer(&buf_rio, comp);
 
         decompressRio dr;
-        ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
+        ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buf_rio), 0);
 
         char result[256];
         memset(result, 0, sizeof(result));
@@ -1658,15 +1660,15 @@ TEST(compression, independentStreamsCoexist) {
     dynamicBufFree(&db2);
 }
 
-TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
+TEST_F(CompressionTest, streamWriterRepetitivePayloadRoundTrip) {
     /* Default block mode is independent.
      * Verify repetitive data still round-trips correctly. */
-    dynamic_buf_t db;
+    DynamicBuf db;
     dynamicBufInit(&db);
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
-    ASSERT_TRUE(t != NULL);
+    ASSERT_NE(t, nullptr);
 
     /* Write repetitive data to a single stream */
     char pattern[4096];
@@ -1674,7 +1676,7 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     for (int i = 0; i < 32; i++) {
         ASSERT_TRUE(streamWriterWrite(t, pattern, sizeof(pattern)) >= 0);
     }
-    ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_EQ(streamWriterFinish(t), 0);
     ASSERT_TRUE(lz4FrameUsesIndependentBlocks(db.data + VKCS_ENVELOPE_SIZE,
                                               sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE))
         << "stream writer should use independent LZ4 blocks";
@@ -1684,7 +1686,7 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     rioInitWithBuffer(&buf_rio, comp);
 
     decompressRio dr;
-    ASSERT_TRUE(initVkcsRdbDecompressRio(&dr, &buf_rio) == 0);
+    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buf_rio), 0);
 
     size_t total_len = sizeof(pattern) * 32;
     char *result = (char *)zmalloc(total_len);
@@ -1692,7 +1694,7 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
 
     /* Verify all bytes match */
     for (size_t i = 0; i < total_len; i++) {
-        ASSERT_TRUE(result[i] == 'X');
+        ASSERT_EQ(result[i], 'X');
     }
 
     decompressRioDestroy(&dr);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -6,12 +6,11 @@
 
 /* Tests for the compression streaming and rio decorator layers. */
 
-#include <cassert>
-#include <cstdio>
-#include <cstdlib>
+#include "generated_wrappers.hpp"
+
 #include <cstring>
-#include <gtest/gtest.h>
 #include <limits>
+#include <string>
 
 extern "C" {
 #include "../../deps/lz4/lz4frame.h"
@@ -42,6 +41,7 @@ typedef struct {
     size_t len;
     size_t pos;
     size_t max_chunk;
+    size_t fail_after_pos;
     int fail_after_success_reads;
     int success_reads;
 } flaky_reader_t;
@@ -82,6 +82,20 @@ static bool lz4FrameHasBlockChecksum(const uint8_t *data, size_t len) {
     return has_block_checksum;
 }
 
+static bool lz4FrameUsesIndependentBlocks(const uint8_t *data, size_t len) {
+    LZ4F_dctx *dctx = NULL;
+    EXPECT_FALSE(LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION)));
+    if (dctx == NULL) return false;
+
+    LZ4F_frameInfo_t frame_info = {};
+    size_t src_size = len;
+    size_t ret = LZ4F_getFrameInfo(dctx, &frame_info, data, &src_size);
+    bool has_independent_blocks = !LZ4F_isError(ret) &&
+                                  frame_info.blockMode == LZ4F_blockIndependent;
+    LZ4F_freeDecompressionContext(dctx);
+    return has_independent_blocks;
+}
+
 static ssize_t memReaderRead(void *ctx, void *buf, size_t len) {
     mem_reader_t *r = (mem_reader_t *)ctx;
     if (!r || !buf) return -1;
@@ -100,11 +114,16 @@ static ssize_t flakyReaderRead(void *ctx, void *buf, size_t len) {
     flaky_reader_t *r = (flaky_reader_t *)ctx;
     if (!r || !buf) return -1;
     if (r->success_reads >= r->fail_after_success_reads) return -1;
+    if (r->fail_after_pos > 0 && r->pos >= r->fail_after_pos) return -1;
     if (r->pos >= r->len) return 0;
 
     size_t avail = r->len - r->pos;
     size_t n = len < avail ? len : avail;
     if (r->max_chunk && n > r->max_chunk) n = r->max_chunk;
+    if (r->fail_after_pos > 0) {
+        size_t until_failure = r->fail_after_pos - r->pos;
+        if (n > until_failure) n = until_failure;
+    }
 
     memcpy(buf, r->data + r->pos, n);
     r->pos += n;
@@ -144,8 +163,6 @@ TEST(compression, streamDecompressorInitDestroy) {
     streamDecompressorDestroy(&sd);
     ASSERT_TRUE(sd.ctx == NULL) << "ctx should be NULL after destroy";
     ASSERT_TRUE(sd.algo == ALGO_NONE) << "algo should be NONE after destroy";
-
-    return;
 }
 
 /* --- Test: LZ4 compress → decompress round-trip --- */
@@ -185,7 +202,6 @@ TEST(compression, streamCompressDecompressRoundTrip) {
 
     streamDecompressorDestroy(&sd);
     zfree(compressed);
-    return;
 }
 
 /* --- Test: streamCompressOutputBound returns sane values --- */
@@ -214,7 +230,6 @@ TEST(compression, streamCompressOutputBound) {
 
     zfree(seed_buf);
     streamCompressorDestroy(&sc);
-    return;
 }
 
 /* --- Test: streamCompressFeed error paths --- */
@@ -232,8 +247,6 @@ TEST(compression, streamCompressFeedErrors) {
                                    (const uint8_t *)"x", 1, FLUSH_CONTINUE) == -1)
         << "NULL output should return -1";
     streamCompressorDestroy(&sc);
-
-    return;
 }
 
 /* --- Test: streamDecompressFeed error paths --- */
@@ -255,6 +268,14 @@ TEST(compression, streamDecompressFeedErrors) {
                                      (const uint8_t *)"x", 1, NULL) == -1)
         << "NULL input_consumed should return -1";
     ASSERT_TRUE(sd.errored == false) << "decompressor should not be errored by NULL bookkeeping arg";
+
+    streamDecompressor sd_null_input;
+    ASSERT_TRUE(streamDecompressorInit(&sd_null_input, ALGO_LZ4) == 0);
+    ASSERT_TRUE(streamDecompressFeed(&sd_null_input, buf, sizeof(buf),
+                                     NULL, 1, &consumed) == -1)
+        << "NULL input with non-zero input_len should return -1";
+    ASSERT_TRUE(sd_null_input.errored == true) << "NULL input should latch a sticky decompressor error";
+    streamDecompressorDestroy(&sd_null_input);
 
     /* Zero output capacity should return -1 (no-progress prevention) */
     ASSERT_TRUE(streamDecompressFeed(&sd, buf, 0,
@@ -281,7 +302,6 @@ TEST(compression, streamDecompressFeedErrors) {
     zfree(compressed);
 
     streamDecompressorDestroy(&sd);
-    return;
 }
 
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
@@ -336,8 +356,6 @@ TEST(compression, streamCompressFeedErrorRecovery) {
     zfree(buf3);
     zfree(buf2);
     streamCompressorDestroy(&sc2);
-
-    return;
 }
 
 TEST(compression, streamReaderClassifiesProbeInputs) {
@@ -423,7 +441,6 @@ TEST(compression, streamReaderClassifiesProbeInputs) {
 
         streamReaderDestroy(t);
     }
-    return;
 }
 
 TEST(compression, streamReaderRejectsOversizedReadRequest) {
@@ -438,7 +455,7 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
     ASSERT_TRUE(t != NULL) << "streamReaderCreate should succeed";
 
     uint8_t out[8] = {0};
-    size_t oversized = (size_t)std::numeric_limits<ssize_t>::max() + 1;
+    size_t oversized = (size_t)(std::numeric_limits<ssize_t>::max)() + 1;
     ASSERT_TRUE(streamReaderRead(t, out, oversized) == -1)
         << "oversized reads should fail before touching stream state";
 
@@ -451,7 +468,6 @@ TEST(compression, streamReaderRejectsOversizedReadRequest) {
     ASSERT_TRUE(memcmp(out, input, sizeof(input)) == 0) << "subsequent valid read should still succeed";
 
     streamReaderDestroy(t);
-    return;
 }
 
 /* ===================================================================
@@ -571,7 +587,6 @@ TEST(compression, streamReaderValidatesCompressedStreamKinds) {
         streamReaderDestroy(r);
         dynamicBufFree(&db);
     }
-    return;
 }
 
 /* --- Test: stream_reader marks errored on partial output + read error.
@@ -593,7 +608,11 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(w != NULL) << "streamWriterCreate should succeed";
-    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    const size_t first_chunk_len = 4 * 1024;
+    ASSERT_TRUE(streamWriterWrite(w, payload, first_chunk_len) >= 0);
+    ASSERT_TRUE(streamWriterFlush(w) == 0);
+    size_t fail_after_pos = sdslen((const char *)db.data);
+    ASSERT_TRUE(streamWriterWrite(w, payload + first_chunk_len, payload_len - first_chunk_len) >= 0);
     ASSERT_TRUE(streamWriterFinish(w) == 0);
     streamWriterDestroy(w);
 
@@ -601,9 +620,8 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     fr.data = db.data;
     fr.len = sdslen((const char *)db.data);
     fr.max_chunk = 4096;
-    /* One probe read plus two 4 KB payload reads is enough to produce some
-     * output with an 8 KB window, but not enough to satisfy the full request. */
-    fr.fail_after_success_reads = 3;
+    fr.fail_after_pos = fail_after_pos;
+    fr.fail_after_success_reads = (std::numeric_limits<int>::max)();
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 8 * 1024);
     streamReader *r = streamReaderCreate(&rcfg, flakyReaderRead, &fr);
     ASSERT_TRUE(r != NULL) << "streamReaderCreate should succeed";
@@ -613,6 +631,8 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
     ASSERT_TRUE(out != NULL);
     ssize_t n1 = streamReaderRead(r, out, out_len);
     ASSERT_TRUE(n1 > 0) << "first read should return partial output";
+    ASSERT_TRUE(n1 < (ssize_t)out_len) << "injected read error should stop the first read early";
+    ASSERT_TRUE(memcmp(out, payload, (size_t)n1) == 0);
     ASSERT_TRUE(streamReaderRead(r, out, out_len) == -1) << "second read should fail immediately";
 
     streamReaderDestroy(r);
@@ -639,7 +659,6 @@ TEST(compression, streamReaderPartialThenErrorSetsErrored) {
 
     dynamicBufFree(&db);
     zfree(payload);
-    return;
 }
 
 /* --- Test: streamWriterCreate/destroy --- */
@@ -675,8 +694,6 @@ TEST(compression, streamWriterCreateDestroy) {
 
     /* destroy NULL should be safe */
     streamWriterDestroy(NULL);
-
-    return;
 }
 
 /* --- Test: stream_writer write + finish round-trip --- */
@@ -739,7 +756,6 @@ TEST(compression, streamWriterRoundTrip) {
     streamDecompressorDestroy(&sd);
     streamWriterDestroy(t);
     dynamicBufFree(&db);
-    return;
 }
 
 /* --- Test: a single large write is chunked internally without changing
@@ -783,7 +799,6 @@ TEST(compression, streamWriterLargeSingleWrite) {
     zfree(payload);
     streamReaderDestroy(r);
     dynamicBufFree(&db);
-    return;
 }
 
 /* --- Test: small caller reads should still drain a compressed stream
@@ -832,7 +847,6 @@ TEST(compression, streamReaderSmallReadsRoundTrip) {
     zfree(payload);
     streamReaderDestroy(r);
     dynamicBufFree(&db);
-    return;
 }
 
 /* --- Test: streamWriterFlush semantics (no-op before writes, valid mid-stream) --- */
@@ -881,7 +895,6 @@ TEST(compression, streamWriterFlushBehavior) {
     streamDecompressorDestroy(&sd);
     streamWriterDestroy(t);
     dynamicBufFree(&db);
-    return;
 }
 
 TEST(compression, streamWriterFlushAfterFinishIsNoop) {
@@ -901,7 +914,6 @@ TEST(compression, streamWriterFlushAfterFinishIsNoop) {
 
     streamWriterDestroy(t);
     dynamicBufFree(&db);
-    return;
 }
 
 TEST(compression, streamWriterCodecChecksumToggle) {
@@ -981,6 +993,34 @@ TEST(compression, streamReaderValidateEndRejectsTrailingBytes) {
     dynamicBufFree(&db);
 }
 
+TEST(compression, streamReaderValidateEndRejectsUnreadDecodedBytes) {
+    const char *payload = "payload with unread decoded suffix";
+    const size_t payload_len = strlen(payload);
+    dynamic_buf_t db;
+    dynamicBufInit(&db);
+
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
+    streamWriter *w = streamWriterCreate(&wcfg, emitToDynamicBuf, &db);
+    ASSERT_TRUE(w != NULL);
+    ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(w) == 0);
+
+    mem_reader_t reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
+    ASSERT_TRUE(reader != NULL);
+
+    char out[8];
+    ASSERT_TRUE(streamReaderRead(reader, out, sizeof(out)) == (ssize_t)sizeof(out));
+    ASSERT_TRUE(memcmp(out, payload, sizeof(out)) == 0);
+    ASSERT_TRUE(streamReaderValidateEnd(reader) == -1);
+    ASSERT_TRUE(streamReaderGetError(reader) == STREAM_READER_ERROR_CORRUPT);
+
+    streamReaderDestroy(reader);
+    streamWriterDestroy(w);
+    dynamicBufFree(&db);
+}
+
 /* --- Test: compressRio write + finish round-trip --- */
 TEST(compression, compressRioRoundTrip) {
     /* Use a buffer rio as the inner rio */
@@ -997,7 +1037,7 @@ TEST(compression, compressRioRoundTrip) {
     ASSERT_TRUE(rioWrite((rio *)&cr, test_data, data_len) != 0) << "rioWrite should succeed";
 
     /* Finalize and destroy */
-    compressRioFinish(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
 
     /* Get the compressed output from the buffer rio */
     sds compressed = buffer_rio.io.buffer.ptr;
@@ -1039,7 +1079,6 @@ TEST(compression, compressRioRoundTrip) {
     streamDecompressorDestroy(&sd);
     compressRioDestroy(&cr);
     sdsfree(compressed);
-    return;
 }
 
 TEST(compression, compressRioDoesNotInstallRdbChecksum) {
@@ -1061,7 +1100,6 @@ TEST(compression, compressRioDoesNotInstallRdbChecksum) {
     ASSERT_TRUE(compressRioFinish(&cr) == 0);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
-    return;
 }
 
 TEST(compression, compressRioDoesNotCopyRdbChecksumFlags) {
@@ -1082,7 +1120,6 @@ TEST(compression, compressRioDoesNotCopyRdbChecksumFlags) {
     ASSERT_TRUE(compressRioFinish(&cr) == 0);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
-    return;
 }
 
 TEST(compression, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
@@ -1102,7 +1139,6 @@ TEST(compression, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
     ASSERT_TRUE(compressRioFinish(&cr) == 0);
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
-    return;
 }
 
 TEST(compression, rioDecoratorsPreserveInnerType) {
@@ -1143,8 +1179,8 @@ TEST(compression, decompressRioRoundTrip) {
     const char *test_data = "Decompression rio test data. "
                             "This should round-trip through compress then decompress.";
     size_t data_len = strlen(test_data);
-    streamWriterWrite(t, test_data, data_len);
-    streamWriterFinish(t);
+    ASSERT_TRUE(streamWriterWrite(t, test_data, data_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     streamWriterDestroy(t);
 
     /* Create a buffer rio with the full VKCS-wrapped stream. */
@@ -1165,7 +1201,6 @@ TEST(compression, decompressRioRoundTrip) {
     decompressRioDestroy(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
-    return;
 }
 
 TEST(compression, decompressRioTellTracksSourceProgress) {
@@ -1236,7 +1271,6 @@ TEST(compression, decompressRioClassifiesInput) {
 
         sdsfree(buf);
     }
-    return;
 }
 
 /* --- Test: compressRioFinish is idempotent --- */
@@ -1249,18 +1283,17 @@ TEST(compression, compressRioFinishIdempotent) {
     compressRio cr;
     ASSERT_TRUE(rioInitWithCompress(&cr, &buffer_rio, &cfg) == 0);
 
-    rioWrite((rio *)&cr, "test", 4);
-    compressRioFinish(&cr);
+    ASSERT_TRUE(rioWrite((rio *)&cr, "test", 4) != 0);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
     size_t len_after_first = sdslen(buffer_rio.io.buffer.ptr);
 
     /* Second finish should be a no-op */
-    compressRioFinish(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
     size_t len_after_second = sdslen(buffer_rio.io.buffer.ptr);
     ASSERT_TRUE(len_after_first == len_after_second) << "second finish should not produce more output";
 
     compressRioDestroy(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
-    return;
 }
 
 /* --- Test: compress_rio flush mid-stream does not end frame --- */
@@ -1283,7 +1316,7 @@ TEST(compression, compressRioFlushMidStream) {
     ASSERT_TRUE(rioWrite((rio *)&cr, "second chunk", 12) != 0) << "write after flush should succeed";
 
     /* Now finalize */
-    compressRioFinish(&cr);
+    ASSERT_TRUE(compressRioFinish(&cr) == 0);
 
     /* Verify the entire stream decompresses correctly */
     sds compressed = buffer_rio.io.buffer.ptr;
@@ -1318,7 +1351,6 @@ TEST(compression, compressRioFlushMidStream) {
     streamDecompressorDestroy(&sd);
     compressRioDestroy(&cr);
     sdsfree(compressed);
-    return;
 }
 
 /* --- Test: rdbLoadProgressCallback does not cast write-side streaming rios
@@ -1340,7 +1372,6 @@ TEST(compression, rdbLoadProgressCallbackStreamingGuard) {
 
     compressRioDestroy(&cr);
     sdsfree(inner.io.buffer.ptr);
-    return;
 }
 
 /* --- Test: decompress_rio with large payload (>64KB) exercises partial
@@ -1365,8 +1396,8 @@ TEST(compression, decompressRioLargePayload) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    streamWriterWrite(t, payload, payload_len);
-    streamWriterFinish(t);
+    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     streamWriterDestroy(t);
 
     /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
@@ -1396,7 +1427,6 @@ TEST(compression, decompressRioLargePayload) {
     zfree(result);
     zfree(payload);
     dynamicBufFree(&db);
-    return;
 }
 
 /* --- Test: decompressRioRead handles a large single rioRead request.
@@ -1417,8 +1447,8 @@ TEST(compression, decompressRioDirectPath) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    streamWriterWrite(t, payload, payload_len);
-    streamWriterFinish(t);
+    ASSERT_TRUE(streamWriterWrite(t, payload, payload_len) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     streamWriterDestroy(t);
 
     /* Decompress via decompress_rio with a single large read. */
@@ -1439,7 +1469,6 @@ TEST(compression, decompressRioDirectPath) {
     zfree(result);
     zfree(payload);
     dynamicBufFree(&db);
-    return;
 }
 
 /* --- Test: stream_reader stops at the end of the compressed frame even if
@@ -1460,6 +1489,7 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     ASSERT_TRUE(streamWriterWrite(w, payload, payload_len) >= 0);
     ASSERT_TRUE(streamWriterFinish(w) == 0);
     streamWriterDestroy(w);
+    size_t frame_len = sdslen((const char *)db.data);
 
     sds input = sdsnewlen(db.data, sdslen((const char *)db.data));
     input = sdscatlen(input, trailer, trailer_len);
@@ -1480,11 +1510,11 @@ TEST(compression, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     /* The reader must stop cleanly at frame end instead of trying to decode
      * trailing bytes as part of the same compressed frame. */
     ASSERT_TRUE(streamReaderRead(r, out, sizeof(out)) == 0);
+    ASSERT_TRUE(mr.pos == frame_len) << "streamReader must not consume bytes after the LZ4 frame";
 
     streamReaderDestroy(r);
     sdsfree(input);
     dynamicBufFree(&db);
-    return;
 }
 
 TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
@@ -1522,7 +1552,6 @@ TEST(compression, streamReaderRejectsTruncatedFrameTrailer) {
 
     streamReaderDestroy(r);
     dynamicBufFree(&db);
-    return;
 }
 
 /* --- Test: streamWriterWrite after finish is rejected.
@@ -1535,8 +1564,8 @@ TEST(compression, streamWriterWriteAfterFinish) {
     streamWriter *t = streamWriterCreate(&cfg, emitToDynamicBuf, &db);
     ASSERT_TRUE(t != NULL);
 
-    streamWriterWrite(t, "hello", 5);
-    streamWriterFinish(t);
+    ASSERT_TRUE(streamWriterWrite(t, "hello", 5) >= 0);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     size_t len_after_finish = sdslen((const char *)db.data);
 
     /* Write after finish must fail and emit no output. */
@@ -1544,7 +1573,7 @@ TEST(compression, streamWriterWriteAfterFinish) {
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "write after finish should not produce output";
 
     /* Second finish — should also be a no-op */
-    streamWriterFinish(t);
+    ASSERT_TRUE(streamWriterFinish(t) == 0);
     ASSERT_TRUE(sdslen((const char *)db.data) == len_after_finish) << "second finish should not produce output";
 
     /* Verify the stream is still valid: one envelope + one frame */
@@ -1573,7 +1602,6 @@ TEST(compression, streamWriterWriteAfterFinish) {
     streamDecompressorDestroy(&sd);
     streamWriterDestroy(t);
     dynamicBufFree(&db);
-    return;
 }
 
 /* Test that two independent compress/decompress streams can coexist
@@ -1593,13 +1621,13 @@ TEST(compression, independentStreamsCoexist) {
     const char *data2 = "Stream two data - different content for second stream BBBB";
 
     /* Interleave writes to both streams */
-    streamWriterWrite(t1, data1, strlen(data1));
-    streamWriterWrite(t2, data2, strlen(data2));
-    streamWriterWrite(t1, data1, strlen(data1)); /* write again to stream 1 */
-    streamWriterWrite(t2, data2, strlen(data2)); /* write again to stream 2 */
+    ASSERT_TRUE(streamWriterWrite(t1, data1, strlen(data1)) >= 0);
+    ASSERT_TRUE(streamWriterWrite(t2, data2, strlen(data2)) >= 0);
+    ASSERT_TRUE(streamWriterWrite(t1, data1, strlen(data1)) >= 0); /* write again to stream 1 */
+    ASSERT_TRUE(streamWriterWrite(t2, data2, strlen(data2)) >= 0); /* write again to stream 2 */
 
-    streamWriterFinish(t1);
-    streamWriterFinish(t2);
+    ASSERT_TRUE(streamWriterFinish(t1) == 0);
+    ASSERT_TRUE(streamWriterFinish(t2) == 0);
 
     /* Decompress both and verify independently */
     for (int i = 0; i < 2; i++) {
@@ -1628,7 +1656,6 @@ TEST(compression, independentStreamsCoexist) {
     streamWriterDestroy(t2);
     dynamicBufFree(&db1);
     dynamicBufFree(&db2);
-    return;
 }
 
 TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
@@ -1648,6 +1675,9 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
         ASSERT_TRUE(streamWriterWrite(t, pattern, sizeof(pattern)) >= 0);
     }
     ASSERT_TRUE(streamWriterFinish(t) == 0);
+    ASSERT_TRUE(lz4FrameUsesIndependentBlocks(db.data + VKCS_ENVELOPE_SIZE,
+                                              sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE))
+        << "stream writer should use independent LZ4 blocks";
 
     sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buf_rio;
@@ -1670,5 +1700,4 @@ TEST(compression, streamWriterRepetitivePayloadRoundTrip) {
     zfree(result);
     streamWriterDestroy(t);
     dynamicBufFree(&db);
-    return;
 }

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -211,8 +211,9 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {Invalid compression algo config is rejected} {
-        catch {r config set rdb-compression-algo snappy} err
-        assert_match "*argument(s) must be one of the following: lzf, lz4*" $err
+        assert_error "*argument(s) must be one of the following: lzf, lz4*" {
+            r config set rdb-compression-algo snappy
+        }
     }
 
     test {RDB compression configs survive CONFIG REWRITE and restart} {
@@ -247,10 +248,9 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_equal [string repeat "payload42 " 200] [r get cksum:42]
     }
 
-    test {Partial VKCS snapshot copied from an interrupted BGSAVE is rejected on load} {
+    test {Truncated VKCS snapshot is rejected on load} {
         r config set rdbcompression yes
         r config set rdb-compression-algo lz4
-        r config set rdb-key-save-delay 10000
         r flushall
         set noisy_payload ""
         for {set j 0} {$j < 32768} {incr j} {
@@ -260,51 +260,24 @@ start_server {overrides {save "" enable-debug-command local}} {
             r set "partial:$i" "${noisy_payload}:$i"
         }
 
-        assert_match {*Background saving started*} [r bgsave]
-        wait_for_condition 200 10 {
-            [s rdb_bgsave_in_progress] eq 1
-        } else {
-            r config set rdb-key-save-delay 0
-            fail "BGSAVE did not start in time"
-        }
+        assert_equal "OK" [r save]
+        set rdbfile [dump_rdb_path r]
+        assert_equal "VKCS" [string range [read_binary_file_prefix $rdbfile 8] 0 3]
 
-        wait_for_condition 200 10 {
-            [get_child_pid 0] ne ""
-        } else {
-            r config set rdb-key-save-delay 0
-            fail "Timed out waiting for BGSAVE child pid"
-        }
-        set child_pid [get_child_pid 0]
-        set dir [lindex [r config get dir] 1]
-        set temp_rdb [file join $dir temp-${child_pid}.rdb]
-        set partial_rdb [file join $dir partial-vkcs.rdb]
-        wait_for_condition 500 10 {
-            [file exists $temp_rdb] && [file size $temp_rdb] > 4096
-        } else {
-            r config set rdb-key-save-delay 0
-            catch {exec kill -9 $child_pid}
-            fail "Timed out waiting for partial VKCS snapshot"
-        }
+        set truncated [read_binary_file_prefix $rdbfile [expr {[file size $rdbfile] / 2}]]
+        set fd [open $rdbfile w]
+        fconfigure $fd -translation binary
+        puts -nonewline $fd $truncated
+        close $fd
 
-        file copy -force $temp_rdb $partial_rdb
-        assert_equal "VKCS" [string range [read_binary_file_prefix $partial_rdb 8] 0 3]
-
-        catch {exec kill -9 $child_pid}
-        wait_for_condition 500 10 {
-            [s rdb_bgsave_in_progress] eq 0
-        } else {
-            r config set rdb-key-save-delay 0
-            fail "Interrupted BGSAVE child was not collected in time"
-        }
-        r config set rdb-key-save-delay 0
-
-        file copy -force $partial_rdb [dump_rdb_path r]
         catch {r debug reload nosave} err
         assert_match "*Error*" $err
     }
 
     test {LZ4 compressed RDB detects tail corruption when codec checksums are enabled} {
+        r config set rdbcompression yes
         r config set rdb-compression-algo lz4
+        assert_equal "yes" [lindex [r config get rdbchecksum] 1]
         r flushall
         for {set i 0} {$i < 100} {incr i} {
             r set "footer:$i" [string repeat "payload$i " 100]
@@ -454,9 +427,7 @@ start_server {tags {"rdb-compression repl external:skip"}} {
             }
 
             assert_equal [string repeat "payload42 " 40] [$replica get repl:42]
-        }
 
-        test {Incremental replication continues after LZ4 full sync} {
             $primary set repl:post-sync "after-sync"
             wait_for_condition 50 100 {
                 [$replica get repl:post-sync] eq "after-sync"
@@ -496,8 +467,27 @@ start_server {tags {"rdb-compression repl external:skip"}} {
 set cluster_bus_port [find_available_port $::baseport $::portcount]
 start_server [list tags {"rdb-compression cluster external:skip singledb"} overrides [list save "" cluster-enabled yes cluster-port $cluster_bus_port]] {
     test {RDB compression config works in cluster mode} {
+        r config set rdbcompression yes
         r config set rdb-compression-algo lz4
+        assert_equal "OK" [r cluster addslotsrange 0 16383]
+        wait_for_condition 50 100 {
+            [getInfoProperty [r cluster info] cluster_state] eq "ok"
+        } else {
+            fail "Cluster did not become writable"
+        }
+        assert_equal "OK" [r cluster saveconfig]
+        r set cluster-rdb-compression value
         assert_equal "OK" [r save]
+        assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
+
+        restart_server 0 true false
+        wait_for_condition 50 100 {
+            [getInfoProperty [r cluster info] cluster_state] eq "ok"
+        } else {
+            fail "Cluster did not become writable after restart"
+        }
+
+        assert_equal "value" [r get cluster-rdb-compression]
     }
 }
 

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -182,16 +182,18 @@ tags {"repl external:skip"} {
                 $replica replicaof $primary_host $primary_port
                 wait_for_sync $replica
 
-                set replica_rdb [file join [lindex [$replica config get dir] 1] dump.rdb]
                 wait_for_condition 50 100 {
-                    [file exists $replica_rdb]
+                    [log_file_matches $replica_log "*uses streaming compression, falling back to BGREWRITEAOF*"]
                 } else {
-                    fail "Replica removed the synced RDB before BGREWRITEAOF fallback completed"
+                    fail "Expected streaming-compressed sync RDB fallback log not found"
                 }
 
-                after 1000
                 assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
                 waitForBgrewriteaof $replica
+                set manifest_path [get_aof_manifest_path $replica]
+                set base_name [get_cur_base_aof_name $manifest_path]
+                assert {$base_name ne ""}
+                assert {[string match "*.rdb" $base_name]}
 
                 for {set i 40} {$i < 60} {incr i} {
                     $primary set "lz4-key:$i" "value:$i"

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -177,8 +177,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             } result
             assert_match {*RDB file was saved with checksum disabled: skipped checksum for this transfer.*} $result
             assert_match {*RDB looks OK!*} $result
-
-            r config set rdb-compression-algo lzf
+            assert_no_match {*Checksum OK*} $result
         }
     }
 }


### PR DESCRIPTION
## Summary
- bound LZ4 stream-reader input to codec hints so reads stop at frame boundaries
- reject compressed streams that still have unread decoded bytes during end validation
- guard invalid decompressor input and add focused regression coverage
- audit and tighten the PR test additions: remove brittle timing, avoid hidden test dependencies, assert setup calls, and strengthen weak integration assertions
- align compression gtests with Valkey style by using fixture-based tests and typed assertions
- remove unused RDB magic helper and let the vendored LZ4 Makefile honor caller-provided AR

## Notes
- This revision intentionally does not include the AOF cleanup production change.

## Validation
- git diff --check
- PATH=/opt/homebrew/opt/llvm/bin:$PATH make -j4 OPT=-O0
- PATH=/opt/homebrew/opt/llvm/bin:$PATH make -C src/unit valkey-unit-gtests OPT=-O0 && ./src/unit/valkey-unit-gtests --gtest_filter='CompressionTest.*'
- ./runtest --single tests/integration/rdb-compression.tcl
- ./runtest --single tests/integration/replication-aof-sync.tcl
- ./runtest --single tests/integration/valkey-check-rdb.tcl
