### PR TITLE
[backport] Backport sweep for 8.0

### DIFF
--- a/src/anet.h
+++ b/src/anet.h
@@ -61,6 +61,7 @@ int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port)
 int anetUnixAccept(char *err, int serversock);
 int anetNonBlock(char *err, int fd);
 int anetBlock(char *err, int fd);
+int anetIsBlock(char *err, int fd);
 int anetCloexec(int fd);
 int anetEnableTcpNoDelay(char *err, int fd);
 int anetDisableTcpNoDelay(char *err, int fd);

--- a/src/tls.c
+++ b/src/tls.c
@@ -989,6 +989,10 @@ static int connTLSSetReadHandler(connection *conn, ConnectionCallbackFunc func) 
     return C_OK;
 }
 
+static int isBlocking(tls_connection *conn) {
+    return anetIsBlock(NULL, conn->c.fd);
+}
+
 static void setBlockingTimeout(tls_connection *conn, long long timeout) {
     anetBlock(NULL, conn->c.fd);
     anetSendTimeout(NULL, conn->c.fd, timeout);
@@ -1027,26 +1031,30 @@ static int connTLSBlockingConnect(connection *conn_, const char *addr, int port,
 
 static ssize_t connTLSSyncWrite(connection *conn_, char *ptr, ssize_t size, long long timeout) {
     tls_connection *conn = (tls_connection *)conn_;
-
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
     SSL_clear_mode(conn->ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
     ERR_clear_error();
     int ret = SSL_write(conn->ssl, ptr, size);
     ret = updateStateAfterSSLIO(conn, ret, 0);
     SSL_set_mode(conn->ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
 
     return ret;
 }
 
 static ssize_t connTLSSyncRead(connection *conn_, char *ptr, ssize_t size, long long timeout) {
     tls_connection *conn = (tls_connection *)conn_;
-
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
     ERR_clear_error();
     int ret = SSL_read(conn->ssl, ptr, size);
     ret = updateStateAfterSSLIO(conn, ret, 0);
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
 
     return ret;
 }
@@ -1055,6 +1063,7 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
     tls_connection *conn = (tls_connection *)conn_;
     ssize_t nread = 0;
 
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
 
     size--;
@@ -1080,7 +1089,9 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
         size--;
     }
 exit:
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
     return nread;
 }
 


### PR DESCRIPTION
# Backport sweep for 8.0

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| #1298 | Preserve original fd blocking state in TLS I/O operations |  |

---
*Generated by valkey-ci-agent using Claude Code.*