### PR TITLE
compression: harden decompressRio downcast with a type discriminator

### DIFF
--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -186,6 +186,16 @@ streamReaderError decompressRioGetError(const decompressRio *dr) {
     return streamReaderGetError(dr->reader);
 }
 
+/* Type discriminator for the decompressRio decorator.
+ * Returns the typed pointer only when `r` is genuinely a decompressRio, NULL
+ * otherwise. Identity is established by the read-vtable pointer, which is
+ * unique to this concrete type — this stays sound even if another stream
+ * decorator sets RIO_FLAG_STREAMING_DECOMPRESSION on a different struct. */
+const decompressRio *rioAsDecompressRio(const rio *r) {
+    if (!r || r->read != decompressRioRead) return NULL;
+    return (const decompressRio *)r;
+}
+
 int decompressRioValidateEnd(decompressRio *dr) {
     if (!dr || !dr->reader) return -1;
     return streamReaderValidateEnd(dr->reader);

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -186,11 +186,7 @@ streamReaderError decompressRioGetError(const decompressRio *dr) {
     return streamReaderGetError(dr->reader);
 }
 
-/* Type discriminator for the decompressRio decorator.
- * Returns the typed pointer only when `r` is genuinely a decompressRio, NULL
- * otherwise. Identity is established by the read-vtable pointer, which is
- * unique to this concrete type — this stays sound even if another stream
- * decorator sets RIO_FLAG_STREAMING_DECOMPRESSION on a different struct. */
+/* Identifies a decompressRio by its read vtable, which is unique to the type. */
 const decompressRio *rioAsDecompressRio(const rio *r) {
     if (!r || r->read != decompressRioRead) return NULL;
     return (const decompressRio *)r;

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -40,6 +40,8 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
                                               const streamReaderConfig *cfg,
                                               streamReaderInfo *info);
 streamReaderError decompressRioGetError(const decompressRio *dr);
+/* Returns the typed pointer when `r` is a decompressRio, NULL otherwise. */
+const decompressRio *rioAsDecompressRio(const rio *r);
 int decompressRioValidateEnd(decompressRio *dr);
 void decompressRioDestroy(decompressRio *dr);
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3188,8 +3188,8 @@ int rdbInputStreamValidateEnd(rdbInputStream *input) {
  * `rio base`). Anyone introducing a second producer of the flag must add a
  * type discriminator before relying on this. */
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
-    return (rdb->flags & RIO_FLAG_STREAMING_DECOMPRESSION) &&
-           decompressRioGetError((const decompressRio *)rdb) == STREAM_READER_ERROR_CORRUPT;
+    const decompressRio *dr = rioAsDecompressRio(rdb);
+    return dr && decompressRioGetError(dr) == STREAM_READER_ERROR_CORRUPT;
 }
 
 /* Save the given functions_ctx to the rdb.

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3183,10 +3183,6 @@ int rdbInputStreamValidateEnd(rdbInputStream *input) {
     return decompressRioValidateEnd(&input->decompressor) == 0 ? C_OK : C_ERR;
 }
 
-/* The cast is sound today because RIO_FLAG_STREAMING_DECOMPRESSION is only
- * set by rioInitWithDecompress on a decompressRio (whose first member is
- * `rio base`). Anyone introducing a second producer of the flag must add a
- * type discriminator before relying on this. */
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
     const decompressRio *dr = rioAsDecompressRio(rdb);
     return dr && decompressRioGetError(dr) == STREAM_READER_ERROR_CORRUPT;


### PR DESCRIPTION
Isolated review change against my own streaming-compression PR branch.

`rdbRioHasCorruptCompressedInput` downcast its `rio` to `decompressRio` after only checking `RIO_FLAG_STREAMING_DECOMPRESSION`. That flag is a contract a second stream decorator could also set (e.g. a replication decompress path with its own struct), so the cast relied on a convention rather than a real type check.

This adds `rioAsDecompressRio()`, which keys off the read-vtable pointer identity (`r->read == decompressRioRead`) — a discriminator unique to the concrete type — and returns the typed pointer or NULL. `rdbRioHasCorruptCompressedInput` now goes through it.

The `rio.type` tag is intentionally left for the wrapped backend type, since `rdbLoadProgressCallback` relies on `rioCheckType(r) == RIO_TYPE_CONN` for diskless-replica detection, so it can't double as a decorator tag.

## Verification
- `make -j` clean
- `integration/rdb-compression` 21/21 pass (incl. tail-corruption / payload-corruption / partial-VKCS paths that exercise this function)