### PR TITLE
compression: clean up streaming compression review nits

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -717,7 +717,6 @@ $(SERVER_NAME): $(ENGINE_SERVER_OBJ) $(LUA_MODULE)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
-	rm -f $@
 	$(SERVER_AR) rcs $@ $^
 
 # valkey-sentinel

--- a/src/compression.c
+++ b/src/compression.c
@@ -27,9 +27,9 @@ typedef struct {
                                const uint8_t *input,
                                size_t input_len,
                                size_t *input_consumed);
-} compressionCodecImpl;
+} compressionCodec;
 
-static const compressionCodecImpl compressionLz4CodecImpl = {
+static const compressionCodec compressionLz4Codec = {
     .compressor_init = compressionLz4CompressorInit,
     .compressor_destroy = compressionLz4CompressorDestroy,
     .decompressor_init = compressionLz4DecompressorInit,
@@ -41,13 +41,13 @@ static const compressionCodecImpl compressionLz4CodecImpl = {
 
 typedef struct {
     const char *name;
-    const compressionCodecImpl *impl;
+    const compressionCodec *impl;
 } compressionAlgoEntry;
 
 static const compressionAlgoEntry compressionAlgoTable[] = {
     [ALGO_NONE] = {"none", NULL},
     [ALGO_LZF] = {"lzf", NULL},
-    [ALGO_LZ4] = {"lz4", &compressionLz4CodecImpl},
+    [ALGO_LZ4] = {"lz4", &compressionLz4Codec},
 };
 
 static const compressionAlgoEntry *compressionAlgoEntryForAlgo(compressionAlgo algo) {
@@ -71,7 +71,7 @@ int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) 
     memset(sc, 0, sizeof(*sc));
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (!impl) return -1;
 
     sc->algo = algo;
@@ -87,7 +87,7 @@ int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) 
 void streamCompressorDestroy(streamCompressor *sc) {
     if (!sc) return;
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sc->algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (impl) impl->compressor_destroy(sc);
     memset(sc, 0, sizeof(*sc));
 }
@@ -97,7 +97,7 @@ int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
     memset(sd, 0, sizeof(*sd));
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (!impl) return -1;
 
     sd->algo = algo;
@@ -112,7 +112,7 @@ int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
 void streamDecompressorDestroy(streamDecompressor *sd) {
     if (!sd) return;
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sd->algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (impl) impl->decompressor_destroy(sd);
     memset(sd, 0, sizeof(*sd));
 }
@@ -120,7 +120,7 @@ void streamDecompressorDestroy(streamDecompressor *sd) {
 size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len) {
     if (!sc) return 0;
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sc->algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (!impl) return 0;
     return impl->compress_output_bound(input_len);
 }
@@ -136,7 +136,7 @@ ssize_t streamCompressFeed(streamCompressor *sc,
     if (input_len > 0 && !input) return -1;
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sc->algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (!impl) return -1;
 
     return impl->compress_feed(sc, output, output_capacity, input, input_len, flush_mode);
@@ -167,7 +167,7 @@ ssize_t streamDecompressFeed(streamDecompressor *sd,
     }
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sd->algo);
-    const compressionCodecImpl *impl = entry ? entry->impl : NULL;
+    const compressionCodec *impl = entry ? entry->impl : NULL;
     if (!impl) {
         sd->errored = true;
         return -1;

--- a/src/compression.c
+++ b/src/compression.c
@@ -6,14 +6,15 @@
 
 #include "compression.h"
 #include "compression_lz4.h"
+#include "serverassert.h"
 #include <limits.h>
 #include <string.h>
 
 typedef struct {
     int (*compressor_init)(streamCompressor *sc);
-    void (*compressor_destroy)(streamCompressor *sc);
+    void (*compressor_free)(streamCompressor *sc);
     int (*decompressor_init)(streamDecompressor *sd);
-    void (*decompressor_destroy)(streamDecompressor *sd);
+    void (*decompressor_free)(streamDecompressor *sd);
     size_t (*compress_output_bound)(size_t input_len);
     ssize_t (*compress_feed)(streamCompressor *sc,
                              uint8_t *output,
@@ -31,9 +32,9 @@ typedef struct {
 
 static const compressionCodec compressionLz4Codec = {
     .compressor_init = compressionLz4CompressorInit,
-    .compressor_destroy = compressionLz4CompressorDestroy,
+    .compressor_free = compressionLz4CompressorFree,
     .decompressor_init = compressionLz4DecompressorInit,
-    .decompressor_destroy = compressionLz4DecompressorDestroy,
+    .decompressor_free = compressionLz4DecompressorFree,
     .compress_output_bound = compressionLz4OutputBound,
     .compress_feed = compressionLz4CompressFeed,
     .decompress_feed = compressionLz4DecompressFeed,
@@ -67,7 +68,7 @@ const char *compressionAlgoName(compressionAlgo algo) {
 }
 
 int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) {
-    if (!sc) return -1;
+    assert(sc != NULL);
     memset(sc, 0, sizeof(*sc));
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(algo);
@@ -78,22 +79,22 @@ int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level) 
     sc->level = level;
 
     if (impl->compressor_init(sc) != 0) {
-        streamCompressorDestroy(sc);
+        streamCompressorFree(sc);
         return -1;
     }
     return 0;
 }
 
-void streamCompressorDestroy(streamCompressor *sc) {
+void streamCompressorFree(streamCompressor *sc) {
     if (!sc) return;
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sc->algo);
     const compressionCodec *impl = entry ? entry->impl : NULL;
-    if (impl) impl->compressor_destroy(sc);
+    if (impl) impl->compressor_free(sc);
     memset(sc, 0, sizeof(*sc));
 }
 
 int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
-    if (!sd) return -1;
+    assert(sd != NULL);
     memset(sd, 0, sizeof(*sd));
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(algo);
@@ -103,25 +104,25 @@ int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo) {
     sd->algo = algo;
 
     if (impl->decompressor_init(sd) != 0) {
-        streamDecompressorDestroy(sd);
+        streamDecompressorFree(sd);
         return -1;
     }
     return 0;
 }
 
-void streamDecompressorDestroy(streamDecompressor *sd) {
+void streamDecompressorFree(streamDecompressor *sd) {
     if (!sd) return;
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sd->algo);
     const compressionCodec *impl = entry ? entry->impl : NULL;
-    if (impl) impl->decompressor_destroy(sd);
+    if (impl) impl->decompressor_free(sd);
     memset(sd, 0, sizeof(*sd));
 }
 
 size_t streamCompressOutputBound(const streamCompressor *sc, size_t input_len) {
-    if (!sc) return 0;
+    assert(sc != NULL);
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sc->algo);
     const compressionCodec *impl = entry ? entry->impl : NULL;
-    if (!impl) return 0;
+    assert(impl != NULL);
     return impl->compress_output_bound(input_len);
 }
 
@@ -131,13 +132,14 @@ ssize_t streamCompressFeed(streamCompressor *sc,
                            const uint8_t *input,
                            size_t input_len,
                            compressFlushMode flush_mode) {
-    if (!sc || !output) return -1;
+    assert(sc != NULL);
+    assert(output != NULL);
+    assert(input_len == 0 || input != NULL);
     if (sc->errored) return -1;
-    if (input_len > 0 && !input) return -1;
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sc->algo);
     const compressionCodec *impl = entry ? entry->impl : NULL;
-    if (!impl) return -1;
+    assert(impl != NULL);
 
     return impl->compress_feed(sc, output, output_capacity, input, input_len, flush_mode);
 }
@@ -148,30 +150,20 @@ ssize_t streamDecompressFeed(streamDecompressor *sd,
                              const uint8_t *input,
                              size_t input_len,
                              size_t *input_consumed) {
-    if (!sd || !input_consumed) return -1;
-    if (sd->errored) return -1;
+    assert(sd != NULL);
+    assert(output != NULL);
+    assert(input_consumed != NULL);
+    assert(input_len == 0 || input != NULL);
+    assert(output_capacity > 0);
+    assert(output_capacity <= (size_t)SSIZE_MAX);
+
     *input_consumed = 0;
+    if (sd->errored) return -1;
     if (sd->frame_done) return 0;
-    if (input_len > 0 && !input) {
-        sd->errored = true;
-        return -1;
-    }
-    /* Zero output capacity would let streaming loops spin forever. */
-    if (!output || output_capacity == 0) {
-        sd->errored = true;
-        return -1;
-    }
-    if (output_capacity > (size_t)SSIZE_MAX) {
-        sd->errored = true;
-        return -1;
-    }
 
     const compressionAlgoEntry *entry = compressionAlgoEntryForAlgo(sd->algo);
     const compressionCodec *impl = entry ? entry->impl : NULL;
-    if (!impl) {
-        sd->errored = true;
-        return -1;
-    }
+    assert(impl != NULL);
 
     return impl->decompress_feed(sd, output, output_capacity, input, input_len, input_consumed);
 }

--- a/src/compression.h
+++ b/src/compression.h
@@ -65,8 +65,10 @@ ssize_t streamCompressFeed(streamCompressor *sc,
                            size_t input_len,
                            compressFlushMode flush_mode);
 
-/* Returns bytes written, or -1 on error. *input_consumed is set so the caller
- * can retain any unconsumed suffix and retry with more output space. */
+/* Returns decompressed bytes written, or -1 on error. *input_consumed is set to
+ * the number of compressed input bytes consumed. If it is less than input_len,
+ * the caller must keep the unconsumed suffix and pass it again with more output
+ * space. */
 ssize_t streamDecompressFeed(streamDecompressor *sd,
                              uint8_t *output,
                              size_t output_capacity,

--- a/src/compression.h
+++ b/src/compression.h
@@ -48,10 +48,10 @@ bool compressionAlgoSupportsStreaming(compressionAlgo algo);
 const char *compressionAlgoName(compressionAlgo algo);
 
 int streamCompressorInit(streamCompressor *sc, compressionAlgo algo, int level);
-void streamCompressorDestroy(streamCompressor *sc);
+void streamCompressorFree(streamCompressor *sc);
 
 int streamDecompressorInit(streamDecompressor *sd, compressionAlgo algo);
-void streamDecompressorDestroy(streamDecompressor *sd);
+void streamDecompressorFree(streamDecompressor *sd);
 
 /* Conservative bound covering header + data + flush/end overhead, so the
  * caller can size one scratch buffer for all flush modes. */

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -27,7 +27,7 @@ int compressionLz4CompressorInit(streamCompressor *sc) {
     return 0;
 }
 
-void compressionLz4CompressorDestroy(streamCompressor *sc) {
+void compressionLz4CompressorFree(streamCompressor *sc) {
     if (!sc || !sc->ctx) return;
     LZ4F_freeCompressionContext((LZ4F_cctx *)sc->ctx);
     sc->ctx = NULL;
@@ -41,7 +41,7 @@ int compressionLz4DecompressorInit(streamDecompressor *sd) {
     return 0;
 }
 
-void compressionLz4DecompressorDestroy(streamDecompressor *sd) {
+void compressionLz4DecompressorFree(streamDecompressor *sd) {
     if (!sd || !sd->ctx) return;
     LZ4F_freeDecompressionContext((LZ4F_dctx *)sd->ctx);
     sd->ctx = NULL;

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -77,7 +77,7 @@ ssize_t compressionLz4CompressFeed(streamCompressor *sc,
                                                   ? LZ4F_contentChecksumEnabled
                                                   : LZ4F_noContentChecksum;
         size_t r = LZ4F_compressBegin(cctx, output, output_capacity, &prefs);
-        if (LZ4F_isError(r)) return -1;
+        if (LZ4F_isError(r)) return -1; /* No frame bytes emitted yet: retriable, don't latch errored. */
         offset = r;
         sc->stream_started = true;
     }

--- a/src/compression_lz4.h
+++ b/src/compression_lz4.h
@@ -10,9 +10,9 @@
 #include "compression.h"
 
 int compressionLz4CompressorInit(streamCompressor *sc);
-void compressionLz4CompressorDestroy(streamCompressor *sc);
+void compressionLz4CompressorFree(streamCompressor *sc);
 int compressionLz4DecompressorInit(streamDecompressor *sd);
-void compressionLz4DecompressorDestroy(streamDecompressor *sd);
+void compressionLz4DecompressorFree(streamDecompressor *sd);
 size_t compressionLz4OutputBound(size_t input_len);
 
 ssize_t compressionLz4CompressFeed(streamCompressor *sc,

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -33,7 +33,7 @@ static void rioInitBase(rio *base,
                         off_t (*tell_fn)(rio *),
                         int (*flush_fn)(rio *),
                         uint64_t flags,
-                        uint8_t type) {
+                        uint8_t transport_type) {
     base->read = read_fn;
     base->write = write_fn;
     base->tell = tell_fn;
@@ -44,7 +44,7 @@ static void rioInitBase(rio *base,
     base->flags = flags;
     base->processed_bytes = 0;
     base->max_processing_chunk = 0;
-    base->type = type;
+    base->transport_type = transport_type;
 }
 
 /* ===== compressRio ===== */
@@ -93,12 +93,12 @@ static int compressRioFlush(rio *r) {
     return 1;
 }
 
-int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg) {
+int rioInitWithCompression(compressRio *cr, rio *inner, const streamWriterConfig *cfg) {
     if (!cr || !inner || !cfg) return -1;
 
     memset(cr, 0, sizeof(*cr));
     rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
-                compressRioFlush, RIO_FLAG_STREAMING_COMPRESSION, rioCheckType(inner));
+                compressRioFlush, RIO_FLAG_STREAMING_COMPRESSION, rioGetTransportType(inner));
 
     cr->inner = inner;
     cr->writer = streamWriterCreate(cfg, compressRioEmit, cr);
@@ -136,10 +136,10 @@ int compressRioFinish(compressRio *cr) {
     return 0;
 }
 
-void compressRioDestroy(compressRio *cr) {
+void compressRioFree(compressRio *cr) {
     if (!cr) return;
     if (cr->writer) {
-        streamWriterDestroy(cr->writer);
+        streamWriterFree(cr->writer);
         cr->writer = NULL;
     }
 }
@@ -181,15 +181,16 @@ static off_t decompressRioTell(rio *r) {
     return (off_t)dr->inner->processed_bytes;
 }
 
-streamReaderError decompressRioGetError(const decompressRio *dr) {
-    if (!dr || !dr->reader) return STREAM_READER_ERROR_IO;
-    return streamReaderGetError(dr->reader);
-}
-
 /* Identifies a decompressRio by its read vtable, which is unique to the type. */
-const decompressRio *rioAsDecompressRio(const rio *r) {
+static const decompressRio *rioGetDecompressor(const rio *r) {
     if (!r || r->read != decompressRioRead) return NULL;
     return (const decompressRio *)r;
+}
+
+streamReaderError rioGetDecompressionError(const rio *r) {
+    const decompressRio *dr = rioGetDecompressor(r);
+    if (!dr || !dr->reader) return STREAM_READER_ERROR_IO;
+    return streamReaderGetError(dr->reader);
 }
 
 int decompressRioValidateEnd(decompressRio *dr) {
@@ -197,10 +198,10 @@ int decompressRioValidateEnd(decompressRio *dr) {
     return streamReaderValidateEnd(dr->reader);
 }
 
-decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
-                                              rio *inner,
-                                              const streamReaderConfig *cfg,
-                                              streamReaderInfo *info) {
+decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
+                                                 rio *inner,
+                                                 const streamReaderConfig *cfg,
+                                                 streamReaderInfo *info) {
     streamReaderInfo local_info = {0};
 
     if (!dr || !inner || !cfg) return DECOMPRESS_RIO_INIT_ERROR;
@@ -209,7 +210,7 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
     rioInitBase(&dr->base, decompressRioRead, rioWriteUnsupported, decompressRioTell,
                 rioFlushNoop,
                 RIO_FLAG_STREAMING_DECOMPRESSION | (inner->flags & RIO_FLAG_SKIP_RDB_CHECKSUM),
-                rioCheckType(inner));
+                rioGetTransportType(inner));
     dr->inner = inner;
 
     dr->reader = streamReaderCreate(cfg, decompressRioReadPartial, dr);
@@ -219,7 +220,7 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
     }
     if (streamReaderGetInfo(dr->reader, &local_info) != 0) {
         streamReaderError error_kind = streamReaderGetError(dr->reader);
-        decompressRioDestroy(dr);
+        decompressRioFree(dr);
         return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
                    ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
                    : DECOMPRESS_RIO_INIT_ERROR;
@@ -230,10 +231,10 @@ decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
     return DECOMPRESS_RIO_INIT_OK;
 }
 
-void decompressRioDestroy(decompressRio *dr) {
+void decompressRioFree(decompressRio *dr) {
     if (!dr) return;
     if (dr->reader) {
-        streamReaderDestroy(dr->reader);
+        streamReaderFree(dr->reader);
         dr->reader = NULL;
     }
 }

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -51,6 +51,8 @@ static void rioInitBase(rio *base,
 
 static int compressRioEmit(void *ctx, const uint8_t *data, size_t len) {
     compressRio *cr = (compressRio *)ctx;
+    /* Bridge streamWriter's 0/-1 sink contract to rioWrite's nonzero/zero
+     * success contract while keeping streamWriter sink-agnostic. */
     return rioWrite(cr->inner, data, len) == 0 ? -1 : 0;
 }
 

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -29,20 +29,18 @@ typedef enum {
     DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
 } decompressRioInitResult;
 
-int rioInitWithCompress(compressRio *cr, rio *inner, const streamWriterConfig *cfg);
+int rioInitWithCompression(compressRio *cr, rio *inner, const streamWriterConfig *cfg);
 int compressRioFinish(compressRio *cr);
-void compressRioDestroy(compressRio *cr);
+void compressRioFree(compressRio *cr);
 
 /* Probes the wrapped rio so the caller learns up front whether it is plain,
  * compressed, or carrying an envelope this build cannot read. */
-decompressRioInitResult rioInitWithDecompress(decompressRio *dr,
-                                              rio *inner,
-                                              const streamReaderConfig *cfg,
-                                              streamReaderInfo *info);
-streamReaderError decompressRioGetError(const decompressRio *dr);
-/* Returns the typed pointer when `r` is a decompressRio, NULL otherwise. */
-const decompressRio *rioAsDecompressRio(const rio *r);
+decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
+                                                 rio *inner,
+                                                 const streamReaderConfig *cfg,
+                                                 streamReaderInfo *info);
+streamReaderError rioGetDecompressionError(const rio *r);
 int decompressRioValidateEnd(decompressRio *dr);
-void decompressRioDestroy(decompressRio *dr);
+void decompressRioFree(decompressRio *dr);
 
 #endif /* COMPRESSION_RIO_H */

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -293,7 +293,7 @@ static int streamWriterFeedAndEmit(streamWriter *t,
 }
 
 static void streamWriterReleaseContext(streamWriter *t) {
-    streamCompressorDestroy(&t->compressor);
+    streamCompressorFree(&t->compressor);
     if (t->out_buf) {
         zfree(t->out_buf);
         t->out_buf = NULL;
@@ -362,7 +362,7 @@ int streamWriterFinish(streamWriter *t) {
     return streamWriterFeedAndEmit(t, NULL, 0, FLUSH_END);
 }
 
-void streamWriterDestroy(streamWriter *t) {
+void streamWriterFree(streamWriter *t) {
     if (!t) return;
     streamWriterReleaseContext(t);
     zfree(t);
@@ -429,7 +429,7 @@ static int streamReaderInitCompressedState(streamReader *t, size_t buffer_size) 
 
 static void streamReaderResetCompressedState(streamReader *t) {
     if (t->decompressor_initialized) {
-        streamDecompressorDestroy(&t->decompressor);
+        streamDecompressorFree(&t->decompressor);
         t->decompressor_initialized = false;
     }
     if (t->compressed_buf) {
@@ -746,7 +746,7 @@ int streamReaderValidateEnd(streamReader *t) {
     return 0;
 }
 
-void streamReaderDestroy(streamReader *t) {
+void streamReaderFree(streamReader *t) {
     if (!t) return;
     streamReaderResetCompressedState(t);
     zfree(t);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -457,7 +457,7 @@ streamReader *streamReaderCreate(const streamReaderConfig *cfg,
     t->probe_cfg.allow_passthrough = cfg->allow_passthrough;
     t->probe_cfg.expected_stream_kind = cfg->expected_stream_kind;
     vkcsProbeInit(&t->probe);
-    t->buffer_size = cfg->buffer_size ? cfg->buffer_size : STREAM_READER_BUFFER_SIZE_DEFAULT;
+    t->buffer_size = cfg->buffer_size;
     if (t->buffer_size < STREAM_READER_BUFFER_SIZE_MIN) {
         t->buffer_size = STREAM_READER_BUFFER_SIZE_MIN;
     }

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -449,7 +449,7 @@ static void streamReaderResetCompressedState(streamReader *t) {
 streamReader *streamReaderCreate(const streamReaderConfig *cfg,
                                  streamReaderReadFn read_cb,
                                  void *read_ctx) {
-    if (!cfg || !read_cb) return NULL;
+    if (!cfg || !read_cb || cfg->buffer_size == 0) return NULL;
 
     streamReader *t = zcalloc(sizeof(*t));
     t->read_cb = read_cb;

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -76,12 +76,12 @@ static int vkcsCodecToCompressionAlgo(vkcsCodec codec, compressionAlgo *algo) {
     }
 }
 
-static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
+static int writeVkcsEnvelope(vkcsEmitFn emit_fn,
                              void *ctx,
                              vkcsCodec codec,
                              uint8_t stream_kind,
                              bool codec_checksum_enabled) {
-    if (!emit_cb || !vkcsCodecIsSupported(codec)) return -1;
+    if (!emit_fn || !vkcsCodecIsSupported(codec)) return -1;
 
     uint8_t envelope[VKCS_ENVELOPE_SIZE] = {
         VKCS_MAGIC_0,
@@ -93,7 +93,7 @@ static int writeVkcsEnvelope(vkcsEmitFn emit_cb,
         codec_checksum_enabled ? VKCS_FLAG_CODEC_CHECKSUM : 0,
         stream_kind,
     };
-    return emit_cb(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
+    return emit_fn(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
 }
 
 /* Rejects unknown flag bits so a future format extension fails loud rather
@@ -214,7 +214,7 @@ struct streamWriter {
     streamCompressor compressor;
     uint8_t *out_buf;
     size_t out_buf_size;
-    vkcsEmitFn emit_cb;
+    vkcsEmitFn emit_fn;
     void *emit_ctx;
     uint8_t stream_kind;
     bool envelope_written;
@@ -225,10 +225,10 @@ struct streamWriter {
 
 static int streamWriterInitContext(streamWriter *t,
                                    const streamWriterConfig *cfg,
-                                   vkcsEmitFn emit_cb,
+                                   vkcsEmitFn emit_fn,
                                    void *emit_ctx) {
     memset(t, 0, sizeof(*t));
-    t->emit_cb = emit_cb;
+    t->emit_fn = emit_fn;
     t->emit_ctx = emit_ctx;
     t->stream_kind = cfg->stream_kind;
 
@@ -243,7 +243,7 @@ static int streamWriterEnsureEnvelope(streamWriter *t) {
     if (t->envelope_written) return 0;
     vkcsCodec codec;
     if (compressionAlgoToVkcsCodec(t->compressor.algo, &codec) != 0 ||
-        writeVkcsEnvelope(t->emit_cb, t->emit_ctx, codec,
+        writeVkcsEnvelope(t->emit_fn, t->emit_ctx, codec,
                           t->stream_kind, t->compressor.codec_checksum) != 0) {
         t->errored = true;
         return -1;
@@ -255,7 +255,7 @@ static int streamWriterEnsureEnvelope(streamWriter *t) {
 
 static int streamWriterEmit(streamWriter *t, const uint8_t *buf, size_t len) {
     if (len == 0) return 0;
-    if (t->emit_cb(t->emit_ctx, buf, len) != 0) {
+    if (t->emit_fn(t->emit_ctx, buf, len) != 0) {
         t->errored = true;
         return -1;
     }
@@ -302,12 +302,12 @@ static void streamWriterReleaseContext(streamWriter *t) {
 }
 
 streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
-                                 vkcsEmitFn emit_cb,
+                                 vkcsEmitFn emit_fn,
                                  void *emit_ctx) {
-    if (!cfg || !emit_cb || !compressionAlgoSupportsStreaming(cfg->algo)) return NULL;
+    if (!cfg || !emit_fn || !compressionAlgoSupportsStreaming(cfg->algo)) return NULL;
 
     streamWriter *t = zmalloc(sizeof(*t));
-    if (streamWriterInitContext(t, cfg, emit_cb, emit_ctx) != 0) {
+    if (streamWriterInitContext(t, cfg, emit_fn, emit_ctx) != 0) {
         zfree(t);
         return NULL;
     }

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -38,9 +38,9 @@ typedef enum {
 
 typedef int (*vkcsEmitFn)(void *ctx, const uint8_t *data, size_t len);
 
-/* Reader compressed-input/decompressed-output buffer size when cfg->buffer_size
- * is unset. Tiny caller values are clamped up so the LZ4 decoder can always
- * make forward progress without growing internal state. */
+/* Default reader compressed-input/decompressed-output buffer size. Tiny caller
+ * values are clamped up so the LZ4 decoder can always make forward progress
+ * without growing internal state. */
 #define STREAM_READER_BUFFER_SIZE_DEFAULT (1024 * 1024)
 #define STREAM_READER_BUFFER_SIZE_MIN (128 * 1024)
 
@@ -56,7 +56,7 @@ typedef struct {
 typedef struct {
     uint8_t expected_stream_kind;
     bool allow_passthrough;
-    size_t buffer_size; /* 0 means use STREAM_READER_BUFFER_SIZE_DEFAULT. */
+    size_t buffer_size; /* Clamped to STREAM_READER_BUFFER_SIZE_MIN. */
 } streamReaderConfig;
 
 typedef struct streamWriter streamWriter;

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -88,7 +88,7 @@ streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
 ssize_t streamWriterWrite(streamWriter *t, const void *buf, size_t len);
 int streamWriterFlush(streamWriter *t);
 int streamWriterFinish(streamWriter *t);
-void streamWriterDestroy(streamWriter *t);
+void streamWriterFree(streamWriter *t);
 int streamWriterIsErrored(const streamWriter *t);
 void streamWriterSetError(streamWriter *t);
 int streamReadEnvelopeInfo(const uint8_t *buf,
@@ -109,6 +109,6 @@ ssize_t streamReaderRead(streamReader *t, void *buf, size_t len);
 int streamReaderGetInfo(streamReader *t, streamReaderInfo *info);
 streamReaderError streamReaderGetError(const streamReader *t);
 int streamReaderValidateEnd(streamReader *t);
-void streamReaderDestroy(streamReader *t);
+void streamReaderFree(streamReader *t);
 
 #endif /* COMPRESSION_STREAM_H */

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -14,7 +14,11 @@
  *   [4]    version (currently VKCS_VERSION)
  *   [5]    codec id
  *   [6]    flags (bit 0 = codec checksum enabled; other bits reserved)
- *   [7]    stream kind */
+ *   [7]    stream kind
+ *
+ * The stream kind identifies the decompressed payload, so readers can reject a
+ * valid compressed stream that is meant for a different logical consumer before
+ * handing bytes to RDB, replication, or another parser. */
 #define VKCS_MAGIC_0 0x56 /* 'V' */
 #define VKCS_MAGIC_1 0x4B /* 'K' */
 #define VKCS_MAGIC_2 0x43 /* 'C' */
@@ -23,7 +27,10 @@
 #define VKCS_ENVELOPE_SIZE 8
 #define VKCS_VERSION 1
 #define VKCS_FLAG_CODEC_CHECKSUM (1 << 0)
-#define STREAM_KIND_RDB 0x00
+
+typedef enum {
+    STREAM_KIND_RDB = 0x00,
+} streamKind;
 
 typedef enum {
     VKCS_CODEC_LZ4 = 0x01,
@@ -49,7 +56,7 @@ typedef struct {
 typedef struct {
     uint8_t expected_stream_kind;
     bool allow_passthrough;
-    size_t buffer_size; /* 0 selects STREAM_READER_BUFFER_SIZE_DEFAULT. */
+    size_t buffer_size; /* 0 means use STREAM_READER_BUFFER_SIZE_DEFAULT. */
 } streamReaderConfig;
 
 typedef struct streamWriter streamWriter;
@@ -73,7 +80,7 @@ typedef enum {
 typedef ssize_t (*streamReaderReadFn)(void *ctx, void *buf, size_t len);
 
 streamWriter *streamWriterCreate(const streamWriterConfig *cfg,
-                                 vkcsEmitFn emit_cb,
+                                 vkcsEmitFn emit_fn,
                                  void *emit_ctx);
 
 /* Returns compressed bytes emitted to the sink (not input bytes consumed),

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -56,7 +56,7 @@ typedef struct {
 typedef struct {
     uint8_t expected_stream_kind;
     bool allow_passthrough;
-    size_t buffer_size; /* Clamped to STREAM_READER_BUFFER_SIZE_MIN. */
+    size_t buffer_size; /* Must be nonzero; clamped to STREAM_READER_BUFFER_SIZE_MIN. */
 } streamReaderConfig;
 
 typedef struct streamWriter streamWriter;

--- a/src/config.c
+++ b/src/config.c
@@ -454,8 +454,6 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * within conf file parsing. This is only needed to support the deprecated
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
-/* Tracks nested config parsing depth (top-level + includes). */
-static int config_parse_depth;
 
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
@@ -476,7 +474,6 @@ void loadServerConfigFromString(sds config) {
     int argc;
 
     reading_config_file = 1;
-    config_parse_depth++;
     lines = sdssplitlen(config, sdslen(config), "\n", 1, &totlines);
 
     for (i = 0; i < totlines; i++) {
@@ -635,13 +632,11 @@ void loadServerConfigFromString(sds config) {
     if (server.hz > CONFIG_MAX_HZ) server.hz = CONFIG_MAX_HZ;
 
     sdsfreesplitres(lines, totlines);
-    config_parse_depth--;
-    reading_config_file = config_parse_depth > 0;
+    reading_config_file = 0;
     return;
 
 loaderr:
-    config_parse_depth--;
-    reading_config_file = config_parse_depth > 0;
+    reading_config_file = 0;
     if (argv) sdsfreesplitres(argv, argc);
     fprintf(stderr, "\n*** FATAL CONFIG FILE ERROR (Version %s) ***\n", VALKEY_VERSION);
     if (i < totlines) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1726,10 +1726,11 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE, "DB saved on disk");
     if (isRdbStreamingCompressionEnabled()) {
-        serverLog(LL_VERBOSE, "RDB saved with %s streaming compression",
+        serverLog(LL_NOTICE, "DB saved on disk with %s streaming compression",
                   compressionAlgoName((compressionAlgo)server.rdb_compression_algo));
+    } else {
+        serverLog(LL_NOTICE, "DB saved on disk");
     }
     server.dirty = 0;
     server.lastsave = time(NULL);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1609,9 +1609,9 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
             .stream_kind = STREAM_KIND_RDB,
             .codec_checksum_enabled = server.rdb_checksum != 0,
         };
-        if (rioInitWithCompress(&cr, &rdb, &cfg) != 0) {
+        if (rioInitWithCompression(&cr, &rdb, &cfg) != 0) {
             errno = EIO; /* Compressor init failure — set errno for werr log */
-            err_op = "rioInitWithCompress";
+            err_op = "rioInitWithCompression";
             goto werr;
         }
         save_rio = (rio *)&cr;
@@ -1636,11 +1636,11 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
         if (compressRioFinish(&cr) != 0) {
             errno = EIO; /* Compression finalization failure */
             err_op = "compressRioFinish";
-            compressRioDestroy(&cr);
+            compressRioFree(&cr);
             cr_initialized = false;
             goto werr;
         }
-        compressRioDestroy(&cr);
+        compressRioFree(&cr);
         cr_initialized = false;
     }
 
@@ -1670,7 +1670,7 @@ werr:
     if (cr_initialized) {
         /* Skip finish on error — output is being discarded (unlink below).
          * Just release resources. */
-        compressRioDestroy(&cr);
+        compressRioFree(&cr);
     }
     if (fp) fclose(fp);
     unlink(filename);
@@ -3136,7 +3136,7 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
         processEventsWhileBlocked();
         processModuleLoadingProgressEvent(0);
     }
-    if (server.repl_state == REPL_STATE_TRANSFER && rioCheckType(r) == RIO_TYPE_CONN) {
+    if (server.repl_state == REPL_STATE_TRANSFER && rioGetTransportType(r) == RIO_TYPE_CONN) {
         server.stat_net_repl_input_bytes += len;
     }
 }
@@ -3159,7 +3159,7 @@ decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
     if (!input || !input->raw_rio) return DECOMPRESS_RIO_INIT_ERROR;
 
     decompressRioInitResult init_rc =
-        rioInitWithDecompress(&input->decompressor, input->raw_rio, &reader_cfg, &input->stream_info);
+        rioInitWithDecompression(&input->decompressor, input->raw_rio, &reader_cfg, &input->stream_info);
     if (init_rc == DECOMPRESS_RIO_INIT_OK) {
         input->initialized = true;
         input->rdb_rio = (rio *)&input->decompressor;
@@ -3170,10 +3170,10 @@ decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
     return init_rc;
 }
 
-void rdbInputStreamDestroy(rdbInputStream *input) {
+void rdbInputStreamFree(rdbInputStream *input) {
     if (!input) return;
     if (input->initialized) {
-        decompressRioDestroy(&input->decompressor);
+        decompressRioFree(&input->decompressor);
         input->initialized = false;
     }
     input->rdb_rio = input->raw_rio;
@@ -3185,8 +3185,7 @@ int rdbInputStreamValidateEnd(rdbInputStream *input) {
 }
 
 bool rdbRioHasCorruptCompressedInput(const rio *rdb) {
-    const decompressRio *dr = rioAsDecompressRio(rdb);
-    return dr && decompressRioGetError(dr) == STREAM_READER_ERROR_CORRUPT;
+    return rioGetDecompressionError(rdb) == STREAM_READER_ERROR_CORRUPT;
 }
 
 /* Save the given functions_ctx to the rdb.
@@ -3787,7 +3786,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     }
 
 done:
-    rdbInputStreamDestroy(&input);
+    rdbInputStreamFree(&input);
     fclose(fp);
     stopLoading(retval == RDB_OK);
     /* Reclaim the cache backed by rdb */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3136,7 +3136,7 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
         processEventsWhileBlocked();
         processModuleLoadingProgressEvent(0);
     }
-    if (server.repl_state == REPL_STATE_TRANSFER && rioGetTransportType(r) == RIO_TYPE_CONN) {
+    if (server.repl_state == REPL_STATE_TRANSFER && rioIsConnTransport(r)) {
         server.stat_net_repl_input_bytes += len;
     }
 }
@@ -3153,7 +3153,7 @@ decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
     streamReaderConfig reader_cfg = {
         .expected_stream_kind = STREAM_KIND_RDB,
         .allow_passthrough = true,
-        .buffer_size = 0,
+        .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
     };
 
     if (!input || !input->raw_rio) return DECOMPRESS_RIO_INIT_ERROR;

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -234,7 +234,7 @@ int rdbLoadRioWithLoadingCtxScopedRdb(rio *rdb, int rdbflags, rdbSaveInfo *rsi, 
 void rdbInputStreamInit(rdbInputStream *input, rio *raw_rio);
 decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input);
 int rdbInputStreamValidateEnd(rdbInputStream *input);
-void rdbInputStreamDestroy(rdbInputStream *input);
+void rdbInputStreamFree(rdbInputStream *input);
 bool rdbRioHasCorruptCompressedInput(const rio *rdb);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, sds *err);
 int rdbSaveRio(int req, int rdbver, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi);

--- a/src/rio.c
+++ b/src/rio.c
@@ -109,7 +109,7 @@ static const rio rioBufferIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .type = RIO_TYPE_BUFFER,
+    .transport_type = RIO_TYPE_BUFFER,
     .io = {{NULL, 0}},
 };
 
@@ -213,7 +213,7 @@ static const rio rioFileIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .type = RIO_TYPE_FILE,
+    .transport_type = RIO_TYPE_FILE,
     .io = {{NULL, 0}},
 };
 
@@ -346,7 +346,7 @@ static const rio rioConnIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .type = RIO_TYPE_CONN,
+    .transport_type = RIO_TYPE_CONN,
     .io = {{NULL, 0}},
 };
 
@@ -464,7 +464,7 @@ static const rio rioFdIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .type = RIO_TYPE_FD,
+    .transport_type = RIO_TYPE_FD,
     .io = {{NULL, 0}},
 };
 
@@ -540,9 +540,9 @@ void rioSetReclaimCache(rio *r, int enabled) {
     r->io.file.reclaim_cache = enabled;
 }
 
-/* Check the type of rio. */
-uint8_t rioCheckType(rio *r) {
-    return r->type;
+/* Return the underlying transport type of the rio. */
+uint8_t rioGetTransportType(const rio *r) {
+    return r->transport_type;
 }
 
 /* --------------------------- Higher level interface --------------------------
@@ -694,7 +694,7 @@ static const rio rioConnsetIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .type = RIO_TYPE_CONN,
+    .transport_type = RIO_TYPE_CONN,
     .io = {{NULL, 0}},
 };
 

--- a/src/rio.c
+++ b/src/rio.c
@@ -545,6 +545,10 @@ uint8_t rioGetTransportType(const rio *r) {
     return r->transport_type;
 }
 
+int rioIsConnTransport(const rio *r) {
+    return r && r->transport_type == RIO_TYPE_CONN;
+}
+
 /* --------------------------- Higher level interface --------------------------
  *
  * The following higher level functions use lower level rio.c functions to help

--- a/src/rio.h
+++ b/src/rio.h
@@ -215,6 +215,7 @@ ssize_t rioReadPartial(rio *r, void *buf, size_t len);
 void rioSetAutoSync(rio *r, off_t bytes);
 void rioSetReclaimCache(rio *r, int enabled);
 uint8_t rioGetTransportType(const rio *r);
+int rioIsConnTransport(const rio *r);
 void rioInitWithConnset(rio *r, connection **conns, int numconns);
 void rioFreeConnset(rio *r);
 #endif

--- a/src/rio.h
+++ b/src/rio.h
@@ -79,8 +79,8 @@ struct _rio {
     /* maximum single read or write chunk size */
     size_t max_processing_chunk;
 
-    /* Backend type (RIO_TYPE_*). Decorators should preserve the wrapped type. */
-    uint8_t type;
+    /* Transport type (RIO_TYPE_*). Rio decorators preserve the wrapped transport. */
+    uint8_t transport_type;
 
     /* Backend-specific vars. */
     union {
@@ -214,7 +214,7 @@ void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len);
 ssize_t rioReadPartial(rio *r, void *buf, size_t len);
 void rioSetAutoSync(rio *r, off_t bytes);
 void rioSetReclaimCache(rio *r, int enabled);
-uint8_t rioCheckType(rio *r);
+uint8_t rioGetTransportType(const rio *r);
 void rioInitWithConnset(rio *r, connection **conns, int numconns);
 void rioFreeConnset(rio *r);
 #endif

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -168,41 +168,38 @@ static void initFailingFlushRio(rio *r) {
     r->write = discardRioWrite;
     r->tell = discardRioTell;
     r->flush = failRioFlush;
-    r->type = RIO_TYPE_BUFFER;
+    r->transport_type = RIO_TYPE_BUFFER;
 }
 
 /* ===================================================================
  * Streaming compression/decompression tests
  * =================================================================== */
 
-/* --- Test: LZ4 compressor init/destroy lifecycle --- */
-TEST_F(CompressionTest, streamCompressorInitDestroy) {
+/* --- Test: LZ4 compressor init/free lifecycle --- */
+TEST_F(CompressionTest, streamCompressorInitFree) {
     streamCompressor sc;
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0) << "LZ4 init should succeed";
     ASSERT_EQ(sc.algo, ALGO_LZ4) << "algo should be LZ4";
     ASSERT_EQ(sc.stream_started, false) << "stream_started should be false";
     ASSERT_NE(sc.ctx, nullptr) << "ctx should be non-nullptr";
-    streamCompressorDestroy(&sc);
-    ASSERT_EQ(sc.ctx, nullptr) << "ctx should be nullptr after destroy";
-    ASSERT_EQ(sc.algo, ALGO_NONE) << "algo should be NONE after destroy";
+    streamCompressorFree(&sc);
+    ASSERT_EQ(sc.ctx, nullptr) << "ctx should be nullptr after free";
+    ASSERT_EQ(sc.algo, ALGO_NONE) << "algo should be NONE after free";
 
     /* ALGO_NONE should fail */
     streamCompressor sc3;
     ASSERT_EQ(streamCompressorInit(&sc3, ALGO_NONE, 0), -1) << "NONE init should fail";
-
-    /* nullptr should fail */
-    ASSERT_EQ(streamCompressorInit(nullptr, ALGO_LZ4, 0), -1) << "nullptr init should fail";
 }
 
-/* --- Test: LZ4 decompressor init/destroy lifecycle --- */
-TEST_F(CompressionTest, streamDecompressorInitDestroy) {
+/* --- Test: LZ4 decompressor init/free lifecycle --- */
+TEST_F(CompressionTest, streamDecompressorInitFree) {
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0) << "LZ4 decomp init should succeed";
     ASSERT_EQ(sd.algo, ALGO_LZ4) << "algo should be LZ4";
     ASSERT_NE(sd.ctx, nullptr) << "ctx should be non-nullptr";
-    streamDecompressorDestroy(&sd);
-    ASSERT_EQ(sd.ctx, nullptr) << "ctx should be nullptr after destroy";
-    ASSERT_EQ(sd.algo, ALGO_NONE) << "algo should be NONE after destroy";
+    streamDecompressorFree(&sd);
+    ASSERT_EQ(sd.ctx, nullptr) << "ctx should be nullptr after free";
+    ASSERT_EQ(sd.algo, ALGO_NONE) << "algo should be NONE after free";
 }
 
 /* --- Test: LZ4 compress → decompress round-trip --- */
@@ -224,7 +221,7 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
                                                 FLUSH_END);
     ASSERT_GT(compressed_len, 0) << "compress should succeed";
     ASSERT_EQ(sc.stream_started, false) << "frame should be closed after FLUSH_END";
-    streamCompressorDestroy(&sc);
+    streamCompressorFree(&sc);
 
     /* Decompress */
     streamDecompressor sd;
@@ -240,7 +237,7 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
     ASSERT_EQ(memcmp(decompressed, input, input_len), 0) << "decompressed content should match input";
     ASSERT_EQ(input_consumed, (size_t)compressed_len) << "all compressed input should be consumed";
 
-    streamDecompressorDestroy(&sd);
+    streamDecompressorFree(&sd);
     zfree(compressed);
 }
 
@@ -270,65 +267,22 @@ TEST_F(CompressionTest, streamCompressOutputBound) {
     ASSERT_GT(b_zero, 0u) << "zero input bound should be > 0";
 
     zfree(seed_buf);
-    streamCompressorDestroy(&sc);
+    streamCompressorFree(&sc);
 }
 
-/* --- Test: streamCompressFeed error paths --- */
-TEST_F(CompressionTest, streamCompressFeedErrors) {
-    uint8_t buf[64];
-    /* nullptr compressor */
-    ASSERT_EQ(streamCompressFeed(nullptr, buf, sizeof(buf),
-                                 (const uint8_t *)"x", 1, FLUSH_CONTINUE),
-              -1)
-        << "nullptr sc should return -1";
-
-    /* nullptr output buffer */
-    streamCompressor sc;
-    ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
-    ASSERT_EQ(streamCompressFeed(&sc, nullptr, sizeof(buf),
-                                 (const uint8_t *)"x", 1, FLUSH_CONTINUE),
-              -1)
-        << "nullptr output should return -1";
-    streamCompressorDestroy(&sc);
-}
-
-/* --- Test: streamDecompressFeed error paths --- */
-TEST_F(CompressionTest, streamDecompressFeedErrors) {
+/* --- Test: corrupt compressed input is a sticky decompressor error. --- */
+TEST_F(CompressionTest, streamDecompressFeedCorruptInputSetsStickyError) {
     const char *payload = "decompress sticky error";
     uint8_t buf[64];
     uint8_t out[128];
     size_t consumed = 0;
 
-    /* nullptr decompressor */
-    ASSERT_EQ(streamDecompressFeed(nullptr, buf, sizeof(buf),
-                                   (const uint8_t *)"x", 1, &consumed),
-              -1)
-        << "nullptr sd should return -1";
-
-    /* nullptr input_consumed */
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
     ASSERT_EQ(streamDecompressFeed(&sd, buf, sizeof(buf),
-                                   (const uint8_t *)"x", 1, nullptr),
-              -1)
-        << "nullptr input_consumed should return -1";
-    ASSERT_EQ(sd.errored, false) << "decompressor should not be errored by nullptr bookkeeping arg";
-
-    streamDecompressor sd_null_input;
-    ASSERT_EQ(streamDecompressorInit(&sd_null_input, ALGO_LZ4), 0);
-    ASSERT_EQ(streamDecompressFeed(&sd_null_input, buf, sizeof(buf),
-                                   nullptr, 1, &consumed),
-              -1)
-        << "nullptr input with non-zero input_len should return -1";
-    ASSERT_EQ(sd_null_input.errored, true) << "nullptr input should latch a sticky decompressor error";
-    streamDecompressorDestroy(&sd_null_input);
-
-    /* Zero output capacity should return -1 (no-progress prevention) */
-    ASSERT_EQ(streamDecompressFeed(&sd, buf, 0,
-                                   (const uint8_t *)"x", 1, &consumed),
-              -1)
-        << "zero output capacity should return -1";
-    ASSERT_EQ(sd.errored, true) << "decompressor should enter sticky errored state";
+                                   (const uint8_t *)"not an lz4 frame", 16, &consumed),
+              -1);
+    ASSERT_EQ(sd.errored, true) << "corrupt input should enter sticky errored state";
 
     /* Once errored, all subsequent feeds fail immediately. */
     streamCompressor sc;
@@ -340,7 +294,7 @@ TEST_F(CompressionTest, streamDecompressFeedErrors) {
                                                 (const uint8_t *)payload, strlen(payload),
                                                 FLUSH_END);
     ASSERT_GT(compressed_len, 0);
-    streamCompressorDestroy(&sc);
+    streamCompressorFree(&sc);
 
     ASSERT_EQ(streamDecompressFeed(&sd, out, sizeof(out),
                                    compressed, (size_t)compressed_len,
@@ -349,7 +303,7 @@ TEST_F(CompressionTest, streamDecompressFeedErrors) {
         << "errored decompressor should fail even with valid input";
     zfree(compressed);
 
-    streamDecompressorDestroy(&sd);
+    streamDecompressorFree(&sd);
 }
 
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
@@ -373,7 +327,7 @@ TEST_F(CompressionTest, streamCompressFeedErrorRecovery) {
                                       (const uint8_t *)"test data", 9, FLUSH_END);
     ASSERT_GT(ret2, 0) << "retry after pre-frame error should succeed";
     zfree(buf);
-    streamCompressorDestroy(&sc);
+    streamCompressorFree(&sc);
 
     /* Mid-frame error: start a frame, then force an error — this is permanent. */
     streamCompressor sc2;
@@ -403,7 +357,7 @@ TEST_F(CompressionTest, streamCompressFeedErrorRecovery) {
     ASSERT_EQ(ret5, -1) << "must fail on errored compressor";
     zfree(buf3);
     zfree(buf2);
-    streamCompressorDestroy(&sc2);
+    streamCompressorFree(&sc2);
 }
 
 TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
@@ -487,7 +441,7 @@ TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
             ASSERT_EQ(streamReaderRead(t, out, sizeof(out)), -1) << cases[i].name;
         }
 
-        streamReaderDestroy(t);
+        streamReaderFree(t);
     }
 }
 
@@ -515,7 +469,7 @@ TEST_F(CompressionTest, streamReaderRejectsOversizedReadRequest) {
     ASSERT_EQ(streamReaderRead(t, out, sizeof(input)), (ssize_t)sizeof(input));
     ASSERT_EQ(memcmp(out, input, sizeof(input)), 0) << "subsequent valid read should still succeed";
 
-    streamReaderDestroy(t);
+    streamReaderFree(t);
 }
 
 /* ===================================================================
@@ -548,7 +502,7 @@ static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
 
 static int initVkcsRdbDecompressRio(decompressRio *dr, rio *inner) {
     streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
-    return rioInitWithDecompress(dr, inner, &cfg, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
+    return rioInitWithDecompression(dr, inner, &cfg, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
 
 TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
@@ -601,7 +555,7 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
         ASSERT_NE(w, nullptr) << cases[i].name;
         ASSERT_GE(streamWriterWrite(w, cases[i].payload, payload_len), 0) << cases[i].name;
         ASSERT_EQ(streamWriterFinish(w), 0) << cases[i].name;
-        streamWriterDestroy(w);
+        streamWriterFree(w);
 
         MemReader mr = {};
         mr.data = db.data;
@@ -632,7 +586,7 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
             ASSERT_EQ(streamReaderRead(r, out, sizeof(out)), -1) << cases[i].name;
         }
 
-        streamReaderDestroy(r);
+        streamReaderFree(r);
         dynamicBufFree(&db);
     }
 }
@@ -662,7 +616,7 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     size_t fail_after_pos = sdslen((const char *)db.data);
     ASSERT_GE(streamWriterWrite(w, payload + first_chunk_len, payload_len - first_chunk_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
-    streamWriterDestroy(w);
+    streamWriterFree(w);
 
     FlakyReader fr = {};
     fr.data = db.data;
@@ -683,7 +637,7 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     ASSERT_EQ(memcmp(out, payload, (size_t)n1), 0);
     ASSERT_EQ(streamReaderRead(r, out, out_len), -1) << "second read should fail immediately";
 
-    streamReaderDestroy(r);
+    streamReaderFree(r);
 
     /* Passthrough mode should also preserve partial bytes when source read
      * fails after probe/prefix buffering, then latch sticky error state. */
@@ -703,15 +657,15 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     ASSERT_EQ(memcmp(pass_out, plain, (size_t)p1), 0) << "passthrough partial bytes should match input prefix";
     ASSERT_EQ(streamReaderRead(rp, pass_out, sizeof(pass_out)), -1)
         << "passthrough second read should fail immediately";
-    streamReaderDestroy(rp);
+    streamReaderFree(rp);
     zfree(out);
 
     dynamicBufFree(&db);
     zfree(payload);
 }
 
-/* --- Test: streamWriterCreate/destroy --- */
-TEST_F(CompressionTest, streamWriterCreateDestroy) {
+/* --- Test: streamWriterCreate/free --- */
+TEST_F(CompressionTest, streamWriterCreateFree) {
     DynamicBuf db;
     dynamicBufInit(&db);
 
@@ -720,14 +674,14 @@ TEST_F(CompressionTest, streamWriterCreateDestroy) {
     ASSERT_NE(t, nullptr) << "create should succeed for LZ4";
     ASSERT_EQ(streamWriterIsErrored(t), 0) << "should not be errored";
 
-    streamWriterDestroy(t);
+    streamWriterFree(t);
     dynamicBufFree(&db);
 
     /* nullptr config should fail */
     ASSERT_EQ(streamWriterCreate(nullptr, emitToDynamicBuf, &db), nullptr) << "nullptr config should return nullptr";
 
-    /* nullptr emit_cb should fail */
-    ASSERT_EQ(streamWriterCreate(&cfg, nullptr, nullptr), nullptr) << "nullptr emit_cb should return nullptr";
+    /* nullptr emit_fn should fail */
+    ASSERT_EQ(streamWriterCreate(&cfg, nullptr, nullptr), nullptr) << "nullptr emit_fn should return nullptr";
 
     /* ALGO_NONE should fail */
     streamWriterConfig bad_cfg = makeWriterConfig(ALGO_NONE, 0, STREAM_KIND_RDB);
@@ -739,10 +693,10 @@ TEST_F(CompressionTest, streamWriterCreateDestroy) {
     streamWriterConfig future_kind_cfg = makeWriterConfig(ALGO_LZ4, 0, 0x7f);
     streamWriter *future_t = streamWriterCreate(&future_kind_cfg, emitToDynamicBuf, &db);
     ASSERT_NE(future_t, nullptr) << "custom stream_kind should succeed with envelope";
-    streamWriterDestroy(future_t);
+    streamWriterFree(future_t);
 
-    /* destroy nullptr should be safe */
-    streamWriterDestroy(nullptr);
+    /* free nullptr should be safe */
+    streamWriterFree(nullptr);
 }
 
 /* --- Test: stream_writer write + finish round-trip --- */
@@ -803,8 +757,8 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
     ASSERT_EQ(total_decompressed, data_len) << "decompressed length should match original";
     ASSERT_EQ(memcmp(decompressed, test_data, data_len), 0) << "decompressed data should match original";
 
-    streamDecompressorDestroy(&sd);
-    streamWriterDestroy(t);
+    streamDecompressorFree(&sd);
+    streamWriterFree(t);
     dynamicBufFree(&db);
 }
 
@@ -825,7 +779,7 @@ TEST_F(CompressionTest, streamWriterLargeSingleWrite) {
     ASSERT_NE(t, nullptr);
     ASSERT_GE(streamWriterWrite(t, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
-    streamWriterDestroy(t);
+    streamWriterFree(t);
 
     MemReader mr = {};
     mr.data = db.data;
@@ -847,7 +801,7 @@ TEST_F(CompressionTest, streamWriterLargeSingleWrite) {
 
     zfree(out);
     zfree(payload);
-    streamReaderDestroy(r);
+    streamReaderFree(r);
     dynamicBufFree(&db);
 }
 
@@ -869,7 +823,7 @@ TEST_F(CompressionTest, streamReaderSmallReadsRoundTrip) {
     ASSERT_NE(w, nullptr);
     ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
-    streamWriterDestroy(w);
+    streamWriterFree(w);
 
     MemReader mr = {};
     mr.data = db.data;
@@ -895,7 +849,7 @@ TEST_F(CompressionTest, streamReaderSmallReadsRoundTrip) {
 
     zfree(out);
     zfree(payload);
-    streamReaderDestroy(r);
+    streamReaderFree(r);
     dynamicBufFree(&db);
 }
 
@@ -942,8 +896,8 @@ TEST_F(CompressionTest, streamWriterFlushBehavior) {
     ASSERT_EQ(total_decompressed, 23u);
     ASSERT_EQ(memcmp(decompressed, "first chunksecond chunk", 23), 0);
 
-    streamDecompressorDestroy(&sd);
-    streamWriterDestroy(t);
+    streamDecompressorFree(&sd);
+    streamWriterFree(t);
     dynamicBufFree(&db);
 }
 
@@ -962,7 +916,7 @@ TEST_F(CompressionTest, streamWriterFlushAfterFinishIsNoop) {
     ASSERT_EQ(streamWriterFlush(t), 0) << "flush after finish should be a no-op success";
     ASSERT_EQ(sdslen((const char *)db.data), len_after_finish) << "flush after finish should not emit bytes";
 
-    streamWriterDestroy(t);
+    streamWriterFree(t);
     dynamicBufFree(&db);
 }
 
@@ -990,7 +944,7 @@ TEST_F(CompressionTest, streamWriterCodecChecksumToggle) {
                   codec_checksum)
             << "LZ4 content checksum should reflect configured codec checksum setting";
 
-        streamWriterDestroy(t);
+        streamWriterFree(t);
         dynamicBufFree(&db);
     }
 }
@@ -1016,8 +970,8 @@ TEST_F(CompressionTest, streamReaderValidateEndAcceptsClosedFrame) {
     ASSERT_EQ(memcmp(out, payload, strlen(payload)), 0);
     ASSERT_EQ(streamReaderValidateEnd(reader), 0);
 
-    streamReaderDestroy(reader);
-    streamWriterDestroy(w);
+    streamReaderFree(reader);
+    streamWriterFree(w);
     dynamicBufFree(&db);
 }
 
@@ -1043,8 +997,8 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsTrailingBytes) {
     ASSERT_EQ(streamReaderValidateEnd(reader), -1);
     ASSERT_EQ(streamReaderGetError(reader), STREAM_READER_ERROR_CORRUPT);
 
-    streamReaderDestroy(reader);
-    streamWriterDestroy(w);
+    streamReaderFree(reader);
+    streamWriterFree(w);
     dynamicBufFree(&db);
 }
 
@@ -1071,8 +1025,8 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsUnreadDecodedBytes) {
     ASSERT_EQ(streamReaderValidateEnd(reader), -1);
     ASSERT_EQ(streamReaderGetError(reader), STREAM_READER_ERROR_CORRUPT);
 
-    streamReaderDestroy(reader);
-    streamWriterDestroy(w);
+    streamReaderFree(reader);
+    streamWriterFree(w);
     dynamicBufFree(&db);
 }
 
@@ -1085,13 +1039,13 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
                             "Pack my box with five dozen liquor jugs.";
     size_t data_len = strlen(test_data);
     ASSERT_NE(rioWrite((rio *)&cr, test_data, data_len), 0u) << "rioWrite should succeed";
 
-    /* Finalize and destroy */
+    /* Finalize and free */
     ASSERT_EQ(compressRioFinish(&cr), 0);
 
     /* Get the compressed output from the buffer rio */
@@ -1131,8 +1085,8 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
     ASSERT_EQ(total_decompressed, data_len) << "decompressed length should match";
     ASSERT_EQ(memcmp(decompressed, test_data, data_len), 0) << "decompressed data should match";
 
-    streamDecompressorDestroy(&sd);
-    compressRioDestroy(&cr);
+    streamDecompressorFree(&sd);
+    compressRioFree(&cr);
     sdsfree(compressed);
 }
 
@@ -1143,7 +1097,7 @@ TEST_F(CompressionTest, compressRioDoesNotInstallRdbChecksum) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
     ASSERT_EQ(cr.base.update_cksum, nullptr);
 
     const char *payload = "checksum-payload-for-compressed-rio";
@@ -1153,7 +1107,7 @@ TEST_F(CompressionTest, compressRioDoesNotInstallRdbChecksum) {
     ASSERT_EQ(cr.base.cksum, 0u) << "compress_rio should not own RDB checksum policy";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
@@ -1165,7 +1119,7 @@ TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
     ASSERT_FALSE(((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM);
 
     const char *payload = "skip-checksum-payload";
@@ -1173,7 +1127,7 @@ TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
     ASSERT_EQ(cr.base.cksum, 0u) << "compress_rio should not inspect RDB checksum flags";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
@@ -1184,7 +1138,7 @@ TEST_F(CompressionTest, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
 
     const char *payload = "codec-checksum-enabled";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
@@ -1192,7 +1146,7 @@ TEST_F(CompressionTest, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
         << "codec checksums should not control standard RDB checksum tracking";
 
     ASSERT_EQ(compressRioFinish(&cr), 0);
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
@@ -1202,14 +1156,14 @@ TEST_F(CompressionTest, compressRioFlushFailureSetsWriteError) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &inner, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &inner, &cfg), 0);
 
     const char *payload = "flush failure should latch rio write error";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
     ASSERT_EQ(rioFlush((rio *)&cr), 0);
     ASSERT_TRUE(((rio *)&cr)->flags & RIO_FLAG_WRITE_ERROR);
 
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
 }
 
 TEST_F(CompressionTest, compressRioFinishFailureSetsWriteError) {
@@ -1218,28 +1172,27 @@ TEST_F(CompressionTest, compressRioFinishFailureSetsWriteError) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &inner, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &inner, &cfg), 0);
 
     const char *payload = "finish failure should latch rio write error";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
     ASSERT_EQ(compressRioFinish(&cr), -1);
     ASSERT_TRUE(((rio *)&cr)->flags & RIO_FLAG_WRITE_ERROR);
 
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
 }
 
-TEST_F(CompressionTest, rioDecoratorsPreserveInnerType) {
+TEST_F(CompressionTest, rioDecoratorsPreserveTransportType) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &wcfg), 0);
-    /* Decorators preserve the inner backend type via the type field.
-     * Verify the decorator reports the same type as the wrapped rio. */
-    ASSERT_EQ(rioCheckType((rio *)&cr), (uint8_t)RIO_TYPE_BUFFER);
-    compressRioDestroy(&cr);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &wcfg), 0);
+    /* Decorators preserve the wrapped rio transport type. */
+    ASSERT_EQ(rioGetTransportType((rio *)&cr), (uint8_t)RIO_TYPE_BUFFER);
+    compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 
     sds raw = sdsnew("plain-rdb-prefix");
@@ -1247,9 +1200,9 @@ TEST_F(CompressionTest, rioDecoratorsPreserveInnerType) {
     rioInitWithBuffer(&raw_rio, raw);
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
     decompressRio dr;
-    ASSERT_EQ(rioInitWithDecompress(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
-    ASSERT_EQ(rioCheckType((rio *)&dr), (uint8_t)RIO_TYPE_BUFFER);
-    decompressRioDestroy(&dr);
+    ASSERT_EQ(rioInitWithDecompression(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
+    ASSERT_EQ(rioGetTransportType((rio *)&dr), (uint8_t)RIO_TYPE_BUFFER);
+    decompressRioFree(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
 }
 
@@ -1268,7 +1221,7 @@ TEST_F(CompressionTest, decompressRioRoundTrip) {
     size_t data_len = strlen(test_data);
     ASSERT_GE(streamWriterWrite(t, test_data, data_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
-    streamWriterDestroy(t);
+    streamWriterFree(t);
 
     /* Create a buffer rio with the full VKCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1285,7 +1238,7 @@ TEST_F(CompressionTest, decompressRioRoundTrip) {
     ASSERT_NE(rioRead((rio *)&dr, result, data_len), 0u) << "rioRead should succeed";
     ASSERT_EQ(memcmp(result, test_data, data_len), 0) << "decompressed data should match original";
 
-    decompressRioDestroy(&dr);
+    decompressRioFree(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
 }
@@ -1300,7 +1253,7 @@ TEST_F(CompressionTest, decompressRioTellTracksSourceProgress) {
     ASSERT_NE(t, nullptr);
     ASSERT_GE(streamWriterWrite(t, payload.data(), payload.size()), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
-    streamWriterDestroy(t);
+    streamWriterFree(t);
 
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
@@ -1315,7 +1268,7 @@ TEST_F(CompressionTest, decompressRioTellTracksSourceProgress) {
     ASSERT_LT((size_t)rioTell((rio *)&dr), sizeof(out))
         << "decompress rio tell should track source bytes, not logical output bytes";
 
-    decompressRioDestroy(&dr);
+    decompressRioFree(&dr);
     sdsfree(comp_sds);
     dynamicBufFree(&db);
 }
@@ -1331,7 +1284,7 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
         decompressRio dr;
         streamReaderInfo info;
-        ASSERT_EQ(rioInitWithDecompress(&dr, &buffer_rio, &cfg, &info), DECOMPRESS_RIO_INIT_OK);
+        ASSERT_EQ(rioInitWithDecompression(&dr, &buffer_rio, &cfg, &info), DECOMPRESS_RIO_INIT_OK);
         ASSERT_FALSE(info.compressed) << "passthrough stream should not be compressed";
 
         char result[64];
@@ -1339,7 +1292,7 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         ASSERT_NE(rioRead((rio *)&dr, result, payload_len), 0u) << "rioRead should succeed";
         ASSERT_EQ(memcmp(result, payload, payload_len), 0) << "payload should be replayed exactly";
 
-        decompressRioDestroy(&dr);
+        decompressRioFree(&dr);
         sdsfree(buf);
     }
 
@@ -1353,7 +1306,7 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
 
         streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
         decompressRio dr;
-        ASSERT_EQ(rioInitWithDecompress(&dr, &buffer_rio, &cfg, nullptr),
+        ASSERT_EQ(rioInitWithDecompression(&dr, &buffer_rio, &cfg, nullptr),
                   DECOMPRESS_RIO_INIT_INCOMPATIBLE);
 
         sdsfree(buf);
@@ -1368,7 +1321,7 @@ TEST_F(CompressionTest, compressRioFinishIdempotent) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
 
     ASSERT_NE(rioWrite((rio *)&cr, "test", 4), 0u);
     ASSERT_EQ(compressRioFinish(&cr), 0);
@@ -1379,7 +1332,7 @@ TEST_F(CompressionTest, compressRioFinishIdempotent) {
     size_t len_after_second = sdslen(buffer_rio.io.buffer.ptr);
     ASSERT_EQ(len_after_first, len_after_second) << "second finish should not produce more output";
 
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 }
 
@@ -1391,7 +1344,7 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
 
     /* Write some data */
     ASSERT_NE(rioWrite((rio *)&cr, "first chunk", 11), 0u);
@@ -1436,8 +1389,8 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
     ASSERT_EQ(memcmp(decompressed, "first chunksecond chunk", 23), 0)
         << "decompressed should match concatenated input";
 
-    streamDecompressorDestroy(&sd);
-    compressRioDestroy(&cr);
+    streamDecompressorFree(&sd);
+    compressRioFree(&cr);
     sdsfree(compressed);
 }
 
@@ -1451,14 +1404,14 @@ TEST_F(CompressionTest, rdbLoadProgressCallbackStreamingGuard) {
 
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompress(&cr, &inner, &cfg), 0);
+    ASSERT_EQ(rioInitWithCompression(&cr, &inner, &cfg), 0);
 
     const char sample[] = "progress-guard";
     rdbLoadProgressCallback((rio *)&cr, sample, sizeof(sample) - 1);
 
     ASSERT_FALSE(cr.base.flags & RIO_FLAG_READ_ERROR) << "write-side streaming rio must not set read error";
 
-    compressRioDestroy(&cr);
+    compressRioFree(&cr);
     sdsfree(inner.io.buffer.ptr);
 }
 
@@ -1486,7 +1439,7 @@ TEST_F(CompressionTest, decompressRioLargePayload) {
 
     ASSERT_GE(streamWriterWrite(t, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
-    streamWriterDestroy(t);
+    streamWriterFree(t);
 
     /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1510,7 +1463,7 @@ TEST_F(CompressionTest, decompressRioLargePayload) {
 
     ASSERT_EQ(memcmp(result, payload, payload_len), 0) << "decompressed data should match original";
 
-    decompressRioDestroy(&dr);
+    decompressRioFree(&dr);
     sdsfree(comp_sds);
     zfree(result);
     zfree(payload);
@@ -1537,7 +1490,7 @@ TEST_F(CompressionTest, decompressRioDirectPath) {
 
     ASSERT_GE(streamWriterWrite(t, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(t), 0);
-    streamWriterDestroy(t);
+    streamWriterFree(t);
 
     /* Decompress via decompress_rio with a single large read. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1552,7 +1505,7 @@ TEST_F(CompressionTest, decompressRioDirectPath) {
     ASSERT_NE(ret, 0u) << "single large rioRead should succeed";
     ASSERT_EQ(memcmp(result, payload, payload_len), 0) << "decompressed data should match original";
 
-    decompressRioDestroy(&dr);
+    decompressRioFree(&dr);
     sdsfree(comp_sds);
     zfree(result);
     zfree(payload);
@@ -1576,7 +1529,7 @@ TEST_F(CompressionTest, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     ASSERT_NE(w, nullptr);
     ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
-    streamWriterDestroy(w);
+    streamWriterFree(w);
     size_t frame_len = sdslen((const char *)db.data);
 
     sds input = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1600,7 +1553,7 @@ TEST_F(CompressionTest, streamReaderStopsAtFrameEndBeforeTrailingBytes) {
     ASSERT_EQ(streamReaderRead(r, out, sizeof(out)), 0);
     ASSERT_EQ(mr.pos, frame_len) << "streamReader must not consume bytes after the LZ4 frame";
 
-    streamReaderDestroy(r);
+    streamReaderFree(r);
     sdsfree(input);
     dynamicBufFree(&db);
 }
@@ -1620,7 +1573,7 @@ TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
     ASSERT_NE(w, nullptr);
     ASSERT_GE(streamWriterWrite(w, payload, payload_len), 0);
     ASSERT_EQ(streamWriterFinish(w), 0);
-    streamWriterDestroy(w);
+    streamWriterFree(w);
 
     ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE + 1);
     MemReader mr = {};
@@ -1638,7 +1591,7 @@ TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
     ASSERT_EQ(streamReaderGetError(r), STREAM_READER_ERROR_CORRUPT)
         << "truncated compressed frame should latch corruption, not I/O";
 
-    streamReaderDestroy(r);
+    streamReaderFree(r);
     dynamicBufFree(&db);
 }
 
@@ -1688,8 +1641,8 @@ TEST_F(CompressionTest, streamWriterWriteAfterFinish) {
     ASSERT_EQ(total, 5u);
     ASSERT_EQ(memcmp(decompressed, "hello", 5), 0) << "should decompress to 'hello' only";
 
-    streamDecompressorDestroy(&sd);
-    streamWriterDestroy(t);
+    streamDecompressorFree(&sd);
+    streamWriterFree(t);
     dynamicBufFree(&db);
 }
 
@@ -1738,12 +1691,12 @@ TEST_F(CompressionTest, independentStreamsCoexist) {
         ASSERT_EQ(memcmp(result, expected, strlen(expected)), 0) << "first half should match";
         ASSERT_EQ(memcmp(result + strlen(expected), expected, strlen(expected)), 0) << "second half should match";
 
-        decompressRioDestroy(&dr);
+        decompressRioFree(&dr);
         sdsfree(comp);
     }
 
-    streamWriterDestroy(t1);
-    streamWriterDestroy(t2);
+    streamWriterFree(t1);
+    streamWriterFree(t2);
     dynamicBufFree(&db1);
     dynamicBufFree(&db2);
 }
@@ -1785,9 +1738,9 @@ TEST_F(CompressionTest, streamWriterRepetitivePayloadRoundTrip) {
         ASSERT_EQ(result[i], 'X');
     }
 
-    decompressRioDestroy(&dr);
+    decompressRioFree(&dr);
     sdsfree(comp);
     zfree(result);
-    streamWriterDestroy(t);
+    streamWriterFree(t);
     dynamicBufFree(&db);
 }

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -50,7 +50,7 @@ typedef struct {
 
 static streamReaderConfig makeReaderConfig(uint8_t expected_stream_kind,
                                            bool allow_passthrough,
-                                           size_t buffer_size) {
+                                           size_t buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT) {
     streamReaderConfig cfg = {};
     cfg.expected_stream_kind = expected_stream_kind;
     cfg.allow_passthrough = allow_passthrough;
@@ -417,7 +417,7 @@ TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
         mr.data = cases[i].input;
         mr.len = cases[i].input_len;
         mr.max_chunk = cases[i].max_chunk;
-        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough, 0);
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, cases[i].allow_passthrough);
         streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
         ASSERT_NE(t, nullptr) << cases[i].name;
 
@@ -451,7 +451,7 @@ TEST_F(CompressionTest, streamReaderRejectsOversizedReadRequest) {
     mr.data = input;
     mr.len = sizeof(input);
     mr.max_chunk = 2;
-    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true);
 
     streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
     ASSERT_NE(t, nullptr) << "streamReaderCreate should succeed";
@@ -501,7 +501,7 @@ static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
 }
 
 static int initVkcsRdbDecompressRio(decompressRio *dr, rio *inner) {
-    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false);
     return rioInitWithDecompression(dr, inner, &cfg, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
 
@@ -527,21 +527,21 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
          0x7f,
          0x7f,
          0,
-         0,
+         STREAM_READER_BUFFER_SIZE_DEFAULT,
          true},
         {"custom stream when RDB expected",
          "stream-kind mismatch",
          0x7f,
          STREAM_KIND_RDB,
          0,
-         0,
+         STREAM_READER_BUFFER_SIZE_DEFAULT,
          false},
         {"RDB stream when custom expected",
          "stream-kind mismatch",
          STREAM_KIND_RDB,
          0x7f,
          0,
-         0,
+         STREAM_READER_BUFFER_SIZE_DEFAULT,
          false},
     };
 
@@ -647,7 +647,7 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
     fr_passthrough.len = sizeof(plain) - 1;
     fr_passthrough.max_chunk = 0;
     fr_passthrough.fail_after_success_reads = 1; /* probe succeeds, next read fails */
-    streamReaderConfig pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReaderConfig pass_cfg = makeReaderConfig(STREAM_KIND_RDB, true);
     streamReader *rp = streamReaderCreate(&pass_cfg, flakyReaderRead, &fr_passthrough);
     ASSERT_NE(rp, nullptr) << "passthrough reader create should succeed";
 
@@ -961,7 +961,7 @@ TEST_F(CompressionTest, streamReaderValidateEndAcceptsClosedFrame) {
     ASSERT_EQ(streamWriterFinish(w), 0);
 
     MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 7};
-    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false);
     streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
     ASSERT_NE(reader, nullptr);
 
@@ -988,7 +988,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsTrailingBytes) {
     db.data = (uint8_t *)sdscatlen((sds)db.data, "x", 1);
 
     MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
-    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false);
     streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
     ASSERT_NE(reader, nullptr);
 
@@ -1015,7 +1015,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsUnreadDecodedBytes) {
     ASSERT_EQ(streamWriterFinish(w), 0);
 
     MemReader reader_ctx = {db.data, sdslen((const char *)db.data), 0, 0};
-    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false, 0);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, false);
     streamReader *reader = streamReaderCreate(&rcfg, memReaderRead, &reader_ctx);
     ASSERT_NE(reader, nullptr);
 
@@ -1198,7 +1198,7 @@ TEST_F(CompressionTest, rioDecoratorsPreserveTransportType) {
     sds raw = sdsnew("plain-rdb-prefix");
     rio raw_rio;
     rioInitWithBuffer(&raw_rio, raw);
-    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true);
     decompressRio dr;
     ASSERT_EQ(rioInitWithDecompression(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
     ASSERT_EQ(rioGetTransportType((rio *)&dr), (uint8_t)RIO_TYPE_BUFFER);
@@ -1281,7 +1281,7 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true);
         decompressRio dr;
         streamReaderInfo info;
         ASSERT_EQ(rioInitWithDecompression(&dr, &buffer_rio, &cfg, &info), DECOMPRESS_RIO_INIT_OK);
@@ -1304,7 +1304,7 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true, 0);
+        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true);
         decompressRio dr;
         ASSERT_EQ(rioInitWithDecompression(&dr, &buffer_rio, &cfg, nullptr),
                   DECOMPRESS_RIO_INIT_INCOMPATIBLE);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -472,6 +472,15 @@ TEST_F(CompressionTest, streamReaderRejectsOversizedReadRequest) {
     streamReaderFree(t);
 }
 
+TEST_F(CompressionTest, streamReaderRejectsZeroBufferSize) {
+    MemReader mr = {};
+    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true);
+    cfg.buffer_size = 0;
+
+    streamReader *t = streamReaderCreate(&cfg, memReaderRead, &mr);
+    ASSERT_EQ(t, nullptr) << "zero buffer size is a caller configuration error";
+}
+
 /* ===================================================================
  * Tests for stream writer API and rio decorators
  * =================================================================== */

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -860,7 +860,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         goto err;
     }
 
-    rdbInputStreamDestroy(&input);
+    rdbInputStreamFree(&input);
     rdbstate.rio = &file_rdb;
     if (closefile) fclose(fp);
     stopLoading(1);
@@ -875,7 +875,7 @@ eoferr: /* unexpected end of file is handled here with a fatal exit */
         rdbCheckError("Unexpected EOF reading RDB file");
     }
 err:
-    rdbInputStreamDestroy(&input);
+    rdbInputStreamFree(&input);
     rdbstate.rio = &file_rdb;
     if (closefile) fclose(fp);
     stopLoading(0);

--- a/valkey.conf
+++ b/valkey.conf
@@ -602,11 +602,11 @@ rdbcompression yes
 #
 # RDB files written with lz4 can be loaded only by Valkey versions that
 # support streaming RDB compression. The logical RDB payload keeps its normal
-# RDB version; the outer VKCS stream envelope carries the streaming compression
+# RDB version; an outer streaming compression envelope carries the compression
 # format version. Older versions do not understand that envelope and will fail
-# before reading the payload, usually with a "Wrong signature" load error. Before
-# downgrading or introducing an older replica, rewrite the snapshot in the
-# legacy format:
+# before reading the payload, usually with a "Wrong signature" load error.
+# Before downgrading or introducing an older replica, rewrite the snapshot in
+# the legacy format:
 #   CONFIG SET rdb-compression-algo lzf
 #   SAVE
 rdb-compression-algo lzf


### PR DESCRIPTION
## Summary

- remove internal VKCS naming from user-facing RDB compression docs
- clarify stream decompression buffer and input-consumption contracts
- tighten naming around codec implementation and stream writer emit functions
- make stream kind an enum and document why it is part of the envelope
- fold the streaming-compression save log into the existing RDB save notice
- remove unrelated config parse-depth and static-archive cleanup changes from this PR
- rename streaming compression cleanup APIs from Destroy to Free
- make rio compression init/read names and transport-type metadata clearer
- make caller-contract violations assert in the codec dispatch layer while preserving runtime errors for corrupt input and codec failures
- remove the reader buffer-size sentinel by passing the default explicitly at the RDB call site, rejecting zero-sized configs, and clamping only tiny nonzero values
- add rioIsConnTransport() so RDB progress accounting does not inspect rio transport internals directly
- document compressRioEmit() as the sink-contract adapter that keeps streamWriter reusable outside rio