### PR TITLE
CI: don't run apt-get upgrade in clang-format job

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Set up Clang
         run: |
           sudo apt-get update -y
-          sudo apt-get upgrade -y
           sudo apt-get install software-properties-common -y
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/llvm-toolchain.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/llvm-toolchain.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
The clang-format job only needs clang-format-18, but apt-get upgrade -y upgrades every pre-installed package on the runner (firefox and others), adding minutes to the job for no benefit. Dropping it. Opened in the fork to verify the job still installs clang-format and passes.