### PR TITLE
compression: align stream codec API naming

### DIFF
--- a/src/compression.c
+++ b/src/compression.c
@@ -108,29 +108,29 @@ void streamDecompressorFree(streamDecompressor *decompressor) {
     impl->decompressor_free(decompressor);
 }
 
-size_t streamCompressOutputBound(streamCompressor *compressor, size_t input_len) {
+size_t streamCompressorOutputBound(streamCompressor *compressor, size_t input_len) {
     const compressionCodec *impl = compressionCodecForAlgo(compressor->algo);
     assert(impl != NULL);
     return impl->compress_output_bound(input_len);
 }
 
-ssize_t streamCompressFeed(streamCompressor *compressor,
-                           uint8_t *output,
-                           size_t output_capacity,
-                           const uint8_t *input,
-                           size_t input_len,
-                           compressFlushMode flush_mode) {
+ssize_t streamCompressorFeed(streamCompressor *compressor,
+                             uint8_t *output,
+                             size_t output_capacity,
+                             const uint8_t *input,
+                             size_t input_len,
+                             compressFlushMode flush_mode) {
     const compressionCodec *impl = compressionCodecForAlgo(compressor->algo);
     assert(impl != NULL);
     return impl->compress_feed(compressor, output, output_capacity, input, input_len, flush_mode);
 }
 
-ssize_t streamDecompressFeed(streamDecompressor *decompressor,
-                             uint8_t *output,
-                             size_t output_capacity,
-                             const uint8_t *input,
-                             size_t input_len,
-                             size_t *input_consumed) {
+ssize_t streamDecompressorFeed(streamDecompressor *decompressor,
+                               uint8_t *output,
+                               size_t output_capacity,
+                               const uint8_t *input,
+                               size_t input_len,
+                               size_t *input_consumed) {
     *input_consumed = 0;
     if (decompressor->errored) return -1;
     if (decompressor->frame_done) return 0;

--- a/src/compression.h
+++ b/src/compression.h
@@ -52,25 +52,25 @@ void streamDecompressorFree(streamDecompressor *decompressor);
 
 /* Conservative bound covering header + data + flush/end overhead, so the
  * caller can size one scratch buffer for all flush modes. */
-size_t streamCompressOutputBound(streamCompressor *compressor, size_t input_len);
+size_t streamCompressorOutputBound(streamCompressor *compressor, size_t input_len);
 
 /* Returns bytes written, or -1 on error. */
-ssize_t streamCompressFeed(streamCompressor *compressor,
-                           uint8_t *output,
-                           size_t output_capacity,
-                           const uint8_t *input,
-                           size_t input_len,
-                           compressFlushMode flush_mode);
+ssize_t streamCompressorFeed(streamCompressor *compressor,
+                             uint8_t *output,
+                             size_t output_capacity,
+                             const uint8_t *input,
+                             size_t input_len,
+                             compressFlushMode flush_mode);
 
 /* Returns decompressed bytes written, or -1 on error. *input_consumed is set to
  * the number of compressed input bytes consumed. If it is less than input_len,
  * the caller must keep the unconsumed suffix and pass it again with more output
  * space. */
-ssize_t streamDecompressFeed(streamDecompressor *decompressor,
-                             uint8_t *output,
-                             size_t output_capacity,
-                             const uint8_t *input,
-                             size_t input_len,
-                             size_t *input_consumed);
+ssize_t streamDecompressorFeed(streamDecompressor *decompressor,
+                               uint8_t *output,
+                               size_t output_capacity,
+                               const uint8_t *input,
+                               size_t input_len,
+                               size_t *input_consumed);
 
 #endif /* COMPRESSION_H */

--- a/src/compression_lz4.c
+++ b/src/compression_lz4.c
@@ -6,8 +6,33 @@
 
 #include "compression_lz4.h"
 #include "serverassert.h"
+#include "zmalloc.h"
 #include <limits.h>
+
+#define LZ4F_STATIC_LINKING_ONLY
 #include <lz4frame.h>
+
+static void *lz4Zmalloc(void *opaque, size_t size) {
+    (void)opaque;
+    return zmalloc(size);
+}
+
+static void *lz4Zcalloc(void *opaque, size_t size) {
+    (void)opaque;
+    return zcalloc(size);
+}
+
+static void lz4Zfree(void *opaque, void *address) {
+    (void)opaque;
+    zfree(address);
+}
+
+static const LZ4F_CustomMem lz4f_mem = {
+    .customAlloc = lz4Zmalloc,
+    .customCalloc = lz4Zcalloc,
+    .customFree = lz4Zfree,
+    .opaqueState = NULL,
+};
 
 /* Shared bound-calc preferences. The actual compress level and checksum mode
  * are overridden per stream before LZ4F_compressBegin. */
@@ -22,9 +47,8 @@ static const LZ4F_preferences_t lz4f_prefs = {
 };
 
 int compressionLz4CompressorInit(streamCompressor *compressor) {
-    LZ4F_cctx *cctx = NULL;
-    if (LZ4F_isError(LZ4F_createCompressionContext(&cctx, LZ4F_VERSION))) return -1;
-    compressor->ctx = cctx;
+    compressor->ctx = LZ4F_createCompressionContext_advanced(lz4f_mem, LZ4F_VERSION);
+    assert(compressor->ctx != NULL);
     return 0;
 }
 
@@ -36,9 +60,8 @@ void compressionLz4CompressorFree(streamCompressor *compressor) {
 }
 
 int compressionLz4DecompressorInit(streamDecompressor *decompressor) {
-    LZ4F_dctx *dctx = NULL;
-    if (LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION))) return -1;
-    decompressor->ctx = dctx;
+    decompressor->ctx = LZ4F_createDecompressionContext_advanced(lz4f_mem, LZ4F_VERSION);
+    assert(decompressor->ctx != NULL);
     decompressor->input_hint = LZ4F_HEADER_SIZE_MIN;
     return 0;
 }

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -32,8 +32,7 @@ static void rioInitBase(rio *base,
                         size_t (*write_fn)(rio *, const void *, size_t),
                         off_t (*tell_fn)(rio *),
                         int (*flush_fn)(rio *),
-                        uint64_t flags,
-                        uint8_t transport_type) {
+                        uint64_t flags) {
     base->read = read_fn;
     base->write = write_fn;
     base->tell = tell_fn;
@@ -44,7 +43,6 @@ static void rioInitBase(rio *base,
     base->flags = flags;
     base->processed_bytes = 0;
     base->max_processing_chunk = 0;
-    base->transport_type = transport_type;
 }
 
 /* ===== compressRio ===== */
@@ -98,7 +96,8 @@ static int compressRioFlush(rio *r) {
 int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg) {
     memset(cr, 0, sizeof(*cr));
     rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
-                compressRioFlush, RIO_FLAG_STREAMING_COMPRESSION, rioGetTransportType(inner));
+                compressRioFlush,
+                RIO_FLAG_STREAMING_COMPRESSION | (inner->flags & RIO_FLAG_CONN_BACKED));
 
     cr->inner = inner;
     return streamWriterInit(&cr->writer, cfg, compressRioEmit, cr);
@@ -184,8 +183,8 @@ decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
     memset(dr, 0, sizeof(*dr));
     rioInitBase(&dr->base, decompressRioRead, rioWriteUnsupported, decompressRioTell,
                 rioFlushNoop,
-                RIO_FLAG_STREAMING_DECOMPRESSION | (inner->flags & RIO_FLAG_SKIP_RDB_CHECKSUM),
-                rioGetTransportType(inner));
+                RIO_FLAG_STREAMING_DECOMPRESSION |
+                    (inner->flags & (RIO_FLAG_SKIP_RDB_CHECKSUM | RIO_FLAG_CONN_BACKED)));
     dr->inner = inner;
 
     if (streamReaderInit(&dr->reader, cfg, decompressRioReadPartial, dr) != 0) return DECOMPRESS_RIO_INIT_ERROR;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -77,7 +77,7 @@ static off_t compressRioTell(rio *r) {
  * that flush mid-stream don't accidentally close it. */
 static int compressRioFlush(rio *r) {
     compressRio *cr = (compressRio *)r;
-    if (streamWriterHasError(&cr->writer)) {
+    if (cr->writer.errored) {
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
@@ -88,7 +88,7 @@ static int compressRioFlush(rio *r) {
         return 0;
     }
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        streamWriterSetError(&cr->writer);
+        cr->writer.errored = true;
         r->flags |= RIO_FLAG_WRITE_ERROR;
         return 0;
     }
@@ -107,7 +107,7 @@ int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg)
 /* Idempotent: subsequent calls report cached error state. */
 int compressRioFinish(compressRio *cr) {
     if (cr->finalized) {
-        if (streamWriterHasError(&cr->writer)) {
+        if (cr->writer.errored) {
             cr->base.flags |= RIO_FLAG_WRITE_ERROR;
             return -1;
         }
@@ -120,10 +120,10 @@ int compressRioFinish(compressRio *cr) {
         return -1;
     }
     if (cr->inner->flush && cr->inner->flush(cr->inner) == 0) {
-        streamWriterSetError(&cr->writer);
+        cr->writer.errored = true;
         cr->base.flags |= RIO_FLAG_WRITE_ERROR;
     }
-    if (streamWriterHasError(&cr->writer)) {
+    if (cr->writer.errored) {
         cr->base.flags |= RIO_FLAG_WRITE_ERROR;
         return -1;
     }
@@ -168,7 +168,7 @@ static off_t decompressRioTell(rio *r) {
 }
 
 streamReaderError decompressRioGetError(decompressRio *dr) {
-    return streamReaderGetError(&dr->reader);
+    return dr->reader.error_kind;
 }
 
 int decompressRioValidateEnd(decompressRio *dr) {
@@ -190,7 +190,7 @@ decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
 
     if (streamReaderInit(&dr->reader, cfg, decompressRioReadPartial, dr) != 0) return DECOMPRESS_RIO_INIT_ERROR;
     if (streamReaderGetInfo(&dr->reader, &local_info) != 0) {
-        streamReaderError error_kind = streamReaderGetError(&dr->reader);
+        streamReaderError error_kind = dr->reader.error_kind;
         decompressRioFree(dr);
         return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
                    ? DECOMPRESS_RIO_INIT_INCOMPATIBLE

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -235,7 +235,7 @@ static int streamWriterEmit(streamWriter *writer, const uint8_t *buf, size_t len
 }
 
 static int streamWriterEnsureOutBuf(streamWriter *writer, size_t input_len) {
-    size_t needed = streamCompressOutputBound(&writer->compressor, input_len);
+    size_t needed = streamCompressorOutputBound(&writer->compressor, input_len);
     if (needed == 0) {
         writer->errored = true;
         return -1;
@@ -253,9 +253,9 @@ static int streamWriterFeedAndEmit(streamWriter *writer,
                                    compressFlushMode flush_mode) {
     if (streamWriterEnsureOutBuf(writer, input_len) != 0) return -1;
 
-    ssize_t compressed = streamCompressFeed(&writer->compressor, writer->out_buf,
-                                            writer->out_buf_size,
-                                            input, input_len, flush_mode);
+    ssize_t compressed = streamCompressorFeed(&writer->compressor, writer->out_buf,
+                                              writer->out_buf_size,
+                                              input, input_len, flush_mode);
     if (compressed < 0) {
         writer->errored = true;
         return -1;
@@ -315,14 +315,6 @@ int streamWriterFinish(streamWriter *writer) {
      * loader sees a well-formed file. */
     if (streamWriterEnsureEnvelope(writer) != 0) return -1;
     return streamWriterFeedAndEmit(writer, NULL, 0, FLUSH_END);
-}
-
-int streamWriterHasError(streamWriter *writer) {
-    return writer->errored;
-}
-
-void streamWriterSetError(streamWriter *writer) {
-    writer->errored = true;
 }
 
 /* ===== Streaming reader ===== */
@@ -467,7 +459,7 @@ static int streamReaderDrainCompressedBuf(streamReader *reader,
         size_t feed_len = reader->compressed_buf_len;
         size_t input_hint = reader->decompressor.input_hint;
         if (input_hint > 0 && feed_len > input_hint) feed_len = input_hint;
-        ssize_t produced = streamDecompressFeed(
+        ssize_t produced = streamDecompressorFeed(
             &reader->decompressor,
             out + *out_written, out_size - *out_written,
             reader->compressed_buf + reader->compressed_buf_pos,
@@ -625,10 +617,6 @@ int streamReaderGetInfo(streamReader *reader, streamReaderInfo *info) {
     info->algo = reader->probe.compressed ? reader->probe.algo : ALGO_NONE;
     info->stream_kind = reader->probe.stream_kind;
     return 0;
-}
-
-streamReaderError streamReaderGetError(streamReader *reader) {
-    return reader->error_kind;
 }
 
 int streamReaderValidateEnd(streamReader *reader) {

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -136,8 +136,6 @@ ssize_t streamWriterWrite(streamWriter *writer, const void *buf, size_t len);
 int streamWriterFlush(streamWriter *writer);
 int streamWriterFinish(streamWriter *writer);
 void streamWriterFree(streamWriter *writer);
-int streamWriterHasError(streamWriter *writer);
-void streamWriterSetError(streamWriter *writer);
 int streamReadEnvelopeInfo(const uint8_t *buf,
                            size_t len,
                            uint8_t expected_stream_kind,
@@ -152,7 +150,6 @@ int streamReaderProbe(streamReader *reader);
 /* Full or fail: returns len on success, 0 on EOF, -1 on error. */
 ssize_t streamReaderRead(streamReader *reader, void *buf, size_t len);
 int streamReaderGetInfo(streamReader *reader, streamReaderInfo *info);
-streamReaderError streamReaderGetError(streamReader *reader);
 int streamReaderValidateEnd(streamReader *reader);
 void streamReaderFree(streamReader *reader);
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3132,7 +3132,7 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
         processEventsWhileBlocked();
         processModuleLoadingProgressEvent(0);
     }
-    if (server.repl_state == REPL_STATE_TRANSFER && rioIsConnTransport(r)) {
+    if (server.repl_state == REPL_STATE_TRANSFER && rioIsConnBacked(r)) {
         server.stat_net_repl_input_bytes += len;
     }
 }

--- a/src/rio.c
+++ b/src/rio.c
@@ -109,7 +109,6 @@ static const rio rioBufferIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .transport_type = RIO_TYPE_BUFFER,
     .io = {{NULL, 0}},
 };
 
@@ -213,7 +212,6 @@ static const rio rioFileIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .transport_type = RIO_TYPE_FILE,
     .io = {{NULL, 0}},
 };
 
@@ -343,10 +341,9 @@ static const rio rioConnIO = {
     .read_some = rioConnReadSome,
     .update_cksum = NULL,
     .cksum = 0,
-    .flags = 0,
+    .flags = RIO_FLAG_CONN_BACKED,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .transport_type = RIO_TYPE_CONN,
     .io = {{NULL, 0}},
 };
 
@@ -464,7 +461,6 @@ static const rio rioFdIO = {
     .flags = 0,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .transport_type = RIO_TYPE_FD,
     .io = {{NULL, 0}},
 };
 
@@ -539,13 +535,8 @@ void rioSetReclaimCache(rio *r, int enabled) {
     r->io.file.reclaim_cache = enabled;
 }
 
-/* Return the underlying transport type of the rio. */
-uint8_t rioGetTransportType(rio *r) {
-    return r->transport_type;
-}
-
-int rioIsConnTransport(rio *r) {
-    return r->transport_type == RIO_TYPE_CONN;
+int rioIsConnBacked(rio *r) {
+    return (r->flags & RIO_FLAG_CONN_BACKED) != 0;
 }
 
 /* --------------------------- Higher level interface --------------------------
@@ -694,10 +685,9 @@ static const rio rioConnsetIO = {
     .read_some = NULL,
     .update_cksum = NULL,
     .cksum = 0,
-    .flags = 0,
+    .flags = RIO_FLAG_CONN_BACKED,
     .processed_bytes = 0,
     .max_processing_chunk = 0,
-    .transport_type = RIO_TYPE_CONN,
     .io = {{NULL, 0}},
 };
 

--- a/src/rio.h
+++ b/src/rio.h
@@ -44,11 +44,7 @@
 #define RIO_FLAG_SKIP_RDB_CHECKSUM (1 << 3)
 #define RIO_FLAG_STREAMING_COMPRESSION (1 << 4)   /* Streaming compression active, skip per-string LZF */
 #define RIO_FLAG_STREAMING_DECOMPRESSION (1 << 5) /* rio is a stream decompression adapter */
-
-#define RIO_TYPE_FILE (1 << 0)
-#define RIO_TYPE_BUFFER (1 << 1)
-#define RIO_TYPE_CONN (1 << 2)
-#define RIO_TYPE_FD (1 << 3)
+#define RIO_FLAG_CONN_BACKED (1 << 6)             /* rio reads from or writes to connection-backed transport. */
 
 struct _rio {
     /* Backend functions.
@@ -78,9 +74,6 @@ struct _rio {
 
     /* maximum single read or write chunk size */
     size_t max_processing_chunk;
-
-    /* Transport type (RIO_TYPE_*). Rio decorators preserve the wrapped transport. */
-    uint8_t transport_type;
 
     /* Backend-specific vars. */
     union {
@@ -214,8 +207,7 @@ void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len);
 ssize_t rioReadPartial(rio *r, void *buf, size_t len);
 void rioSetAutoSync(rio *r, off_t bytes);
 void rioSetReclaimCache(rio *r, int enabled);
-uint8_t rioGetTransportType(rio *r);
-int rioIsConnTransport(rio *r);
+int rioIsConnBacked(rio *r);
 void rioInitWithConnset(rio *r, connection **conns, int numconns);
 void rioFreeConnset(rio *r);
 #endif

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -166,7 +166,6 @@ static void initFailingFlushRio(rio *r) {
     r->write = discardRioWrite;
     r->tell = discardRioTell;
     r->flush = failRioFlush;
-    r->transport_type = RIO_TYPE_BUFFER;
 }
 
 /* ===================================================================
@@ -1160,7 +1159,7 @@ TEST_F(CompressionTest, compressRioFinishFailureSetsWriteError) {
     compressRioFree(&cr);
 }
 
-TEST_F(CompressionTest, rioDecoratorsPreserveTransportType) {
+TEST_F(CompressionTest, rioDecoratorsPreserveConnBackedFlag) {
     sds buf = sdsempty();
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
@@ -1168,8 +1167,7 @@ TEST_F(CompressionTest, rioDecoratorsPreserveTransportType) {
     streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
     ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &wcfg), 0);
-    /* Decorators preserve the wrapped rio transport type. */
-    ASSERT_EQ(rioGetTransportType((rio *)&cr), (uint8_t)RIO_TYPE_BUFFER);
+    ASSERT_FALSE(rioIsConnBacked((rio *)&cr));
     compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
 
@@ -1179,9 +1177,29 @@ TEST_F(CompressionTest, rioDecoratorsPreserveTransportType) {
     streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true);
     decompressRio dr;
     ASSERT_EQ(rioInitWithDecompression(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
-    ASSERT_EQ(rioGetTransportType((rio *)&dr), (uint8_t)RIO_TYPE_BUFFER);
+    ASSERT_FALSE(rioIsConnBacked((rio *)&dr));
     decompressRioFree(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
+
+    sds conn_backed_buf = sdsempty();
+    rio conn_backed_rio;
+    rioInitWithBuffer(&conn_backed_rio, conn_backed_buf);
+    conn_backed_rio.flags |= RIO_FLAG_CONN_BACKED;
+
+    ASSERT_EQ(rioInitWithCompression(&cr, &conn_backed_rio, &wcfg), 0);
+    ASSERT_TRUE(rioIsConnBacked((rio *)&cr));
+    compressRioFree(&cr);
+
+    sds conn_backed_raw = sdsnew("plain-rdb-prefix");
+    rio conn_backed_raw_rio;
+    rioInitWithBuffer(&conn_backed_raw_rio, conn_backed_raw);
+    conn_backed_raw_rio.flags |= RIO_FLAG_CONN_BACKED;
+    ASSERT_EQ(rioInitWithDecompression(&dr, &conn_backed_raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
+    ASSERT_TRUE(rioIsConnBacked((rio *)&dr));
+    decompressRioFree(&dr);
+
+    sdsfree(conn_backed_rio.io.buffer.ptr);
+    sdsfree(conn_backed_raw_rio.io.buffer.ptr);
 }
 
 /* --- Test: decompressRio read round-trip --- */

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -199,7 +199,7 @@ TEST_F(CompressionTest, streamDecompressorInitFree) {
 }
 
 /* --- Test: LZ4 compress → decompress round-trip --- */
-TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
+TEST_F(CompressionTest, streamCompressorDecompressorRoundTrip) {
     const char *input = "Hello, Valkey compression module! This is a test payload.";
     size_t input_len = strlen(input);
 
@@ -207,14 +207,14 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
     streamCompressor sc;
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
-    size_t bound = streamCompressOutputBound(&sc, input_len);
+    size_t bound = streamCompressorOutputBound(&sc, input_len);
     ASSERT_GT(bound, 0u) << "bound should be > 0";
 
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
     ASSERT_NE(compressed, nullptr);
-    ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
-                                                (const uint8_t *)input, input_len,
-                                                FLUSH_END);
+    ssize_t compressed_len = streamCompressorFeed(&sc, compressed, bound,
+                                                  (const uint8_t *)input, input_len,
+                                                  FLUSH_END);
     ASSERT_GT(compressed_len, 0) << "compress should succeed";
     ASSERT_EQ(sc.stream_started, false) << "frame should be closed after FLUSH_END";
     streamCompressorFree(&sc);
@@ -225,9 +225,9 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
 
     uint8_t decompressed[256];
     size_t input_consumed = 0;
-    ssize_t decompressed_len = streamDecompressFeed(&sd, decompressed, sizeof(decompressed),
-                                                    compressed, (size_t)compressed_len,
-                                                    &input_consumed);
+    ssize_t decompressed_len = streamDecompressorFeed(&sd, decompressed, sizeof(decompressed),
+                                                      compressed, (size_t)compressed_len,
+                                                      &input_consumed);
     ASSERT_GT(decompressed_len, 0) << "decompress should succeed";
     ASSERT_EQ((size_t)decompressed_len, input_len) << "decompressed length should match input";
     ASSERT_EQ(memcmp(decompressed, input, input_len), 0) << "decompressed content should match input";
@@ -237,29 +237,29 @@ TEST_F(CompressionTest, streamCompressDecompressRoundTrip) {
     zfree(compressed);
 }
 
-/* --- Test: streamCompressOutputBound returns sane values --- */
-TEST_F(CompressionTest, streamCompressOutputBound) {
+/* --- Test: streamCompressorOutputBound returns sane values --- */
+TEST_F(CompressionTest, streamCompressorOutputBound) {
     streamCompressor sc;
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
     /* Basic: bound for 1KB input should be > 0 */
-    size_t b1 = streamCompressOutputBound(&sc, 1024);
+    size_t b1 = streamCompressorOutputBound(&sc, 1024);
     ASSERT_GT(b1, 0u) << "bound for 1KB should be > 0";
 
     /* Bound is always conservative (includes frame header + flush overhead),
      * so it should be stable regardless of frame state. */
-    size_t b_before = streamCompressOutputBound(&sc, 1024);
+    size_t b_before = streamCompressorOutputBound(&sc, 1024);
     uint8_t *seed_buf = (uint8_t *)zmalloc(b_before);
     ASSERT_NE(seed_buf, nullptr);
-    ASSERT_GE(streamCompressFeed(&sc, seed_buf, b_before,
-                                 (const uint8_t *)"x", 1, FLUSH_CONTINUE),
+    ASSERT_GE(streamCompressorFeed(&sc, seed_buf, b_before,
+                                   (const uint8_t *)"x", 1, FLUSH_CONTINUE),
               0)
         << "seed write should start the frame";
-    size_t b_after = streamCompressOutputBound(&sc, 1024);
+    size_t b_after = streamCompressorOutputBound(&sc, 1024);
     ASSERT_EQ(b_before, b_after) << "bound should be the same before and after frame start";
 
     /* Zero input should still return > 0 (frame header + flush overhead) */
-    size_t b_zero = streamCompressOutputBound(&sc, 0);
+    size_t b_zero = streamCompressorOutputBound(&sc, 0);
     ASSERT_GT(b_zero, 0u) << "zero input bound should be > 0";
 
     zfree(seed_buf);
@@ -267,7 +267,7 @@ TEST_F(CompressionTest, streamCompressOutputBound) {
 }
 
 /* --- Test: corrupt compressed input is a sticky decompressor error. --- */
-TEST_F(CompressionTest, streamDecompressFeedCorruptInputSetsStickyError) {
+TEST_F(CompressionTest, streamDecompressorFeedCorruptInputSetsStickyError) {
     const char *payload = "decompress sticky error";
     uint8_t buf[64];
     uint8_t out[128];
@@ -275,26 +275,26 @@ TEST_F(CompressionTest, streamDecompressFeedCorruptInputSetsStickyError) {
 
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
-    ASSERT_EQ(streamDecompressFeed(&sd, buf, sizeof(buf),
-                                   (const uint8_t *)"not an lz4 frame", 16, &consumed),
+    ASSERT_EQ(streamDecompressorFeed(&sd, buf, sizeof(buf),
+                                     (const uint8_t *)"not an lz4 frame", 16, &consumed),
               -1);
     ASSERT_EQ(sd.errored, true) << "corrupt input should enter sticky errored state";
 
     /* Once errored, all subsequent feeds fail immediately. */
     streamCompressor sc;
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
-    size_t bound = streamCompressOutputBound(&sc, strlen(payload));
+    size_t bound = streamCompressorOutputBound(&sc, strlen(payload));
     uint8_t *compressed = (uint8_t *)zmalloc(bound);
     ASSERT_NE(compressed, nullptr);
-    ssize_t compressed_len = streamCompressFeed(&sc, compressed, bound,
-                                                (const uint8_t *)payload, strlen(payload),
-                                                FLUSH_END);
+    ssize_t compressed_len = streamCompressorFeed(&sc, compressed, bound,
+                                                  (const uint8_t *)payload, strlen(payload),
+                                                  FLUSH_END);
     ASSERT_GT(compressed_len, 0);
     streamCompressorFree(&sc);
 
-    ASSERT_EQ(streamDecompressFeed(&sd, out, sizeof(out),
-                                   compressed, (size_t)compressed_len,
-                                   &consumed),
+    ASSERT_EQ(streamDecompressorFeed(&sd, out, sizeof(out),
+                                     compressed, (size_t)compressed_len,
+                                     &consumed),
               -1)
         << "errored decompressor should fail even with valid input";
     zfree(compressed);
@@ -303,23 +303,23 @@ TEST_F(CompressionTest, streamDecompressFeedCorruptInputSetsStickyError) {
 }
 
 /* --- Test: pre-frame errors are recoverable, mid-frame errors are permanent --- */
-TEST_F(CompressionTest, streamCompressFeedErrorRecovery) {
+TEST_F(CompressionTest, streamCompressorFeedErrorRecovery) {
     streamCompressor sc;
     ASSERT_EQ(streamCompressorInit(&sc, ALGO_LZ4, 0), 0);
 
     /* Pre-frame error: compressBegin fails with tiny buffer, but no frame
      * bytes have been emitted yet — this is recoverable. */
     uint8_t tiny[1];
-    ssize_t ret = streamCompressFeed(&sc, tiny, 1,
-                                     (const uint8_t *)"test data", 9, FLUSH_END);
+    ssize_t ret = streamCompressorFeed(&sc, tiny, 1,
+                                       (const uint8_t *)"test data", 9, FLUSH_END);
     ASSERT_EQ(ret, -1) << "should fail with tiny buffer";
     ASSERT_EQ(sc.stream_started, false) << "stream_started should still be false";
 
     /* Retry with a proper buffer — should succeed */
-    size_t bound = streamCompressOutputBound(&sc, 9);
+    size_t bound = streamCompressorOutputBound(&sc, 9);
     uint8_t *buf = (uint8_t *)zmalloc(bound);
-    ssize_t ret2 = streamCompressFeed(&sc, buf, bound,
-                                      (const uint8_t *)"test data", 9, FLUSH_END);
+    ssize_t ret2 = streamCompressorFeed(&sc, buf, bound,
+                                        (const uint8_t *)"test data", 9, FLUSH_END);
     ASSERT_GT(ret2, 0) << "retry after pre-frame error should succeed";
     zfree(buf);
     streamCompressorFree(&sc);
@@ -328,17 +328,17 @@ TEST_F(CompressionTest, streamCompressFeedErrorRecovery) {
     streamCompressor sc2;
     ASSERT_EQ(streamCompressorInit(&sc2, ALGO_LZ4, 0), 0);
 
-    size_t bound2 = streamCompressOutputBound(&sc2, 5);
+    size_t bound2 = streamCompressorOutputBound(&sc2, 5);
     uint8_t *buf2 = (uint8_t *)zmalloc(bound2);
-    ssize_t ret3 = streamCompressFeed(&sc2, buf2, bound2,
-                                      (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
+    ssize_t ret3 = streamCompressorFeed(&sc2, buf2, bound2,
+                                        (const uint8_t *)"hello", 5, FLUSH_CONTINUE);
     ASSERT_GE(ret3, 0) << "first write should succeed";
     ASSERT_EQ(sc2.stream_started, true) << "stream should be started";
 
     uint8_t tiny2[1];
-    ssize_t ret4 = streamCompressFeed(&sc2, tiny2, 1,
-                                      (const uint8_t *)"more data to compress", 21,
-                                      FLUSH_END);
+    ssize_t ret4 = streamCompressorFeed(&sc2, tiny2, 1,
+                                        (const uint8_t *)"more data to compress", 21,
+                                        FLUSH_END);
     ASSERT_EQ(ret4, -1) << "mid-frame error should fail";
 
     zfree(buf2);
@@ -420,7 +420,7 @@ TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
         } else {
             ASSERT_EQ(streamReaderProbe(&t), -1) << cases[i].name;
             ASSERT_EQ(streamReaderGetInfo(&t, &info), -1) << cases[i].name;
-            ASSERT_EQ(streamReaderGetError(&t), cases[i].expected_error) << cases[i].name;
+            ASSERT_EQ(t.error_kind, cases[i].expected_error) << cases[i].name;
 
             uint8_t out[8] = {0};
             ASSERT_EQ(streamReaderRead(&t, out, sizeof(out)), -1) << cases[i].name;
@@ -566,7 +566,7 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
         } else {
             ASSERT_EQ(streamReaderProbe(&r), -1) << cases[i].name;
             ASSERT_EQ(streamReaderGetInfo(&r, &info), -1) << cases[i].name;
-            ASSERT_EQ(streamReaderGetError(&r), STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
+            ASSERT_EQ(r.error_kind, STREAM_READER_ERROR_INCOMPATIBLE) << cases[i].name;
 
             uint8_t out[32] = {0};
             ASSERT_EQ(streamReaderRead(&r, out, sizeof(out)), -1) << cases[i].name;
@@ -658,7 +658,7 @@ TEST_F(CompressionTest, streamWriterInitFree) {
     streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     streamWriter t;
     ASSERT_EQ(streamWriterInit(&t, &cfg, emitToDynamicBuf, &db), 0);
-    ASSERT_EQ(streamWriterHasError(&t), 0) << "should not be errored";
+    ASSERT_EQ(t.errored, false) << "should not be errored";
 
     streamWriterFree(&t);
     dynamicBufFree(&db);
@@ -690,12 +690,12 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
     const char *test_data = "Hello, compression world! This is a test of the stream writer API.";
     size_t data_len = strlen(test_data);
     ASSERT_GE(streamWriterWrite(&t, test_data, data_len), 0);
-    ASSERT_EQ(streamWriterHasError(&t), 0) << "should not be errored after write";
+    ASSERT_EQ(t.errored, false) << "should not be errored after write";
     ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE) << "write should emit envelope";
 
     /* Finalize */
     ASSERT_EQ(streamWriterFinish(&t), 0);
-    ASSERT_EQ(streamWriterHasError(&t), 0) << "should not be errored after finish";
+    ASSERT_EQ(t.errored, false) << "should not be errored after finish";
 
     /* Verify output starts with VKCS envelope */
     ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE)
@@ -721,7 +721,7 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
 
     while (src_offset < compressed_len) {
         size_t consumed = 0;
-        ssize_t produced = streamDecompressFeed(
+        ssize_t produced = streamDecompressorFeed(
             &sd, decompressed + total_decompressed,
             sizeof(decompressed) - total_decompressed,
             compressed_data + src_offset,
@@ -860,7 +860,7 @@ TEST_F(CompressionTest, streamWriterFlushBehavior) {
 
     while (src_offset < comp_len) {
         size_t consumed = 0;
-        ssize_t produced = streamDecompressFeed(
+        ssize_t produced = streamDecompressorFeed(
             &sd, decompressed + total_decompressed,
             sizeof(decompressed) - total_decompressed,
             comp_data + src_offset,
@@ -973,7 +973,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsTrailingBytes) {
     char out[64];
     ASSERT_EQ(streamReaderRead(&reader, out, strlen(payload)), (ssize_t)strlen(payload));
     ASSERT_EQ(streamReaderValidateEnd(&reader), -1);
-    ASSERT_EQ(streamReaderGetError(&reader), STREAM_READER_ERROR_CORRUPT);
+    ASSERT_EQ(reader.error_kind, STREAM_READER_ERROR_CORRUPT);
 
     streamReaderFree(&reader);
     streamWriterFree(&w);
@@ -1001,7 +1001,7 @@ TEST_F(CompressionTest, streamReaderValidateEndRejectsUnreadDecodedBytes) {
     ASSERT_EQ(streamReaderRead(&reader, out, sizeof(out)), (ssize_t)sizeof(out));
     ASSERT_EQ(memcmp(out, payload, sizeof(out)), 0);
     ASSERT_EQ(streamReaderValidateEnd(&reader), -1);
-    ASSERT_EQ(streamReaderGetError(&reader), STREAM_READER_ERROR_CORRUPT);
+    ASSERT_EQ(reader.error_kind, STREAM_READER_ERROR_CORRUPT);
 
     streamReaderFree(&reader);
     streamWriterFree(&w);
@@ -1049,7 +1049,7 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
 
     while (src_offset < comp_len) {
         size_t consumed = 0;
-        ssize_t produced = streamDecompressFeed(
+        ssize_t produced = streamDecompressorFeed(
             &sd, decompressed + total_decompressed,
             sizeof(decompressed) - total_decompressed,
             comp_data + src_offset,
@@ -1352,7 +1352,7 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
 
     while (src_offset < comp_len) {
         size_t consumed = 0;
-        ssize_t produced = streamDecompressFeed(
+        ssize_t produced = streamDecompressorFeed(
             &sd, decompressed + total_decompressed,
             sizeof(decompressed) - total_decompressed,
             comp_data + src_offset,
@@ -1566,7 +1566,7 @@ TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
     ASSERT_EQ(streamReaderRead(&r, out, payload_len), (ssize_t)payload_len);
     ASSERT_EQ(memcmp(out, payload, payload_len), 0);
     ASSERT_LT(streamReaderRead(&r, out, 1), 0) << "EOF before frame end should be treated as corruption";
-    ASSERT_EQ(streamReaderGetError(&r), STREAM_READER_ERROR_CORRUPT)
+    ASSERT_EQ(r.error_kind, STREAM_READER_ERROR_CORRUPT)
         << "truncated compressed frame should latch corruption, not I/O";
 
     streamReaderFree(&r);
@@ -1607,7 +1607,7 @@ TEST_F(CompressionTest, streamWriterWriteAfterFinish) {
     size_t off = 0;
     while (off < comp_len) {
         size_t consumed = 0;
-        ssize_t produced = streamDecompressFeed(
+        ssize_t produced = streamDecompressorFeed(
             &sd, decompressed + total, sizeof(decompressed) - total,
             cdata + off, comp_len - off, &consumed);
         ASSERT_GE(produced, 0);


### PR DESCRIPTION
Follow-up to #281 for the remaining API-shape nuance from hpatro's review.

Changes:
- Rename low-level codec helpers to match the struct names: streamCompressorOutputBound, streamCompressorFeed, and streamDecompressorFeed.
- Remove the redundant streamWriterHasError/streamWriterSetError public helpers now that streamWriter is embedded and non-opaque.
- Update compression tests to use the aligned names and direct writer error state.

Validation:
- make -j$(sysctl -n hw.ncpu)
- PATH="/opt/homebrew/opt/llvm/bin:/opt/homebrew/bin:$PATH" make -C src test-unit UNIT_TEST_PATTERN=CompressionTest
- ./runtest --single integration/rdb-compression
- ./runtest --single integration/valkey-check-rdb