### PR TITLE
[backport] Backport sweep for 8.1

### DIFF
--- a/.github/actions/upload-test-failures/action.yml
+++ b/.github/actions/upload-test-failures/action.yml
@@ -1,0 +1,14 @@
+name: 'Upload Test Failures'
+description: 'Upload test failure artifacts'
+inputs:
+  job-name:
+    description: 'Unique name for the artifact'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload test failures
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: test-failures-${{ inputs.job-name }}
+        path: test-failures/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: make
         # Build with additional upcoming features
-        run: make -j3 all-with-unit-tests SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=yes
+        run: |
+          export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
+          export RANLIB=/opt/homebrew/opt/llvm/bin/llvm-ranlib
+          make -j3 all-with-unit-tests SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=yes
 
   build-32bit:
     runs-on: ubuntu-latest

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -37,6 +37,9 @@ set ::run_matching {} ; # If non empty, only tests matching pattern are run.
 set ::exit_on_failure 0
 set ::stop_on_failure 0
 set ::loop 0
+set ::failures_output_file ""; # If set, write failures JSON to this path
+set ::failed_tests {}; # List of individual test failures [name, file, error]
+set ::cur_test_file ""; # Currently executing test file
 
 if {[catch {cd tmp}]} {
     puts "tmp directory not found."
@@ -317,6 +320,9 @@ proc parse_options {} {
             set ::log_req_res 1
         } elseif {$opt eq {--force-resp3}} {
             set ::force_resp3 1
+        } elseif {$opt eq {--failures-output}} {
+            incr j
+            set ::failures_output_file $val
         } elseif {$opt eq "--help"} {
             puts "--single <pattern>      Only runs tests specified by pattern."
             puts "--dont-clean            Keep log files on exit."
@@ -331,6 +337,7 @@ proc parse_options {} {
             puts "--fast-fail             Exit immediately once the first test fails."
             puts "--stop                  Blocks once the first test fails."
             puts "--loop                  Execute the specified set of tests forever."
+            puts "--failures-output <path> Write test failures to the specified JSON file."
             puts "--help                  Shows this help."
             exit 0
         } else {
@@ -429,8 +436,9 @@ proc test {descr code} {
     if {[catch {set retval [uplevel 1 $code]} error]} {
         incr ::failed
         if {[string match "assertion:*" $error]} {
-            set msg "FAILED: [string range $error 10 end]"
-            puts [colorstr red $msg]
+            set msg [string range $error 10 end]
+            puts [colorstr red "FAILED: $msg"]
+            lappend ::failed_tests [list $descr $::cur_test_file $msg]
             if {$::pause_on_error} pause_on_error
             puts [colorstr red "(Jumping to next unit after error)"]
             return -code continue
@@ -489,6 +497,14 @@ while 1 {
             continue
         }
         if {[file isdirectory $test]} continue
+        # Track current test file for failure reporting
+        set normalized [file normalize $test]
+        set project_root [file normalize "../../.."]
+        if {[string match "${project_root}/*" $normalized]} {
+            set ::cur_test_file [string range $normalized [expr {[string length $project_root] + 1}] end]
+        } else {
+            set ::cur_test_file $test
+        }
         puts [colorstr yellow "Testing unit: [lindex [file split $test] end]"]
         if {[catch { source $test } err]} {
             puts "FAILED: caught an error in the test $err"
@@ -522,8 +538,39 @@ while 1 {
 } ;# while 1
 }
 
-# Print a message and exists with 0 / 1 according to zero or more failures.
+proc write_test_failures {} {
+    if {$::failures_output_file eq ""} {
+        return
+    }
+
+    set failures {}
+    foreach entry $::failed_tests {
+        set test_name [lindex $entry 0]
+        set test_file [lindex $entry 1]
+        set error_msg [lindex $entry 2]
+
+        set test_name [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_name]
+        set test_file [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_file]
+        set error_msg [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $error_msg]
+
+        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"err\",\"error\":\"$error_msg\"\}"
+    }
+
+    set outdir [file dirname $::failures_output_file]
+    if {$outdir ne "."} {
+        file mkdir $outdir
+    }
+    set fp [open $::failures_output_file w]
+    puts $fp "\[[join $failures ","]\]"
+    close $fp
+}
+
+# Print a message and exits with 0 / 1 according to zero or more failures.
 proc end_tests {} {
+    if {[catch {write_test_failures} err]} {
+        puts "Warning: Failed to write test failures: $err"
+    }
+
     if {$::failed == 0 } {
         puts [colorstr green "GOOD! No errors."]
         exit 0

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -93,6 +93,7 @@ set ::log_req_res 0
 set ::force_resp3 0
 set ::solo_tests_count 0
 set ::debug_defrag 0
+set ::failures_output_file ""; # If set, write failures JSON to this path
 
 # Set to 1 when we are running in client mode. The server test uses a
 # server-client model to run tests simultaneously. The server instance
@@ -444,8 +445,7 @@ proc read_from_test_client fd {
     } elseif {$status eq {err}} {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
-        set test_name [lindex [split $data "\n"] 0]
-        lappend ::failed_tests $test_name
+        lappend ::failed_tests $err
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
             puts -nonewline "(Fast fail: test will exit now)"
@@ -459,6 +459,9 @@ proc read_from_test_client fd {
         }
     } elseif {$status eq {exception}} {
         puts "\[[colorstr red $status]\]: $data"
+        if {[catch {write_test_failures} err]} {
+            puts "Warning: Failed to write test failures: $err"
+        }
         kill_clients
         force_kill_all_servers
         exit 1
@@ -566,6 +569,49 @@ proc signal_idle_client fd {
 
 # The the_end function gets called when all the test units were already
 # executed, so the test finished.
+proc write_test_failures {} {
+    if {$::failures_output_file eq ""} {
+        return
+    }
+
+    set failures {}
+    foreach failed $::failed_tests {
+        if {[string match {*\[*TIMEOUT*\]*} $failed]} continue
+        if {[string match {*Sanitizer error*} $failed]} continue
+        if {[string match {*Valgrind error*} $failed]} continue
+        if {[string match {*Can't start*} $failed]} continue
+        if {[string match {*Check for memory leaks*} $failed]} continue
+
+        set status "err"
+        set test_name ""
+        set test_file ""
+        set error_msg ""
+
+        if {[regexp {\[(\w+)\]:\s*(.+?)\s+in\s+(tests/\S+\.tcl)\s*(.*)} $failed -> status test_name test_file error_msg]} {
+            # Successfully parsed
+        } else {
+            set test_name $failed
+            set test_file "unknown"
+            set error_msg $failed
+        }
+
+        set test_name [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_name]
+        set test_file [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_file]
+        set error_msg [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $error_msg]
+        set status [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $status]
+
+        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"$status\",\"error\":\"$error_msg\"\}"
+    }
+
+    set outdir [file dirname $::failures_output_file]
+    if {$outdir ne "."} {
+        file mkdir $outdir
+    }
+    set fp [open $::failures_output_file w]
+    puts $fp "\[[join $failures ","]\]"
+    close $fp
+}
+
 proc the_end {} {
     # TODO: print the status, exit with the right exit code.
     puts "\n                   The End\n"
@@ -573,6 +619,12 @@ proc the_end {} {
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
     }
+
+    # Write structured failures for automated detection
+    if {[catch {write_test_failures} err]} {
+        puts "Warning: Failed to write test failures: $err"
+    }
+
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"
         foreach failed $::failed_tests {
@@ -639,6 +691,8 @@ proc print_help_screen {} {
         "--clients <num>    Number of test clients (default 16)."
         "--timeout <sec>    Test timeout in seconds (default 20 min)."
         "--force-failure    Force the execution of a test that always fails."
+        "--failures-output <path>"
+        "                   Write test failures to the specified JSON file."
         "--config <k> <v>   Extra config file argument."
         "--skipfile <file>  Name of a file containing test names or regexp patterns (if"
         "                   <test> starts with '/') that should be skipped (one per"
@@ -752,6 +806,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::accurate 1
     } elseif {$opt eq {--force-failure}} {
         set ::force_failure 1
+    } elseif {$opt eq {--failures-output}} {
+        set ::failures_output_file $arg
+        incr j
     } elseif {$opt eq {--single}} {
         lappend ::single_tests $arg
         incr j


### PR DESCRIPTION
# Backport sweep for 8.1

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| #3317 | Use ar archiver installed by brew in CI `build-macos-latest` | conflicts resolved by Claude Code |
| #3770 | Add --failures-output flag to test runners for weekly CI compatibility | conflicts resolved by Claude Code |

## Needs attention

These candidates could not be applied automatically and need a maintainer to follow up.

<details><summary>1 candidate(s)</summary>

| Source PR | Title | Outcome | Reason |
|---|---|---|---|
| #3548 | Fix lua-enable-insecure-api default value cannot be changed to yes | skipped-conflict | target branch lacks conflicted file(s): src/modules/lua/engine_lua.c |

</details>

---
*Generated by valkey-ci-agent using Claude Code.*