### PR TITLE
[backport] Backport sweep for 8.0

### DIFF
--- a/src/anet.h
+++ b/src/anet.h
@@ -61,6 +61,7 @@ int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port)
 int anetUnixAccept(char *err, int serversock);
 int anetNonBlock(char *err, int fd);
 int anetBlock(char *err, int fd);
+int anetIsBlock(char *err, int fd);
 int anetCloexec(int fd);
 int anetEnableTcpNoDelay(char *err, int fd);
 int anetDisableTcpNoDelay(char *err, int fd);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3306,11 +3306,17 @@ int isClientConnIpV6(client *c) {
     /* The cached client peer id is on the form "[IPv6]:port" for IPv6
      * addresses, so we just check for '[' here. */
     if (c->flag.fake && server.current_client) {
-        /* Fake client? Use current client instead.
-         * Noted that in here we are assuming server.current_client is set
-         * and real (aof has already violated this in loadSingleAppendOnlyFil). */
+        /* Fake client? Use current client instead, if we have one. */
         c = server.current_client;
     }
+
+    if (c->flag.fake || !c->conn) {
+        /* If we still don't have a client with a real connection (e.g., called
+         * from module timer with no real current client), default to IPv4 to
+         * avoid crashing. */
+        return 0;
+    }
+
     return getClientPeerId(c)[0] == '[';
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -989,6 +989,10 @@ static int connTLSSetReadHandler(connection *conn, ConnectionCallbackFunc func) 
     return C_OK;
 }
 
+static int isBlocking(tls_connection *conn) {
+    return anetIsBlock(NULL, conn->c.fd);
+}
+
 static void setBlockingTimeout(tls_connection *conn, long long timeout) {
     anetBlock(NULL, conn->c.fd);
     anetSendTimeout(NULL, conn->c.fd, timeout);
@@ -1027,26 +1031,30 @@ static int connTLSBlockingConnect(connection *conn_, const char *addr, int port,
 
 static ssize_t connTLSSyncWrite(connection *conn_, char *ptr, ssize_t size, long long timeout) {
     tls_connection *conn = (tls_connection *)conn_;
-
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
     SSL_clear_mode(conn->ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
     ERR_clear_error();
     int ret = SSL_write(conn->ssl, ptr, size);
     ret = updateStateAfterSSLIO(conn, ret, 0);
     SSL_set_mode(conn->ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
 
     return ret;
 }
 
 static ssize_t connTLSSyncRead(connection *conn_, char *ptr, ssize_t size, long long timeout) {
     tls_connection *conn = (tls_connection *)conn_;
-
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
     ERR_clear_error();
     int ret = SSL_read(conn->ssl, ptr, size);
     ret = updateStateAfterSSLIO(conn, ret, 0);
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
 
     return ret;
 }
@@ -1055,6 +1063,7 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
     tls_connection *conn = (tls_connection *)conn_;
     ssize_t nread = 0;
 
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
 
     size--;
@@ -1080,7 +1089,9 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
         size--;
     }
 exit:
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
     return nread;
 }
 

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -2,6 +2,35 @@
 
 #define UNUSED(x) (void)(x)
 
+void cluster_timer_handler(ValkeyModuleCtx *ctx, void *data) {
+    VALKEYMODULE_NOT_USED(data);
+
+    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, "CLUSTER", "c", "SLOTS");
+
+    if (rep) {
+        if (ValkeyModule_CallReplyType(rep) == VALKEYMODULE_REPLY_ARRAY) {
+            ValkeyModule_Log(ctx, "notice", "Timer: CLUSTER SLOTS success");
+        } else {
+            ValkeyModule_Log(ctx, "notice",
+                             "Timer: CLUSTER SLOTS unexpected reply type %d",
+                             ValkeyModule_CallReplyType(rep));
+        }
+        ValkeyModule_FreeCallReply(rep);
+    } else {
+        ValkeyModule_Log(ctx, "warning", "Timer: CLUSTER SLOTS failed");
+    }
+}
+
+int test_start_cluster_timer(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    ValkeyModule_CreateTimer(ctx, 1, cluster_timer_handler, NULL);
+
+    return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+
 int test_cluster_slots(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     UNUSED(argv);
 
@@ -45,6 +74,9 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
         return VALKEYMODULE_ERR;
 
     if (ValkeyModule_CreateCommand(ctx, "test.cluster_shards", test_cluster_shards, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "test.start_cluster_timer", test_start_cluster_timer, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -251,6 +251,18 @@ start_cluster 3 0 [list config_lines $modules] {
         assert_equal [lsort [$node2 cluster shards]] [lsort [$node2 test.cluster_shards]]
         assert_equal [lsort [$node3 cluster shards]] [lsort [$node3 test.cluster_shards]]
     }
+
+    test "VM_CALL CLUSTER SLOTS from Module Timer" {
+        assert_equal {OK} [$node1 test.start_cluster_timer]
+        assert_equal {OK} [$node2 test.start_cluster_timer]
+        assert_equal {OK} [$node3 test.start_cluster_timer]
+
+        wait_for_condition 50 100 {
+            [count_log_message 0 "* <cluster> Timer: CLUSTER SLOTS success*"] >= 1
+        } else {
+            fail "Timer did not execute CLUSTER SLOTS or server crashed"
+        }
+    }
 }
 
 } ;# end tag


### PR DESCRIPTION
# Backport sweep for 8.0

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| #1298 | Preserve original fd blocking state in TLS I/O operations |  |
| #2915 | Fix CLUSTER SLOTS crash when called from module timer callback | conflicts resolved by Claude Code |

## Needs attention

These candidates could not be applied automatically and need a maintainer to follow up.

<details><summary>1 candidate(s)</summary>

| Source PR | Title | Outcome | Reason |
|---|---|---|---|
| #1826 | Fix Lua VM crash after FUNCTION FLUSH ASYNC + FUNCTION LOAD | skipped-conflict | target branch lacks conflicted file(s): src/lua/engine_lua.c, src/lua/engine_lua.h, src/lua/function_lua.h, src/scripting_engine.c, src/scripting_engine.h, tests/modules/helloscripting.c, tests/unit/moduleapi/scriptingengine.tcl |

</details>

---
*Generated by valkey-ci-agent using Claude Code.*