### PR TITLE
Streaming RDB compression: envelope and lifecycle hardening

### DIFF
--- a/src/compression.c
+++ b/src/compression.c
@@ -83,7 +83,7 @@ int streamCompressorInit(streamCompressor *compressor, compressionAlgo algo, int
 
 void streamCompressorFree(streamCompressor *compressor) {
     const compressionCodec *codec = compressionCodecForAlgo(compressor->algo);
-    assert(codec != NULL);
+    if (codec == NULL) return; /* Nothing to release on a zeroed instance. */
     codec->compressor_free(compressor);
 }
 
@@ -104,7 +104,7 @@ int streamDecompressorInit(streamDecompressor *decompressor, compressionAlgo alg
 
 void streamDecompressorFree(streamDecompressor *decompressor) {
     const compressionCodec *codec = compressionCodecForAlgo(decompressor->algo);
-    assert(codec != NULL);
+    if (codec == NULL) return; /* Nothing to release on a zeroed instance. */
     codec->decompressor_free(decompressor);
 }
 

--- a/src/compression.c
+++ b/src/compression.c
@@ -82,8 +82,9 @@ int streamCompressorInit(streamCompressor *compressor, compressionAlgo algo, int
 }
 
 void streamCompressorFree(streamCompressor *compressor) {
+    if (compressor->algo == ALGO_NONE) return; /* Zeroed or failed-init instance. */
     const compressionCodec *codec = compressionCodecForAlgo(compressor->algo);
-    if (codec == NULL) return; /* Nothing to release on a zeroed instance. */
+    assert(codec != NULL);
     codec->compressor_free(compressor);
 }
 
@@ -103,8 +104,9 @@ int streamDecompressorInit(streamDecompressor *decompressor, compressionAlgo alg
 }
 
 void streamDecompressorFree(streamDecompressor *decompressor) {
+    if (decompressor->algo == ALGO_NONE) return; /* Zeroed or failed-init instance. */
     const compressionCodec *codec = compressionCodecForAlgo(decompressor->algo);
-    if (codec == NULL) return; /* Nothing to release on a zeroed instance. */
+    assert(codec != NULL);
     codec->decompressor_free(decompressor);
 }
 

--- a/src/compression.c
+++ b/src/compression.c
@@ -82,7 +82,6 @@ int streamCompressorInit(streamCompressor *compressor, compressionAlgo algo, int
 }
 
 void streamCompressorFree(streamCompressor *compressor) {
-    if (compressor->algo == ALGO_NONE) return; /* Zeroed or failed-init instance. */
     const compressionCodec *codec = compressionCodecForAlgo(compressor->algo);
     assert(codec != NULL);
     codec->compressor_free(compressor);
@@ -104,7 +103,6 @@ int streamDecompressorInit(streamDecompressor *decompressor, compressionAlgo alg
 }
 
 void streamDecompressorFree(streamDecompressor *decompressor) {
-    if (decompressor->algo == ALGO_NONE) return; /* Zeroed or failed-init instance. */
     const compressionCodec *codec = compressionCodecForAlgo(decompressor->algo);
     assert(codec != NULL);
     codec->decompressor_free(decompressor);

--- a/src/compression.h
+++ b/src/compression.h
@@ -21,13 +21,18 @@ typedef enum {
 
 typedef enum {
     FLUSH_CONTINUE = 0, /* Buffer internally. */
-    FLUSH_SYNC = 1,     /* Drain buffered bytes, keep frame open. */
-    FLUSH_END = 2,      /* Finalize frame. */
+    /* Drain buffered bytes to the sink but leave the frame open so more data
+     * can follow. RDB save only needs FLUSH_END, but a streaming consumer that
+     * must bound latency (e.g. an incremental replication stream) needs to push
+     * what it has without closing the frame, so the rio flush hook maps to this
+     * rather than to FLUSH_END. */
+    FLUSH_SYNC = 1,
+    FLUSH_END = 2, /* Finalize frame. */
 } compressFlushMode;
 
 typedef struct {
     compressionAlgo algo;
-    int level;
+    int level; /* 0 selects the codec's default level. */
     void *ctx;
     bool stream_started;
     bool codec_checksum;

--- a/src/compression.h
+++ b/src/compression.h
@@ -21,18 +21,13 @@ typedef enum {
 
 typedef enum {
     FLUSH_CONTINUE = 0, /* Buffer internally. */
-    /* Drain buffered bytes to the sink but leave the frame open so more data
-     * can follow. RDB save only needs FLUSH_END, but a streaming consumer that
-     * must bound latency (e.g. an incremental replication stream) needs to push
-     * what it has without closing the frame, so the rio flush hook maps to this
-     * rather than to FLUSH_END. */
-    FLUSH_SYNC = 1,
-    FLUSH_END = 2, /* Finalize frame. */
+    FLUSH_SYNC = 1,     /* Drain buffered bytes, keep frame open. */
+    FLUSH_END = 2,      /* Finalize frame. */
 } compressFlushMode;
 
 typedef struct {
     compressionAlgo algo;
-    int level; /* 0 selects the codec's default level. */
+    int level; /* 0 selects the codec default. */
     void *ctx;
     bool stream_started;
     bool codec_checksum;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -102,7 +102,7 @@ int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg)
     cr->inner = inner;
     if (streamWriterInit(&cr->writer, cfg, compressRioEmit, cr) != 0) {
         /* Self-clean so the failure contract matches rioInitWithDecompression:
-         * on a nonzero return the compressRio is left untouched and the caller
+         * on a nonzero return the compressRio is left zeroed and the caller
          * must not call compressRioFree. */
         memset(cr, 0, sizeof(*cr));
         return -1;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -100,7 +100,14 @@ int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg)
                 RIO_FLAG_STREAMING_COMPRESSION | (inner->flags & RIO_FLAG_CONN_BACKED));
 
     cr->inner = inner;
-    return streamWriterInit(&cr->writer, cfg, compressRioEmit, cr);
+    if (streamWriterInit(&cr->writer, cfg, compressRioEmit, cr) != 0) {
+        /* Self-clean so the failure contract matches rioInitWithDecompression:
+         * on a nonzero return the compressRio is left untouched and the caller
+         * must not call compressRioFree. */
+        memset(cr, 0, sizeof(*cr));
+        return -1;
+    }
+    return 0;
 }
 
 /* Idempotent: subsequent calls report cached error state. */

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -29,7 +29,7 @@ typedef enum {
     DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
 } decompressRioInitResult;
 
-/* Returns 0 on success. On failure the compressRio is left clean and the
+/* Returns 0 on success. On failure the compressRio is left zeroed and the
  * caller must not call compressRioFree. */
 int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg);
 int compressRioFinish(compressRio *cr);

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -29,6 +29,8 @@ typedef enum {
     DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
 } decompressRioInitResult;
 
+/* Returns 0 on success. On failure the compressRio is left clean and the
+ * caller must not call compressRioFree. */
 int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg);
 int compressRioFinish(compressRio *cr);
 void compressRioFree(compressRio *cr);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -19,8 +19,9 @@ static const uint8_t VKCS_MAGIC[VKCS_MAGIC_SIZE] = {
     VKCS_MAGIC_3,
 };
 
-/* True when the first len bytes of buf match the VKCS magic prefix. */
-static bool vkcsMagicMatches(const uint8_t *buf, size_t len) {
+/* True when the first len bytes of buf match the VKCS magic. When len is below
+ * VKCS_MAGIC_SIZE this only compares that prefix. */
+static bool vkcsHasMagicPrefix(const uint8_t *buf, size_t len) {
     size_t n = len < VKCS_MAGIC_SIZE ? len : VKCS_MAGIC_SIZE;
     return memcmp(buf, VKCS_MAGIC, n) == 0;
 }
@@ -34,7 +35,7 @@ typedef enum {
 
 static bool streamReaderProbeHasMagicPrefix(streamReader *reader) {
     if (reader->probe.header_len == 0) return false;
-    return vkcsMagicMatches(reader->probe.header, reader->probe.header_len);
+    return vkcsHasMagicPrefix(reader->probe.header, reader->probe.header_len);
 }
 
 static void streamReaderProbeSetPassthrough(streamReader *reader) {
@@ -85,7 +86,7 @@ static int readVkcsEnvelope(const uint8_t *buf,
                             bool *codec_checksum_enabled) {
     if (len < VKCS_ENVELOPE_SIZE) return -1;
 
-    if (!vkcsMagicMatches(buf, VKCS_MAGIC_SIZE)) return -1;
+    if (!vkcsHasMagicPrefix(buf, VKCS_MAGIC_SIZE)) return -1;
     if (buf[VKCS_OFFSET_VERSION] != VKCS_VERSION) return -1;
 
     compressionAlgo parsed_algo = (compressionAlgo)buf[VKCS_OFFSET_ALGO];
@@ -144,7 +145,7 @@ static vkcsProbeResult streamReaderProbeFeed(streamReader *reader,
         reader->probe.header_len += take;
         consumed += take;
 
-        if (reader->probe.header_len >= VKCS_MAGIC_SIZE && !vkcsMagicMatches(reader->probe.header, VKCS_MAGIC_SIZE)) {
+        if (reader->probe.header_len >= VKCS_MAGIC_SIZE && !vkcsHasMagicPrefix(reader->probe.header, VKCS_MAGIC_SIZE)) {
             *src_consumed = consumed;
             if (!reader->probe_cfg.allow_passthrough) return VKCS_PROBE_ERROR;
             streamReaderProbeSetPassthrough(reader);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -12,6 +12,19 @@
 
 /* ===== VKCS envelope ===== */
 
+static const uint8_t VKCS_MAGIC[VKCS_MAGIC_SIZE] = {
+    VKCS_MAGIC_0,
+    VKCS_MAGIC_1,
+    VKCS_MAGIC_2,
+    VKCS_MAGIC_3,
+};
+
+/* True when the first len bytes of buf match the VKCS magic prefix. */
+static bool vkcsMagicMatches(const uint8_t *buf, size_t len) {
+    size_t n = len < VKCS_MAGIC_SIZE ? len : VKCS_MAGIC_SIZE;
+    return memcmp(buf, VKCS_MAGIC, n) == 0;
+}
+
 typedef enum {
     VKCS_PROBE_NEED_INPUT = 0,
     VKCS_PROBE_PASSTHROUGH = 1,
@@ -21,8 +34,7 @@ typedef enum {
 
 static bool streamReaderProbeHasMagicPrefix(streamReader *reader) {
     if (reader->probe.header_len == 0) return false;
-    size_t magic_prefix_len = reader->probe.header_len < VKCS_MAGIC_SIZE ? reader->probe.header_len : VKCS_MAGIC_SIZE;
-    return memcmp(reader->probe.header, "VKCS", magic_prefix_len) == 0;
+    return vkcsMagicMatches(reader->probe.header, reader->probe.header_len);
 }
 
 static void streamReaderProbeSetPassthrough(streamReader *reader) {
@@ -56,10 +68,10 @@ static int writeVkcsEnvelope(streamWriterEmitFn emit_fn,
         VKCS_MAGIC_1,
         VKCS_MAGIC_2,
         VKCS_MAGIC_3,
-        VKCS_VERSION,
-        (uint8_t)algo,
-        codec_checksum_enabled ? VKCS_FLAG_CODEC_CHECKSUM : 0,
-        stream_kind,
+        [VKCS_OFFSET_VERSION] = VKCS_VERSION,
+        [VKCS_OFFSET_ALGO] = (uint8_t)algo,
+        [VKCS_OFFSET_FLAGS] = codec_checksum_enabled ? VKCS_FLAG_CODEC_CHECKSUM : 0,
+        [VKCS_OFFSET_STREAM_KIND] = stream_kind,
     };
     return emit_fn(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
 }
@@ -73,17 +85,17 @@ static int readVkcsEnvelope(const uint8_t *buf,
                             bool *codec_checksum_enabled) {
     if (len < VKCS_ENVELOPE_SIZE) return -1;
 
-    if (memcmp(buf, "VKCS", VKCS_MAGIC_SIZE) != 0) return -1;
-    if (buf[4] != VKCS_VERSION) return -1;
+    if (!vkcsMagicMatches(buf, VKCS_MAGIC_SIZE)) return -1;
+    if (buf[VKCS_OFFSET_VERSION] != VKCS_VERSION) return -1;
 
-    compressionAlgo parsed_algo = (compressionAlgo)buf[5];
+    compressionAlgo parsed_algo = (compressionAlgo)buf[VKCS_OFFSET_ALGO];
     if (!compressionAlgoSupportsStreaming(parsed_algo)) return -1;
 
-    uint8_t flags = buf[6];
+    uint8_t flags = buf[VKCS_OFFSET_FLAGS];
     if (flags & ~VKCS_FLAG_CODEC_CHECKSUM) return -1;
 
     if (algo) *algo = parsed_algo;
-    if (stream_kind) *stream_kind = buf[7];
+    if (stream_kind) *stream_kind = buf[VKCS_OFFSET_STREAM_KIND];
     if (codec_checksum_enabled) *codec_checksum_enabled = (flags & VKCS_FLAG_CODEC_CHECKSUM) != 0;
     return 0;
 }
@@ -132,7 +144,7 @@ static vkcsProbeResult streamReaderProbeFeed(streamReader *reader,
         reader->probe.header_len += take;
         consumed += take;
 
-        if (reader->probe.header_len >= VKCS_MAGIC_SIZE && memcmp(reader->probe.header, "VKCS", VKCS_MAGIC_SIZE) != 0) {
+        if (reader->probe.header_len >= VKCS_MAGIC_SIZE && !vkcsMagicMatches(reader->probe.header, VKCS_MAGIC_SIZE)) {
             *src_consumed = consumed;
             if (!reader->probe_cfg.allow_passthrough) return VKCS_PROBE_ERROR;
             streamReaderProbeSetPassthrough(reader);

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -14,7 +14,13 @@
  *   [4]    version (currently VKCS_VERSION)
  *   [5]    codec id
  *   [6]    flags (bit 0 = codec checksum enabled; other bits reserved)
- *   [7]    stream kind */
+ *   [7]    stream kind
+ *
+ * Every field is a single byte today, so the on-disk form is identical on all
+ * architectures. Any multi-byte field added in a future version must be stored
+ * in network byte order so a VKCS stream stays portable across architectures,
+ * including when it is sent over replication between hosts of differing
+ * endianness. */
 #define VKCS_MAGIC_0 0x56 /* 'V' */
 #define VKCS_MAGIC_1 0x4B /* 'K' */
 #define VKCS_MAGIC_2 0x43 /* 'C' */
@@ -24,6 +30,17 @@
 #define VKCS_VERSION 1
 #define VKCS_FLAG_CODEC_CHECKSUM (1 << 0)
 
+/* Byte offsets of each envelope field after the magic. */
+#define VKCS_OFFSET_VERSION 4
+#define VKCS_OFFSET_ALGO 5
+#define VKCS_OFFSET_FLAGS 6
+#define VKCS_OFFSET_STREAM_KIND 7
+
+/* Identifies what the compressed bytes decode to, letting a reader reject a
+ * stream meant for a different consumer. Full-sync replication still carries
+ * an RDB image, so it keeps STREAM_KIND_RDB; a future incremental command
+ * stream would use its own kind, and the RDB loader rejects anything that is
+ * not STREAM_KIND_RDB. */
 typedef enum {
     STREAM_KIND_RDB = 0x00,
 } streamKind;

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -16,11 +16,8 @@
  *   [6]    flags (bit 0 = codec checksum enabled; other bits reserved)
  *   [7]    stream kind
  *
- * Every field is a single byte today, so the on-disk form is identical on all
- * architectures. Any multi-byte field added in a future version must be stored
- * in network byte order so a VKCS stream stays portable across architectures,
- * including when it is sent over replication between hosts of differing
- * endianness. */
+ * All fields are single-byte in version 1. Future multi-byte fields must use
+ * network byte order. */
 #define VKCS_MAGIC_0 0x56 /* 'V' */
 #define VKCS_MAGIC_1 0x4B /* 'K' */
 #define VKCS_MAGIC_2 0x43 /* 'C' */

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -30,17 +30,14 @@
 #define VKCS_VERSION 1
 #define VKCS_FLAG_CODEC_CHECKSUM (1 << 0)
 
-/* Byte offsets of each envelope field after the magic. */
+/* Byte offsets of each envelope field. */
 #define VKCS_OFFSET_VERSION 4
 #define VKCS_OFFSET_ALGO 5
 #define VKCS_OFFSET_FLAGS 6
 #define VKCS_OFFSET_STREAM_KIND 7
 
-/* Identifies what the compressed bytes decode to, letting a reader reject a
- * stream meant for a different consumer. Full-sync replication still carries
- * an RDB image, so it keeps STREAM_KIND_RDB; a future incremental command
- * stream would use its own kind, and the RDB loader rejects anything that is
- * not STREAM_KIND_RDB. */
+/* Identifies what the compressed bytes decode to. The RDB loader rejects any
+ * stream whose kind is not STREAM_KIND_RDB. */
 typedef enum {
     STREAM_KIND_RDB = 0x00,
 } streamKind;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1605,10 +1605,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     if (use_streaming_compression) {
         streamWriterConfig cfg = {
             .algo = (compressionAlgo)server.rdb_compression_algo,
-            /* 0 keeps the codec's default level. A configurable level only
-             * becomes meaningful once a codec with a wide level range (zstd)
-             * lands, so the knob is deferred until then. */
-            .level = 0,
+            .level = 0, /* Codec default. */
             .stream_kind = STREAM_KIND_RDB,
             .codec_checksum_enabled = server.rdb_checksum != 0,
         };

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1605,6 +1605,9 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     if (use_streaming_compression) {
         streamWriterConfig cfg = {
             .algo = (compressionAlgo)server.rdb_compression_algo,
+            /* 0 keeps the codec's default level. A configurable level only
+             * becomes meaningful once a codec with a wide level range (zstd)
+             * lands, so the knob is deferred until then. */
             .level = 0,
             .stream_kind = STREAM_KIND_RDB,
             .codec_checksum_enabled = server.rdb_checksum != 0,
@@ -1726,8 +1729,9 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE, "DB saved on disk with %s compression",
-              compressionAlgoName(server.rdb_compression ? (compressionAlgo)server.rdb_compression_algo : ALGO_NONE));
+    serverLog(LL_NOTICE, "DB saved on disk%s%s",
+              server.rdb_compression ? " with compression: " : "",
+              server.rdb_compression ? compressionAlgoName((compressionAlgo)server.rdb_compression_algo) : "");
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -576,6 +576,61 @@ TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
     }
 }
 
+/* --- Test: streamReadEnvelopeInfo rejects envelopes this build cannot accept.
+ * Builds a valid envelope, then flips one field at a time and asserts the
+ * parse fails. Guards the version, codec-id, and reserved-flag-bit branches
+ * that the format relies on for forward compatibility. */
+TEST_F(CompressionTest, streamReadEnvelopeInfoRejectsBadEnvelopes) {
+    DynamicBuf db;
+    dynamicBufInit(&db);
+
+    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
+    streamWriter w;
+    ASSERT_EQ(streamWriterInit(&w, &wcfg, emitToDynamicBuf, &db), 0);
+    ASSERT_GE(streamWriterWrite(&w, "negative envelope", 17), 0);
+    ASSERT_EQ(streamWriterFinish(&w), 0);
+    streamWriterFree(&w);
+
+    ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
+
+    uint8_t good[VKCS_ENVELOPE_SIZE];
+    memcpy(good, db.data, VKCS_ENVELOPE_SIZE);
+    dynamicBufFree(&db);
+
+    streamReaderInfo info;
+
+    /* Sanity: the unmodified envelope parses. */
+    ASSERT_EQ(streamReadEnvelopeInfo(good, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), 0);
+
+    /* Unknown version. */
+    uint8_t bad_version[VKCS_ENVELOPE_SIZE];
+    memcpy(bad_version, good, VKCS_ENVELOPE_SIZE);
+    bad_version[VKCS_OFFSET_VERSION] = VKCS_VERSION + 1;
+    ASSERT_EQ(streamReadEnvelopeInfo(bad_version, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+        << "future version must be rejected";
+
+    /* Unknown / non-streaming codec id. */
+    uint8_t bad_algo[VKCS_ENVELOPE_SIZE];
+    memcpy(bad_algo, good, VKCS_ENVELOPE_SIZE);
+    bad_algo[VKCS_OFFSET_ALGO] = 0x7f;
+    ASSERT_EQ(streamReadEnvelopeInfo(bad_algo, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+        << "unknown codec id must be rejected";
+
+    /* LZF is a real algorithm but has no streaming codec. */
+    uint8_t lzf_algo[VKCS_ENVELOPE_SIZE];
+    memcpy(lzf_algo, good, VKCS_ENVELOPE_SIZE);
+    lzf_algo[VKCS_OFFSET_ALGO] = (uint8_t)ALGO_LZF;
+    ASSERT_EQ(streamReadEnvelopeInfo(lzf_algo, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+        << "non-streaming algorithm must be rejected";
+
+    /* Reserved flag bit set. */
+    uint8_t bad_flags[VKCS_ENVELOPE_SIZE];
+    memcpy(bad_flags, good, VKCS_ENVELOPE_SIZE);
+    bad_flags[VKCS_OFFSET_FLAGS] |= ~VKCS_FLAG_CODEC_CHECKSUM;
+    ASSERT_EQ(streamReadEnvelopeInfo(bad_flags, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+        << "reserved flag bits must be rejected";
+}
+
 /* --- Test: stream_reader marks errored on partial output + read error.
  * Regression for direct-path error accounting (partial bytes were returned
  * without sticky errored state). */

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -626,7 +626,7 @@ TEST_F(CompressionTest, streamReadEnvelopeInfoRejectsBadEnvelopes) {
     /* Reserved flag bit set. */
     uint8_t bad_flags[VKCS_ENVELOPE_SIZE];
     memcpy(bad_flags, good, VKCS_ENVELOPE_SIZE);
-    bad_flags[VKCS_OFFSET_FLAGS] |= ~VKCS_FLAG_CODEC_CHECKSUM;
+    bad_flags[VKCS_OFFSET_FLAGS] |= (1 << 1);
     ASSERT_EQ(streamReadEnvelopeInfo(bad_flags, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
         << "reserved flag bits must be rejected";
 }

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -151,6 +151,16 @@ start_server {overrides {save "" enable-debug-command local}} {
             fail "BGSAVE did not start in time"
         }
 
+        # Wait for the child to actually begin serializing keys before
+        # flipping the config, otherwise the algo read in the child can
+        # race the parent's CONFIG SET.
+        wait_for_condition 200 10 {
+            [s current_save_keys_processed] >= 1
+        } else {
+            r config set rdb-key-save-delay 0
+            fail "BGSAVE child did not begin serializing in time"
+        }
+
         r config set rdb-compression-algo lzf
 
         wait_for_condition 500 10 {
@@ -419,6 +429,10 @@ start_server {tags {"rdb-compression repl external:skip"}} {
 
             $replica replicaof $primary_host $primary_port
             wait_for_sync $replica
+            # wait_for_sync only checks master_link_status; the replica may
+            # still be loading the RDB. Wait until loading completes before
+            # comparing digests.
+            wait_done_loading $replica
 
             wait_for_condition 50 100 {
                 [status $replica master_link_status] eq "up" &&
@@ -449,6 +463,10 @@ start_server {tags {"rdb-compression repl external:skip"}} {
 
             $replica replicaof $primary_host $primary_port
             wait_for_sync $replica
+            # wait_for_sync only checks master_link_status; the replica may
+            # still be loading the RDB. Wait until loading completes before
+            # comparing digests.
+            wait_done_loading $replica
 
             wait_for_condition 50 100 {
                 [status $replica master_link_status] eq "up" &&

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -188,6 +188,10 @@ tags {"repl external:skip"} {
                     fail "Expected streaming-compressed sync RDB fallback log not found"
                 }
 
+                # The positive wait above proves restartAOFWithSyncRdb has run and
+                # taken the fallback branch; only after that ordering is the negative
+                # check below meaningful (otherwise it could pass simply because the
+                # log line hasn't been written yet).
                 assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
                 waitForBgrewriteaof $replica
                 set manifest_path [get_aof_manifest_path $replica]


### PR DESCRIPTION
Hardening on top of the streaming RDB compression branch, ahead of the next
review pass. No behavior change beyond the log line and the test stabilizations.

### Format and forward-compatibility

- Name the VKCS envelope field offsets (`VKCS_OFFSET_VERSION/ALGO/FLAGS/STREAM_KIND`)
  and use them in both the reader and the writer (designated initializers), so the
  layout is defined in one place rather than as positional `buf[4..7]` accesses.
- Route the three magic comparisons through a single `VKCS_MAGIC` source.
- State in the envelope header that any multi-byte field added in a future version
  must be stored in network byte order, so a stream stays portable across
  architectures, including when it is sent over replication between hosts of
  differing endianness. Every field is a single byte today, so this is a forward
  rule, not a change.

### Lifecycle safety

- `rioInitWithCompression` now zeroes the `compressRio` when `streamWriterInit`
  fails, matching `rioInitWithDecompression`: on a nonzero return the decorator is
  left clean and the caller must not call `compressRioFree`. This keeps the cleanup
  rule uniform before a second caller (replication on a connection-backed rio) is
  added.
- `streamCompressorFree`/`streamDecompressorFree` return early when the instance has
  no codec instead of asserting, so freeing a zeroed or failed-init instance is safe.

### Log

- The save notice read "DB saved on disk with none compression" when compression was
  off. The algorithm suffix is now only appended when compression is in use.

### Tests

- Add a unit test that flips the version, codec id, and flag bytes of a valid
  envelope and asserts `streamReadEnvelopeInfo` rejects each (unknown version,
  unknown or non-streaming algorithm, reserved flag bits).
- Stabilize integration timing: wait for the BGSAVE child to start serializing
  before flipping the config (so the algorithm read does not race CONFIG SET);
  wait for the replica to finish loading before comparing digests in the full-sync
  tests; document why the AOF-fallback negative log assertion is only meaningful
  after the positive wait.

### Comments

- `stream_kind` is kept as a parser guard: full-sync replication still carries an
  RDB image and keeps `STREAM_KIND_RDB`, while a future incremental command stream
  would use its own kind and the RDB loader rejects anything that is not
  `STREAM_KIND_RDB`.
- The streaming compression level stays at 0 (codec default) until a codec with a
  wide level range lands.
- `FLUSH_SYNC` is documented as draining the frame without closing it, which RDB
  save does not need but a latency-bound incremental replication stream would.

Out of scope here: whether a primary may send a VKCS stream is a replication
capability-negotiation question (REPLCONF), separate from the envelope, and is left
for the replication work.

Tested: unit `test_compression` (41/41), `integration/rdb-compression` (21/21),
`integration/replication-aof-sync` (7/7), `integration/valkey-check-rdb` (10/10).
