### PR TITLE
rdb: avoid rio tell indirection in check-rdb offset and load progress

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3114,20 +3114,16 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
     /* Event scheduling uses decoded (logical) bytes so that
      * processEventsWhileBlocked() fires based on actual parsing work, even
      * when the stream reader is draining its internal decompressed buffer
-     * without advancing the transport position.
-     *
-     * Progress reporting uses transport bytes for decompression paths so the
-     * loading percentage stays consistent with the file size passed to
-     * startLoadingFile(). */
+     * without advancing the transport position. */
     off_t decoded_pos = (off_t)(r->processed_bytes + len);
-    off_t report_pos = decoded_pos;
-    if (r->flags & RIO_FLAG_STREAMING_DECOMPRESSION) {
-        report_pos = rioTell(r);
-    }
 
     if (server.loading_process_events_interval_bytes &&
         decoded_pos / server.loading_process_events_interval_bytes >
             (off_t)r->processed_bytes / server.loading_process_events_interval_bytes) {
+        /* Progress reporting uses transport bytes for decompression paths so the
+         * loading percentage stays consistent with the file size passed to
+         * startLoadingFile(); plain paths report decoded bytes. */
+        off_t report_pos = (r->flags & RIO_FLAG_STREAMING_DECOMPRESSION) ? rioTell(r) : decoded_pos;
         if (server.primary_host && server.repl_state == REPL_STATE_TRANSFER) replicationSendNewlineToPrimary();
         loadingAbsProgress(report_pos);
         processEventsWhileBlocked();

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -96,10 +96,6 @@ struct {
 
 static unsigned long long rdbCheckOffset(void) {
     if (!rdbstate.rio) return 0;
-
-    off_t pos = rioTell(rdbstate.rio);
-    if (pos >= 0) return (unsigned long long)pos;
-
     return (unsigned long long)rdbstate.rio->processed_bytes;
 }
 


### PR DESCRIPTION
valkey-check-rdb reported offsets via rioTell() on every read, and rdbLoadProgressCallback computed the transport offset via rioTell() on every read even when no progress event was due. Read processed_bytes directly for the offset, and only compute the transport position when a progress event is actually reported.