### PR TITLE
Fold LZ4 streaming into rdbcompression

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -38,7 +38,6 @@
 #include "cluster_migrateslots.h"
 #include "eval.h"
 #include "lrulfu.h"
-#include "compression.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -177,9 +176,10 @@ configEnum rdb_version_check_enum[] = {{"strict", RDB_VERSION_CHECK_STRICT},
                                        {"relaxed", RDB_VERSION_CHECK_RELAXED},
                                        {NULL, 0}};
 
-configEnum rdb_compression_algo_enum[] = {{"lzf", ALGO_LZF},
-                                          {"lz4", ALGO_LZ4},
-                                          {NULL, 0}};
+configEnum rdb_compression_enum[] = {{"no", RDB_COMPRESSION_NO},
+                                     {"yes", RDB_COMPRESSION_YES},
+                                     {"lz4-stream", RDB_COMPRESSION_LZ4_STREAM},
+                                     {NULL, 0}};
 
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
@@ -3277,7 +3277,6 @@ standardConfig static_configs[] = {
     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, server.daemonize, 0, NULL, NULL),
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
-    createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
@@ -3384,7 +3383,7 @@ standardConfig static_configs[] = {
     createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_LEGACY, NULL, NULL),
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
-    createEnumConfig("rdb-compression-algo", NULL, MODIFIABLE_CONFIG, rdb_compression_algo_enum, server.rdb_compression_algo, ALGO_LZF, NULL, NULL),
+    createEnumConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, rdb_compression_enum, server.rdb_compression, RDB_COMPRESSION_YES, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -69,12 +69,6 @@
 /* This macro is called when RDB read failed (possibly a short read) */
 #define rdbReportReadError(...) rdbReportError(0, __LINE__, __VA_ARGS__)
 
-/* Returns true if streaming compression is enabled for RDB saves. */
-static inline bool isRdbStreamingCompressionEnabled(void) {
-    return server.rdb_compression &&
-           compressionAlgoSupportsStreaming((compressionAlgo)server.rdb_compression_algo);
-}
-
 /* This macro tells if we are in the context of a RESTORE command, and not loading an RDB or AOF. */
 #define isRestoreContext() ((server.current_client == NULL || server.current_client->id == CLIENT_ID_AOF) ? 0 : 1)
 
@@ -1570,7 +1564,8 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     int error = 0;
     int saved_errno;
     char *err_op; /* For a detailed log */
-    bool use_streaming_compression = isRdbStreamingCompressionEnabled();
+    compressionAlgo streaming_algo = server.rdb_compression == RDB_COMPRESSION_LZ4_STREAM ? ALGO_LZ4 : ALGO_NONE;
+    bool use_streaming_compression = streaming_algo != ALGO_NONE;
     compressRio cr;
     compressRio *crp = NULL;
 
@@ -1604,7 +1599,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     rio *save_rio = &rdb;
     if (use_streaming_compression) {
         streamWriterConfig cfg = {
-            .algo = (compressionAlgo)server.rdb_compression_algo,
+            .algo = streaming_algo,
             .level = 0, /* Codec default. */
             .stream_kind = STREAM_KIND_RDB,
             .codec_checksum_enabled = server.rdb_checksum != 0,
@@ -1726,9 +1721,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE, "DB saved on disk%s%s",
-              server.rdb_compression ? " with compression: " : "",
-              server.rdb_compression ? compressionAlgoName((compressionAlgo)server.rdb_compression_algo) : "");
+    serverLog(LL_NOTICE, "DB saved on disk%s", server.rdb_compression ? " with compression" : "");
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;

--- a/src/server.h
+++ b/src/server.h
@@ -599,6 +599,10 @@ typedef enum { LOG_TIMESTAMP_LEGACY = 0,
 typedef enum { RDB_VERSION_CHECK_STRICT = 0,
                RDB_VERSION_CHECK_RELAXED } rdb_version_check_type;
 
+typedef enum { RDB_COMPRESSION_NO = 0,
+               RDB_COMPRESSION_YES,
+               RDB_COMPRESSION_LZ4_STREAM } rdb_compression_mode;
+
 /* Structure representing a non-owning view of a buffer.
  * A stringRef struct does not manage the underlying memory, so its destruction
  * will not free the buffer. */
@@ -2043,9 +2047,7 @@ struct valkeyServer {
     struct saveparam *saveparams;         /* Save points array for RDB */
     int saveparamslen;                    /* Number of saving points */
     char *rdb_filename;                   /* Name of RDB file */
-    int rdb_compression;                  /* Use compression in RDB? */
-    int rdb_compression_algo;             /* RDB compression algorithm (compressionAlgo):
-                                           * ALGO_LZF (default), ALGO_LZ4 */
+    int rdb_compression;                  /* RDB compression mode */
     int rdb_checksum;                     /* Use RDB checksum? */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
                                              the instance does not use persistence. */

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -42,8 +42,7 @@ proc assert_rdb_test_dataset {client prefix} {
 start_server {overrides {save "" enable-debug-command local}} {
     test {RDB save and load round-trip with LZ4 compression} {
         set prefix "lz4-round-trip"
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         write_rdb_test_dataset r $prefix
         assert_rdb_test_dataset r $prefix
         set digest [debug_digest]
@@ -52,15 +51,14 @@ start_server {overrides {save "" enable-debug-command local}} {
         r config rewrite
         restart_server 0 true false
 
-        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
         set newdigest [debug_digest]
         assert {$digest eq $newdigest}
         assert_rdb_test_dataset r $prefix
     }
 
     test {Empty LZ4-compressed RDB saves and loads correctly} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
 
         assert_equal 0 [r dbsize]
@@ -70,14 +68,13 @@ start_server {overrides {save "" enable-debug-command local}} {
 
         restart_server 0 true false
 
-        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
         assert_equal 0 [r dbsize]
     }
 
     test {RDB save with LZF (default) round-trips correctly} {
         set prefix "lzf-round-trip"
         r config set rdbcompression yes
-        r config set rdb-compression-algo lzf
         write_rdb_test_dataset r $prefix
         assert_rdb_test_dataset r $prefix
 
@@ -86,7 +83,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         r config rewrite
         restart_server 0 true false
 
-        assert_equal "lzf" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "yes" [lindex [r config get rdbcompression] 1]
         set newdigest [debug_digest]
         assert {$digest eq $newdigest}
         assert_rdb_test_dataset r $prefix
@@ -95,7 +92,6 @@ start_server {overrides {save "" enable-debug-command local}} {
     test {Uncompressed RDB files load correctly (backward compat)} {
         set prefix "plain-rdb"
         r config set rdbcompression no
-        r config set rdb-compression-algo lzf
         write_rdb_test_dataset r $prefix
         assert_rdb_test_dataset r $prefix
 
@@ -111,8 +107,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {LZ4 compressed RDB with large dataset} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         for {set i 0} {$i < 1000} {incr i} {
             r set "bulk:$i" [string repeat "payload:$i " 32]
@@ -125,7 +120,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         r config rewrite
         restart_server 0 true false
 
-        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
         set newdigest [debug_digest]
         assert {$digest eq $newdigest}
         assert_equal [string repeat "payload:42 " 32] [r get bulk:42]
@@ -135,8 +130,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {Changing compression config during active BGSAVE does not affect the in-flight save} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r config set rdb-key-save-delay 10000
         r flushall
         for {set i 0} {$i < 128} {incr i} {
@@ -161,7 +155,7 @@ start_server {overrides {save "" enable-debug-command local}} {
             fail "BGSAVE child did not begin serializing in time"
         }
 
-        r config set rdb-compression-algo lzf
+        r config set rdbcompression yes
 
         wait_for_condition 500 10 {
             [s rdb_bgsave_in_progress] eq 0
@@ -171,30 +165,29 @@ start_server {overrides {save "" enable-debug-command local}} {
         }
         r config set rdb-key-save-delay 0
 
-        assert_equal "lzf" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "yes" [lindex [r config get rdbcompression] 1]
         assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
 
         assert_equal "OK" [r save]
         assert_equal "VALKEY" [string range [read_dump_rdb_header_bytes r] 0 5]
 
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
     }
 
     test {Switching from LZ4 to LZF preserves data} {
         set prefix "lz4-to-lzf"
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         write_rdb_test_dataset r $prefix
         assert_rdb_test_dataset r $prefix
         set digest [debug_digest]
 
         # Save with LZ4, then restart with LZF and load the existing file.
         assert_equal "OK" [r save]
-        r config set rdb-compression-algo lzf
+        r config set rdbcompression yes
         r config rewrite
         restart_server 0 true false
 
-        assert_equal "lzf" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "yes" [lindex [r config get rdbcompression] 1]
         set newdigest [debug_digest]
         assert {$digest eq $newdigest}
         assert_rdb_test_dataset r $prefix
@@ -203,43 +196,39 @@ start_server {overrides {save "" enable-debug-command local}} {
     test {Switching from LZF to LZ4 preserves data} {
         set prefix "lzf-to-lz4"
         r config set rdbcompression yes
-        r config set rdb-compression-algo lzf
         write_rdb_test_dataset r $prefix
         assert_rdb_test_dataset r $prefix
         set digest [debug_digest]
 
         # Save with LZF, then restart with LZ4 and load the existing file.
         assert_equal "OK" [r save]
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r config rewrite
         restart_server 0 true false
 
-        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
         set newdigest [debug_digest]
         assert {$digest eq $newdigest}
         assert_rdb_test_dataset r $prefix
     }
 
-    test {Invalid compression algo config is rejected} {
-        assert_error "*argument(s) must be one of the following: lzf, lz4*" {
-            r config set rdb-compression-algo snappy
+    test {Invalid compression config is rejected} {
+        assert_error "*argument(s) must be one of the following: no, yes, lz4-stream*" {
+            r config set rdbcompression snappy
         }
     }
 
-    test {RDB compression configs survive CONFIG REWRITE and restart} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+    test {RDB compression config survives CONFIG REWRITE and restart} {
+        r config set rdbcompression lz4-stream
         r config rewrite
 
         restart_server 0 true false
 
-        assert_equal "yes" [lindex [r config get rdbcompression] 1]
-        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
     }
 
     test {LZ4 compressed RDB with rdbchecksum yes sets the VKCS codec checksum flag} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         for {set i 0} {$i < 200} {incr i} {
             r set "cksum:$i" [string repeat "payload$i " 200]
@@ -259,8 +248,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {Truncated VKCS snapshot is rejected on load} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         set noisy_payload ""
         for {set j 0} {$j < 32768} {incr j} {
@@ -285,8 +273,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {LZ4 compressed RDB detects tail corruption when codec checksums are enabled} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         assert_equal "yes" [lindex [r config get rdbchecksum] 1]
         r flushall
         for {set i 0} {$i < 100} {incr i} {
@@ -306,8 +293,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {LZ4 compressed RDB with REPL stream kind is rejected} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         r set wrong-kind:key [string repeat "payload " 100]
 
@@ -328,8 +314,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {LZ4 compressed RDB detects corruption in compressed payload} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         for {set i 0} {$i < 100} {incr i} {
             r set "corrupt:$i" [string repeat "testdata$i " 100]
@@ -362,8 +347,7 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 
     test {Invalid non-VKCS/non-RDB file fails reload} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         r set smoke-key smoke-value
 
@@ -380,16 +364,15 @@ start_server {overrides {save "" enable-debug-command local}} {
     }
 }
 
-start_server {config "minimal.conf" args {"--rdb-compression-algo lz4"}} {
+start_server {config "minimal.conf" args {"--rdbcompression lz4-stream"}} {
     test {Startup accepts valid LZ4 compression config} {
-        assert_equal "lz4" [lindex [r config get rdb-compression-algo] 1]
+        assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
     }
 }
 
 start_server {overrides {save "" enable-debug-command local rdbchecksum no}} {
     test {LZ4 compressed RDB with rdbchecksum no leaves VKCS flags clear and loads correctly} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         r flushall
         for {set i 0} {$i < 50} {incr i} {
             r set "nocksum:$i" [string repeat "data$i " 100]
@@ -420,8 +403,7 @@ start_server {tags {"rdb-compression repl external:skip"}} {
         set primary_port [srv 0 port]
 
         test {Disk-based full sync replication works with LZ4-compressed RDB snapshot} {
-            $primary config set rdbcompression yes
-            $primary config set rdb-compression-algo lz4
+            $primary config set rdbcompression lz4-stream
             $primary flushall
             for {set i 0} {$i < 500} {incr i} {
                 $primary set "repl:$i" [string repeat "payload$i " 40]
@@ -451,7 +433,7 @@ start_server {tags {"rdb-compression repl external:skip"}} {
             }
         }
 
-        test {Diskless full sync remains compatible when rdb-compression-algo is lz4} {
+        test {Diskless full sync remains compatible when rdbcompression is lz4-stream} {
             $replica replicaof no one
             $primary config set repl-diskless-sync yes
             $primary config set repl-diskless-sync-delay 0
@@ -486,8 +468,7 @@ start_server {tags {"rdb-compression repl external:skip"}} {
 set cluster_bus_port [find_available_port $::baseport $::portcount]
 start_server [list tags {"rdb-compression cluster external:skip singledb"} overrides [list save "" cluster-enabled yes cluster-port $cluster_bus_port]] {
     test {RDB compression config works in cluster mode} {
-        r config set rdbcompression yes
-        r config set rdb-compression-algo lz4
+        r config set rdbcompression lz4-stream
         assert_equal "OK" [r cluster addslotsrange 0 16383]
         wait_for_condition 50 100 {
             [getInfoProperty [r cluster info] cluster_state] eq "ok"

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -165,7 +165,7 @@ tags {"repl external:skip"} {
     }
 
     test "Replica restart falls back to bgrewriteaof when synced RDB uses streaming compression" {
-        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save "" rdb-compression-algo lz4}} {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save "" rdbcompression lz4-stream}} {
             set primary [srv 0 client]
             set primary_host [srv 0 host]
             set primary_port [srv 0 port]

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -51,8 +51,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
     start_server {} {
         test "test valkey-check-rdb validates LZ4-compressed RDB frame" {
             r flushall
-            r config set rdbcompression yes
-            r config set rdb-compression-algo lz4
+            r config set rdbcompression lz4-stream
             r set lz4:key [string repeat "payload " 200]
             r save
 
@@ -65,7 +64,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             assert_no_match {*Checksum OK*} $result
 
             # Keep subsequent tests on default path unless they explicitly change it.
-            r config set rdb-compression-algo lzf
+            r config set rdbcompression yes
         }
 
         test "test valkey-check-rdb stats with empty RDB" {
@@ -166,8 +165,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
     start_server {overrides {save "" rdbchecksum no}} {
         test "test valkey-check-rdb reports checksum-disabled compressed RDBs accurately" {
             r flushall
-            r config set rdbcompression yes
-            r config set rdb-compression-algo lz4
+            r config set rdbcompression lz4-stream
             r set lz4:no-cksum [string repeat "payload " 200]
             r save
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -589,27 +589,26 @@ locale-collate ""
 # permissions, and so forth.
 stop-writes-on-bgsave-error yes
 
-# Compress string objects using LZF when dump .rdb databases?
-# By default compression is enabled as it's almost always a win.
-# If you want to save some CPU in the saving child set it to 'no' but
-# the dataset will likely be bigger if you have compressible values or keys.
-rdbcompression yes
-
-# Select the compression algorithm used when rdbcompression is enabled.
+# Compress string objects when dumping .rdb databases?
 # Supported values:
-#   lzf  - legacy/default per-string compression inside the RDB payload
-#   lz4  - streaming LZ4 frame compression for the entire RDB file
+#   yes        - legacy/default per-string LZF compression inside the RDB payload
+#   no         - no RDB compression
+#   lz4-stream - streaming LZ4 frame compression for the entire RDB file.
+#                RDB files written with this value can be loaded only by Valkey
+#                versions that support streaming RDB compression. Older versions
+#                do not understand the outer compression envelope and will fail
+#                before reading the payload, usually with a "Wrong signature"
+#                load error.
 #
-# RDB files written with lz4 can be loaded only by Valkey versions that
-# support streaming RDB compression. The logical RDB payload keeps its normal
-# RDB version; an outer streaming compression envelope carries the compression
-# format version. Older versions do not understand that envelope and will fail
-# before reading the payload, usually with a "Wrong signature" load error.
 # Before downgrading or introducing an older replica, rewrite the snapshot in
 # the legacy format:
-#   CONFIG SET rdb-compression-algo lzf
+#   CONFIG SET rdbcompression yes
 #   SAVE
-rdb-compression-algo lzf
+#
+# By default compression is enabled as it's almost always a win. If you want to
+# save some CPU in the saving child set it to 'no' but the dataset will likely
+# be bigger if you have compressible values or keys.
+rdbcompression yes
 
 # Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
 # This makes the format more resistant to corruption but there is a performance


### PR DESCRIPTION
## Summary

Addresses the PR #3531 review feedback to keep the RDB compression selection in one config.

- Replaces the separate `rdb-compression-algo` config with `rdbcompression no|yes|lz4-stream`.
- Keeps `yes` as the legacy/default per-string LZF path and uses `lz4-stream` for whole-file streaming LZ4 RDB saves.
- Updates `valkey.conf` and the RDB compression/check-rdb/replication AOF sync tests to use the new config value.

## Validation

- `make -j4`
- `./runtest --single tests/integration/rdb-compression.tcl`
- `./runtest --single tests/integration/valkey-check-rdb.tcl`
- `./runtest --single tests/integration/replication-aof-sync.tcl`
- `git diff --check`

`make -C src test-unit` was attempted but the local environment is missing `pkg-config` and googletest (`googletest not found. Install gtest or set GTEST_CFLAGS/GTEST_LIBS explicitly.`).