### PR TITLE
Rename streaming compression envelope to VCS

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1007,7 +1007,7 @@ int startAppendOnly(void) {
 }
 
 static int rdbFileUsesStreamingCompression(const char *filename) {
-    unsigned char header[VKCS_ENVELOPE_SIZE];
+    unsigned char header[VCS_ENVELOPE_SIZE];
     int fd = open(filename, O_RDONLY);
     if (fd == -1) return -1;
 

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -10,32 +10,31 @@
 #include <limits.h>
 #include <string.h>
 
-/* ===== VKCS envelope ===== */
+/* ===== VCS envelope ===== */
 
-static const uint8_t VKCS_MAGIC[VKCS_MAGIC_SIZE] = {
-    VKCS_MAGIC_0,
-    VKCS_MAGIC_1,
-    VKCS_MAGIC_2,
-    VKCS_MAGIC_3,
+static const uint8_t VCS_MAGIC[VCS_MAGIC_SIZE] = {
+    VCS_MAGIC_0,
+    VCS_MAGIC_1,
+    VCS_MAGIC_2,
 };
 
-/* True when the first len bytes of buf match the VKCS magic. When len is below
- * VKCS_MAGIC_SIZE this only compares that prefix. */
-static bool vkcsHasMagicPrefix(const uint8_t *buf, size_t len) {
-    size_t n = len < VKCS_MAGIC_SIZE ? len : VKCS_MAGIC_SIZE;
-    return memcmp(buf, VKCS_MAGIC, n) == 0;
+/* True when the first len bytes of buf match the VCS magic. When len is below
+ * VCS_MAGIC_SIZE this only compares that prefix. */
+static bool vcsHasMagicPrefix(const uint8_t *buf, size_t len) {
+    size_t n = len < VCS_MAGIC_SIZE ? len : VCS_MAGIC_SIZE;
+    return memcmp(buf, VCS_MAGIC, n) == 0;
 }
 
 typedef enum {
-    VKCS_PROBE_NEED_INPUT = 0,
-    VKCS_PROBE_PASSTHROUGH = 1,
-    VKCS_PROBE_COMPRESSED = 2,
-    VKCS_PROBE_ERROR = 3,
-} vkcsProbeResult;
+    VCS_PROBE_NEED_INPUT = 0,
+    VCS_PROBE_PASSTHROUGH = 1,
+    VCS_PROBE_COMPRESSED = 2,
+    VCS_PROBE_ERROR = 3,
+} vcsProbeResult;
 
 static bool streamReaderProbeHasMagicPrefix(streamReader *reader) {
     if (reader->probe.header_len == 0) return false;
-    return vkcsHasMagicPrefix(reader->probe.header, reader->probe.header_len);
+    return vcsHasMagicPrefix(reader->probe.header, reader->probe.header_len);
 }
 
 static void streamReaderProbeSetPassthrough(streamReader *reader) {
@@ -57,47 +56,46 @@ static void streamReaderProbeSetCompressed(streamReader *reader,
     reader->probe.stream_kind = stream_kind;
 }
 
-static int writeVkcsEnvelope(streamWriterEmitFn emit_fn,
-                             void *ctx,
-                             compressionAlgo algo,
-                             uint8_t stream_kind,
-                             bool codec_checksum_enabled) {
+static int writeVcsEnvelope(streamWriterEmitFn emit_fn,
+                            void *ctx,
+                            compressionAlgo algo,
+                            uint8_t stream_kind,
+                            bool codec_checksum_enabled) {
     if (!compressionAlgoSupportsStreaming(algo)) return -1;
 
-    uint8_t envelope[VKCS_ENVELOPE_SIZE] = {
-        VKCS_MAGIC_0,
-        VKCS_MAGIC_1,
-        VKCS_MAGIC_2,
-        VKCS_MAGIC_3,
-        [VKCS_OFFSET_VERSION] = VKCS_VERSION,
-        [VKCS_OFFSET_ALGO] = (uint8_t)algo,
-        [VKCS_OFFSET_FLAGS] = codec_checksum_enabled ? VKCS_FLAG_CODEC_CHECKSUM : 0,
-        [VKCS_OFFSET_STREAM_KIND] = stream_kind,
+    uint8_t envelope[VCS_ENVELOPE_SIZE] = {
+        VCS_MAGIC_0,
+        VCS_MAGIC_1,
+        VCS_MAGIC_2,
+        [VCS_OFFSET_VERSION] = VCS_VERSION,
+        [VCS_OFFSET_ALGO] = (uint8_t)algo,
+        [VCS_OFFSET_FLAGS] = codec_checksum_enabled ? VCS_FLAG_CODEC_CHECKSUM : 0,
+        [VCS_OFFSET_STREAM_KIND] = stream_kind,
     };
-    return emit_fn(ctx, envelope, VKCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
+    return emit_fn(ctx, envelope, VCS_ENVELOPE_SIZE) == 0 ? 0 : -1;
 }
 
 /* Rejects unknown flag bits so a future format extension fails loud rather
  * than silently corrupting load. */
-static int readVkcsEnvelope(const uint8_t *buf,
-                            size_t len,
-                            compressionAlgo *algo,
-                            uint8_t *stream_kind,
-                            bool *codec_checksum_enabled) {
-    if (len < VKCS_ENVELOPE_SIZE) return -1;
+static int readVcsEnvelope(const uint8_t *buf,
+                           size_t len,
+                           compressionAlgo *algo,
+                           uint8_t *stream_kind,
+                           bool *codec_checksum_enabled) {
+    if (len < VCS_ENVELOPE_SIZE) return -1;
 
-    if (!vkcsHasMagicPrefix(buf, VKCS_MAGIC_SIZE)) return -1;
-    if (buf[VKCS_OFFSET_VERSION] != VKCS_VERSION) return -1;
+    if (!vcsHasMagicPrefix(buf, VCS_MAGIC_SIZE)) return -1;
+    if (buf[VCS_OFFSET_VERSION] != VCS_VERSION) return -1;
 
-    compressionAlgo parsed_algo = (compressionAlgo)buf[VKCS_OFFSET_ALGO];
+    compressionAlgo parsed_algo = (compressionAlgo)buf[VCS_OFFSET_ALGO];
     if (!compressionAlgoSupportsStreaming(parsed_algo)) return -1;
 
-    uint8_t flags = buf[VKCS_OFFSET_FLAGS];
-    if (flags & ~VKCS_FLAG_CODEC_CHECKSUM) return -1;
+    uint8_t flags = buf[VCS_OFFSET_FLAGS];
+    if (flags & ~VCS_FLAG_CODEC_CHECKSUM) return -1;
 
     if (algo) *algo = parsed_algo;
-    if (stream_kind) *stream_kind = buf[VKCS_OFFSET_STREAM_KIND];
-    if (codec_checksum_enabled) *codec_checksum_enabled = (flags & VKCS_FLAG_CODEC_CHECKSUM) != 0;
+    if (stream_kind) *stream_kind = buf[VCS_OFFSET_STREAM_KIND];
+    if (codec_checksum_enabled) *codec_checksum_enabled = (flags & VCS_FLAG_CODEC_CHECKSUM) != 0;
     return 0;
 }
 
@@ -109,8 +107,8 @@ int streamReadEnvelopeInfo(const uint8_t *buf,
     bool codec_checksum_enabled = false;
     compressionAlgo algo = ALGO_NONE;
 
-    if (len < VKCS_ENVELOPE_SIZE ||
-        readVkcsEnvelope(buf, len, &algo, &stream_kind, &codec_checksum_enabled) != 0 ||
+    if (len < VCS_ENVELOPE_SIZE ||
+        readVcsEnvelope(buf, len, &algo, &stream_kind, &codec_checksum_enabled) != 0 ||
         stream_kind != expected_stream_kind) {
         return -1;
     }
@@ -122,10 +120,10 @@ int streamReadEnvelopeInfo(const uint8_t *buf,
     return 0;
 }
 
-/* Incremental: wrapped rios may legally return fewer than VKCS_ENVELOPE_SIZE
+/* Incremental: wrapped rios may legally return fewer than VCS_ENVELOPE_SIZE
  * bytes per read. Consumed bytes are retained in probe->header so passthrough
  * can replay them exactly. */
-static vkcsProbeResult streamReaderProbeFeed(streamReader *reader,
+static vcsProbeResult streamReaderProbeFeed(streamReader *reader,
                                              const uint8_t *src,
                                              size_t src_len,
                                              bool input_eof,
@@ -133,11 +131,11 @@ static vkcsProbeResult streamReaderProbeFeed(streamReader *reader,
     size_t consumed = 0;
     *src_consumed = 0;
     if (reader->probe.ready) {
-        return reader->probe.compressed ? VKCS_PROBE_COMPRESSED : VKCS_PROBE_PASSTHROUGH;
+        return reader->probe.compressed ? VCS_PROBE_COMPRESSED : VCS_PROBE_PASSTHROUGH;
     }
 
     while (consumed < src_len) {
-        size_t target = reader->probe.header_len < VKCS_MAGIC_SIZE ? VKCS_MAGIC_SIZE : VKCS_ENVELOPE_SIZE;
+        size_t target = reader->probe.header_len < VCS_MAGIC_SIZE ? VCS_MAGIC_SIZE : VCS_ENVELOPE_SIZE;
         size_t need = target - reader->probe.header_len;
         size_t take = src_len - consumed < need ? src_len - consumed : need;
 
@@ -145,38 +143,38 @@ static vkcsProbeResult streamReaderProbeFeed(streamReader *reader,
         reader->probe.header_len += take;
         consumed += take;
 
-        if (reader->probe.header_len >= VKCS_MAGIC_SIZE && !vkcsHasMagicPrefix(reader->probe.header, VKCS_MAGIC_SIZE)) {
+        if (reader->probe.header_len >= VCS_MAGIC_SIZE && !vcsHasMagicPrefix(reader->probe.header, VCS_MAGIC_SIZE)) {
             *src_consumed = consumed;
-            if (!reader->probe_cfg.allow_passthrough) return VKCS_PROBE_ERROR;
+            if (!reader->probe_cfg.allow_passthrough) return VCS_PROBE_ERROR;
             streamReaderProbeSetPassthrough(reader);
-            return VKCS_PROBE_PASSTHROUGH;
+            return VCS_PROBE_PASSTHROUGH;
         }
 
-        if (reader->probe.header_len == VKCS_ENVELOPE_SIZE) {
+        if (reader->probe.header_len == VCS_ENVELOPE_SIZE) {
             streamReaderInfo info = {0};
-            if (streamReadEnvelopeInfo(reader->probe.header, VKCS_ENVELOPE_SIZE,
+            if (streamReadEnvelopeInfo(reader->probe.header, VCS_ENVELOPE_SIZE,
                                        reader->probe_cfg.expected_stream_kind, &info) != 0) {
                 *src_consumed = consumed;
-                return VKCS_PROBE_ERROR;
+                return VCS_PROBE_ERROR;
             }
             streamReaderProbeSetCompressed(reader, info.algo, info.stream_kind,
                                            info.codec_checksum_enabled);
             *src_consumed = consumed;
-            return VKCS_PROBE_COMPRESSED;
+            return VCS_PROBE_COMPRESSED;
         }
     }
 
     if (input_eof) {
         *src_consumed = consumed;
-        /* EOF mid-magic looks like a truncated VKCS, not a valid passthrough. */
-        if (streamReaderProbeHasMagicPrefix(reader)) return VKCS_PROBE_ERROR;
-        if (!reader->probe_cfg.allow_passthrough) return VKCS_PROBE_ERROR;
+        /* EOF mid-magic looks like a truncated VCS, not a valid passthrough. */
+        if (streamReaderProbeHasMagicPrefix(reader)) return VCS_PROBE_ERROR;
+        if (!reader->probe_cfg.allow_passthrough) return VCS_PROBE_ERROR;
         streamReaderProbeSetPassthrough(reader);
-        return VKCS_PROBE_PASSTHROUGH;
+        return VCS_PROBE_PASSTHROUGH;
     }
 
     *src_consumed = consumed;
-    return VKCS_PROBE_NEED_INPUT;
+    return VCS_PROBE_NEED_INPUT;
 }
 
 /* ===== Streaming writer ===== */
@@ -200,12 +198,12 @@ int streamWriterInit(streamWriter *writer, streamWriterConfig *cfg, streamWriter
  * doesn't leave a stub envelope on the sink. */
 static int streamWriterEnsureEnvelope(streamWriter *writer) {
     if (writer->envelope_written) return 0;
-    if (writeVkcsEnvelope(writer->emit_fn, writer->emit_ctx, writer->compressor.algo,
+    if (writeVcsEnvelope(writer->emit_fn, writer->emit_ctx, writer->compressor.algo,
                           writer->stream_kind, writer->compressor.codec_checksum) != 0) {
         writer->errored = true;
         return -1;
     }
-    writer->bytes_emitted += VKCS_ENVELOPE_SIZE;
+    writer->bytes_emitted += VCS_ENVELOPE_SIZE;
     writer->envelope_written = true;
     return 0;
 }
@@ -365,8 +363,8 @@ int streamReaderInit(streamReader *reader, streamReaderConfig *cfg, streamReader
 }
 
 static size_t streamReaderProbeBytesNeeded(streamReader *reader) {
-    if (reader->probe.header_len < VKCS_MAGIC_SIZE) return VKCS_MAGIC_SIZE - reader->probe.header_len;
-    return VKCS_ENVELOPE_SIZE - reader->probe.header_len;
+    if (reader->probe.header_len < VCS_MAGIC_SIZE) return VCS_MAGIC_SIZE - reader->probe.header_len;
+    return VCS_ENVELOPE_SIZE - reader->probe.header_len;
 }
 
 int streamReaderProbe(streamReader *reader) {
@@ -374,7 +372,7 @@ int streamReaderProbe(streamReader *reader) {
     if (reader->probe.ready) return 0;
 
     while (!reader->probe.ready) {
-        uint8_t buf[VKCS_ENVELOPE_SIZE];
+        uint8_t buf[VCS_ENVELOPE_SIZE];
         size_t need = streamReaderProbeBytesNeeded(reader);
         ssize_t got = reader->read_cb(reader->read_ctx, buf, need);
         size_t consumed = 0;
@@ -384,23 +382,23 @@ int streamReaderProbe(streamReader *reader) {
             return -1;
         }
 
-        vkcsProbeResult status = streamReaderProbeFeed(reader, buf,
+        vcsProbeResult status = streamReaderProbeFeed(reader, buf,
                                                        got > 0 ? (size_t)got : 0,
                                                        got == 0, &consumed);
         switch (status) {
-        case VKCS_PROBE_ERROR:
+        case VCS_PROBE_ERROR:
             streamReaderSetError(reader, STREAM_READER_ERROR_INCOMPATIBLE);
             return -1;
-        case VKCS_PROBE_NEED_INPUT:
+        case VCS_PROBE_NEED_INPUT:
             continue;
-        case VKCS_PROBE_COMPRESSED:
+        case VCS_PROBE_COMPRESSED:
             if (!reader->decompressor_initialized &&
                 streamReaderInitCompressedState(reader, reader->buffer_size) != 0) {
                 streamReaderSetError(reader, STREAM_READER_ERROR_IO);
                 return -1;
             }
             break;
-        case VKCS_PROBE_PASSTHROUGH:
+        case VCS_PROBE_PASSTHROUGH:
             break;
         default:
             streamReaderSetError(reader, STREAM_READER_ERROR_INCOMPATIBLE);

--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -124,10 +124,10 @@ int streamReadEnvelopeInfo(const uint8_t *buf,
  * bytes per read. Consumed bytes are retained in probe->header so passthrough
  * can replay them exactly. */
 static vcsProbeResult streamReaderProbeFeed(streamReader *reader,
-                                             const uint8_t *src,
-                                             size_t src_len,
-                                             bool input_eof,
-                                             size_t *src_consumed) {
+                                            const uint8_t *src,
+                                            size_t src_len,
+                                            bool input_eof,
+                                            size_t *src_consumed) {
     size_t consumed = 0;
     *src_consumed = 0;
     if (reader->probe.ready) {
@@ -199,7 +199,7 @@ int streamWriterInit(streamWriter *writer, streamWriterConfig *cfg, streamWriter
 static int streamWriterEnsureEnvelope(streamWriter *writer) {
     if (writer->envelope_written) return 0;
     if (writeVcsEnvelope(writer->emit_fn, writer->emit_ctx, writer->compressor.algo,
-                          writer->stream_kind, writer->compressor.codec_checksum) != 0) {
+                         writer->stream_kind, writer->compressor.codec_checksum) != 0) {
         writer->errored = true;
         return -1;
     }
@@ -383,8 +383,8 @@ int streamReaderProbe(streamReader *reader) {
         }
 
         vcsProbeResult status = streamReaderProbeFeed(reader, buf,
-                                                       got > 0 ? (size_t)got : 0,
-                                                       got == 0, &consumed);
+                                                      got > 0 ? (size_t)got : 0,
+                                                      got == 0, &consumed);
         switch (status) {
         case VCS_PROBE_ERROR:
             streamReaderSetError(reader, STREAM_READER_ERROR_INCOMPATIBLE);

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -9,29 +9,28 @@
 
 #include "compression.h"
 
-/* VKCS envelope:
- *   [0..3] magic "VKCS"
- *   [4]    version (currently VKCS_VERSION)
- *   [5]    codec id
- *   [6]    flags (bit 0 = codec checksum enabled; other bits reserved)
- *   [7]    stream kind
+/* VCS envelope:
+ *   [0..2] magic "VCS"
+ *   [3]    version (currently VCS_VERSION)
+ *   [4]    codec id
+ *   [5]    flags (bit 0 = codec checksum enabled; other bits reserved)
+ *   [6]    stream kind
  *
  * All fields are single-byte in version 1. Future multi-byte fields must use
  * network byte order. */
-#define VKCS_MAGIC_0 0x56 /* 'V' */
-#define VKCS_MAGIC_1 0x4B /* 'K' */
-#define VKCS_MAGIC_2 0x43 /* 'C' */
-#define VKCS_MAGIC_3 0x53 /* 'S' */
-#define VKCS_MAGIC_SIZE 4
-#define VKCS_ENVELOPE_SIZE 8
-#define VKCS_VERSION 1
-#define VKCS_FLAG_CODEC_CHECKSUM (1 << 0)
+#define VCS_MAGIC_0 0x56 /* 'V' */
+#define VCS_MAGIC_1 0x43 /* 'C' */
+#define VCS_MAGIC_2 0x53 /* 'S' */
+#define VCS_MAGIC_SIZE 3
+#define VCS_ENVELOPE_SIZE 7
+#define VCS_VERSION 1
+#define VCS_FLAG_CODEC_CHECKSUM (1 << 0)
 
 /* Byte offsets of each envelope field. */
-#define VKCS_OFFSET_VERSION 4
-#define VKCS_OFFSET_ALGO 5
-#define VKCS_OFFSET_FLAGS 6
-#define VKCS_OFFSET_STREAM_KIND 7
+#define VCS_OFFSET_VERSION 3
+#define VCS_OFFSET_ALGO 4
+#define VCS_OFFSET_FLAGS 5
+#define VCS_OFFSET_STREAM_KIND 6
 
 /* Identifies what the compressed bytes decode to. The RDB loader rejects any
  * stream whose kind is not STREAM_KIND_RDB. */
@@ -56,7 +55,7 @@ typedef struct {
     bool codec_checksum_enabled;
 } streamWriterConfig;
 
-/* When allow_passthrough is set, non-VKCS input is forwarded as raw bytes;
+/* When allow_passthrough is set, non-VCS input is forwarded as raw bytes;
  * otherwise it is rejected. */
 typedef struct {
     uint8_t expected_stream_kind;
@@ -100,13 +99,13 @@ typedef struct streamReader {
         uint8_t expected_stream_kind;
     } probe_cfg;
     struct {
-        uint8_t header[VKCS_ENVELOPE_SIZE];
+        uint8_t header[VCS_ENVELOPE_SIZE];
+        uint8_t stream_kind;
         size_t header_len;
+        compressionAlgo algo;
         bool ready;
         bool compressed;
         bool codec_checksum_enabled;
-        compressionAlgo algo;
-        uint8_t stream_kind;
     } probe;
     size_t probe_replay_pos; /* Passthrough bytes left to replay from probe. */
     size_t buffer_size;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1613,7 +1613,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
         save_rio = (rio *)crp;
     }
     /* Streaming-compressed RDBs use the frame checksum policy recorded in the
-     * VKCS envelope instead of the logical RDB CRC64 trailer. */
+     * VCS envelope instead of the logical RDB CRC64 trailer. */
     if (use_streaming_compression || !server.rdb_checksum) {
         save_rio->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
         save_rio->update_cksum = NULL;
@@ -3147,7 +3147,7 @@ decompressRioInitResult rdbInputStreamPrepare(rdbInputStream *input) {
     if (init_rc == DECOMPRESS_RIO_INIT_OK) {
         input->initialized = true;
         input->rdb_rio = (rio *)&input->decompressor;
-        /* The VKCS frame carries its own checksum policy, so there is no
+        /* The VCS frame carries its own checksum policy, so there is no
          * logical RDB CRC64 to validate over the decoded stream. */
         if (input->stream_info.compressed) input->rdb_rio->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
     }

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -346,11 +346,10 @@ TEST_F(CompressionTest, streamCompressorFeedErrorRecovery) {
 
 TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
     static const uint8_t plain_input[] = {'H', 'E', 'L', 'L', 'O'};
-    static const uint8_t truncated_vkcs[] = {'V', 'K', 'C'};
-    static const uint8_t invalid_vkcs[VKCS_ENVELOPE_SIZE] = {
-        VKCS_MAGIC_0, VKCS_MAGIC_1, VKCS_MAGIC_2, VKCS_MAGIC_3,
-        0, ALGO_LZ4, 0, STREAM_KIND_RDB};
-    static const uint8_t strict_non_vkcs[VKCS_ENVELOPE_SIZE] = {'R', 'E', 'D', 'I', 'S', '0', '0', '1'};
+    static const uint8_t truncated_vcs[] = {'V', 'C'};
+    static const uint8_t invalid_vcs[VCS_ENVELOPE_SIZE] = {
+        VCS_MAGIC_0, VCS_MAGIC_1, VCS_MAGIC_2, 0, ALGO_LZ4, 0, STREAM_KIND_RDB};
+    static const uint8_t strict_non_vcs[VCS_ENVELOPE_SIZE] = {'R', 'E', 'D', 'I', 'S', '0', '0'};
 
     struct {
         const char *name;
@@ -370,25 +369,25 @@ TEST_F(CompressionTest, streamReaderClassifiesProbeInputs) {
          true,
          STREAM_READER_ERROR_NONE,
          sizeof(plain_input)},
-        {"truncated VKCS prefix",
-         truncated_vkcs,
-         sizeof(truncated_vkcs),
+        {"truncated VCS prefix",
+         truncated_vcs,
+         sizeof(truncated_vcs),
          2,
          true,
          false,
          STREAM_READER_ERROR_INCOMPATIBLE,
          0},
-        {"invalid VKCS envelope",
-         invalid_vkcs,
-         sizeof(invalid_vkcs),
+        {"invalid VCS envelope",
+         invalid_vcs,
+         sizeof(invalid_vcs),
          0,
          true,
          false,
          STREAM_READER_ERROR_INCOMPATIBLE,
          0},
-        {"non-VKCS with passthrough disabled",
-         strict_non_vkcs,
-         sizeof(strict_non_vkcs),
+        {"non-VCS with passthrough disabled",
+         strict_non_vcs,
+         sizeof(strict_non_vcs),
          0,
          false,
          false,
@@ -485,7 +484,7 @@ static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
     return db->data != nullptr ? 0 : -1;
 }
 
-static int initVkcsRdbDecompressRio(decompressRio *dr, rio *inner) {
+static int initVcsRdbDecompressRio(decompressRio *dr, rio *inner) {
     streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false);
     return rioInitWithDecompression(dr, inner, &cfg, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
@@ -591,43 +590,43 @@ TEST_F(CompressionTest, streamReadEnvelopeInfoRejectsBadEnvelopes) {
     ASSERT_EQ(streamWriterFinish(&w), 0);
     streamWriterFree(&w);
 
-    ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
+    ASSERT_GE(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE);
 
-    uint8_t good[VKCS_ENVELOPE_SIZE];
-    memcpy(good, db.data, VKCS_ENVELOPE_SIZE);
+    uint8_t good[VCS_ENVELOPE_SIZE];
+    memcpy(good, db.data, VCS_ENVELOPE_SIZE);
     dynamicBufFree(&db);
 
     streamReaderInfo info;
 
     /* Sanity: the unmodified envelope parses. */
-    ASSERT_EQ(streamReadEnvelopeInfo(good, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), 0);
+    ASSERT_EQ(streamReadEnvelopeInfo(good, VCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), 0);
 
     /* Unknown version. */
-    uint8_t bad_version[VKCS_ENVELOPE_SIZE];
-    memcpy(bad_version, good, VKCS_ENVELOPE_SIZE);
-    bad_version[VKCS_OFFSET_VERSION] = VKCS_VERSION + 1;
-    ASSERT_EQ(streamReadEnvelopeInfo(bad_version, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+    uint8_t bad_version[VCS_ENVELOPE_SIZE];
+    memcpy(bad_version, good, VCS_ENVELOPE_SIZE);
+    bad_version[VCS_OFFSET_VERSION] = VCS_VERSION + 1;
+    ASSERT_EQ(streamReadEnvelopeInfo(bad_version, VCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
         << "future version must be rejected";
 
     /* Unknown / non-streaming codec id. */
-    uint8_t bad_algo[VKCS_ENVELOPE_SIZE];
-    memcpy(bad_algo, good, VKCS_ENVELOPE_SIZE);
-    bad_algo[VKCS_OFFSET_ALGO] = 0x7f;
-    ASSERT_EQ(streamReadEnvelopeInfo(bad_algo, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+    uint8_t bad_algo[VCS_ENVELOPE_SIZE];
+    memcpy(bad_algo, good, VCS_ENVELOPE_SIZE);
+    bad_algo[VCS_OFFSET_ALGO] = 0x7f;
+    ASSERT_EQ(streamReadEnvelopeInfo(bad_algo, VCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
         << "unknown codec id must be rejected";
 
     /* LZF is a real algorithm but has no streaming codec. */
-    uint8_t lzf_algo[VKCS_ENVELOPE_SIZE];
-    memcpy(lzf_algo, good, VKCS_ENVELOPE_SIZE);
-    lzf_algo[VKCS_OFFSET_ALGO] = (uint8_t)ALGO_LZF;
-    ASSERT_EQ(streamReadEnvelopeInfo(lzf_algo, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+    uint8_t lzf_algo[VCS_ENVELOPE_SIZE];
+    memcpy(lzf_algo, good, VCS_ENVELOPE_SIZE);
+    lzf_algo[VCS_OFFSET_ALGO] = (uint8_t)ALGO_LZF;
+    ASSERT_EQ(streamReadEnvelopeInfo(lzf_algo, VCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
         << "non-streaming algorithm must be rejected";
 
     /* Reserved flag bit set. */
-    uint8_t bad_flags[VKCS_ENVELOPE_SIZE];
-    memcpy(bad_flags, good, VKCS_ENVELOPE_SIZE);
-    bad_flags[VKCS_OFFSET_FLAGS] |= (1 << 1);
-    ASSERT_EQ(streamReadEnvelopeInfo(bad_flags, VKCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
+    uint8_t bad_flags[VCS_ENVELOPE_SIZE];
+    memcpy(bad_flags, good, VCS_ENVELOPE_SIZE);
+    bad_flags[VCS_OFFSET_FLAGS] |= (1 << 1);
+    ASSERT_EQ(streamReadEnvelopeInfo(bad_flags, VCS_ENVELOPE_SIZE, STREAM_KIND_RDB, &info), -1)
         << "reserved flag bits must be rejected";
 }
 
@@ -681,7 +680,7 @@ TEST_F(CompressionTest, streamReaderPartialThenErrorSetsErrored) {
 
     /* Passthrough mode should also preserve partial bytes when source read
      * fails after probe/prefix buffering, then latch sticky error state. */
-    const uint8_t plain[] = "NOTVKCS-passthrough-regression";
+    const uint8_t plain[] = "NOTVCS-passthrough-regression";
     FlakyReader fr_passthrough = {};
     fr_passthrough.data = plain;
     fr_passthrough.len = sizeof(plain) - 1;
@@ -745,23 +744,22 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
     size_t data_len = strlen(test_data);
     ASSERT_GE(streamWriterWrite(&t, test_data, data_len), 0);
     ASSERT_EQ(t.errored, false) << "should not be errored after write";
-    ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE) << "write should emit envelope";
+    ASSERT_GE(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE) << "write should emit envelope";
 
     /* Finalize */
     ASSERT_EQ(streamWriterFinish(&t), 0);
     ASSERT_EQ(t.errored, false) << "should not be errored after finish";
 
-    /* Verify output starts with VKCS envelope */
-    ASSERT_GE(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE)
+    /* Verify output starts with VCS envelope */
+    ASSERT_GE(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE)
         << "output should have at least envelope size";
-    ASSERT_EQ(db.data[0], VKCS_MAGIC_0) << "magic byte 0";
-    ASSERT_EQ(db.data[1], VKCS_MAGIC_1) << "magic byte 1";
-    ASSERT_EQ(db.data[2], VKCS_MAGIC_2) << "magic byte 2";
-    ASSERT_EQ(db.data[3], VKCS_MAGIC_3) << "magic byte 3";
-    ASSERT_EQ(db.data[4], VKCS_VERSION) << "version";
-    ASSERT_EQ(db.data[5], ALGO_LZ4) << "algo id";
-    ASSERT_EQ(db.data[6], (uint8_t)0) << "flags should be clear when checksum is disabled";
-    ASSERT_EQ(db.data[7], STREAM_KIND_RDB) << "stream_kind RDB";
+    ASSERT_EQ(db.data[0], VCS_MAGIC_0) << "magic byte 0";
+    ASSERT_EQ(db.data[1], VCS_MAGIC_1) << "magic byte 1";
+    ASSERT_EQ(db.data[2], VCS_MAGIC_2) << "magic byte 2";
+    ASSERT_EQ(db.data[3], VCS_VERSION) << "version";
+    ASSERT_EQ(db.data[4], ALGO_LZ4) << "algo id";
+    ASSERT_EQ(db.data[5], (uint8_t)0) << "flags should be clear when checksum is disabled";
+    ASSERT_EQ(db.data[6], STREAM_KIND_RDB) << "stream_kind RDB";
 
     /* Decompress and verify round-trip */
     streamDecompressor sd;
@@ -769,8 +767,8 @@ TEST_F(CompressionTest, streamWriterRoundTrip) {
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
-    uint8_t *compressed_data = db.data + VKCS_ENVELOPE_SIZE;
-    size_t compressed_len = sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE;
+    uint8_t *compressed_data = db.data + VCS_ENVELOPE_SIZE;
+    size_t compressed_len = sdslen((const char *)db.data) - VCS_ENVELOPE_SIZE;
     size_t src_offset = 0;
 
     while (src_offset < compressed_len) {
@@ -902,14 +900,14 @@ TEST_F(CompressionTest, streamWriterFlushBehavior) {
     ASSERT_GE(streamWriterWrite(&t, "second chunk", 12), 0);
     ASSERT_EQ(streamWriterFinish(&t), 0);
 
-    ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE);
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
-    uint8_t *comp_data = db.data + VKCS_ENVELOPE_SIZE;
-    size_t comp_len = sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE;
+    uint8_t *comp_data = db.data + VCS_ENVELOPE_SIZE;
+    size_t comp_len = sdslen((const char *)db.data) - VCS_ENVELOPE_SIZE;
     size_t src_offset = 0;
 
     while (src_offset < comp_len) {
@@ -966,13 +964,13 @@ TEST_F(CompressionTest, streamWriterCodecChecksumToggle) {
         ASSERT_GE(streamWriterWrite(&t, payload, strlen(payload)), 0);
         ASSERT_EQ(streamWriterFinish(&t), 0);
 
-        ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
-        ASSERT_EQ(lz4FrameHasBlockChecksum(db.data + VKCS_ENVELOPE_SIZE,
-                                           sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE),
+        ASSERT_GT(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE);
+        ASSERT_EQ(lz4FrameHasBlockChecksum(db.data + VCS_ENVELOPE_SIZE,
+                                           sdslen((const char *)db.data) - VCS_ENVELOPE_SIZE),
                   codec_checksum)
             << "LZ4 block checksum should reflect configured codec checksum setting";
-        ASSERT_EQ(lz4FrameHasContentChecksum(db.data + VKCS_ENVELOPE_SIZE,
-                                             sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE),
+        ASSERT_EQ(lz4FrameHasContentChecksum(db.data + VCS_ENVELOPE_SIZE,
+                                             sdslen((const char *)db.data) - VCS_ENVELOPE_SIZE),
                   codec_checksum)
             << "LZ4 content checksum should reflect configured codec checksum setting";
 
@@ -1083,13 +1081,13 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
     /* Get the compressed output from the buffer rio */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
-    ASSERT_GT(compressed_len, (size_t)VKCS_ENVELOPE_SIZE) << "compressed output should exist";
+    ASSERT_GT(compressed_len, (size_t)VCS_ENVELOPE_SIZE) << "compressed output should exist";
 
-    /* Verify VKCS envelope */
-    ASSERT_EQ(compressed[0], (char)VKCS_MAGIC_0) << "magic V";
-    ASSERT_EQ(compressed[1], (char)VKCS_MAGIC_1) << "magic K";
-    ASSERT_EQ(compressed[2], (char)VKCS_MAGIC_2) << "magic C";
-    ASSERT_EQ(compressed[3], (char)VKCS_MAGIC_3) << "magic S";
+    /* Verify VCS envelope */
+    ASSERT_EQ(compressed[0], (char)VCS_MAGIC_0) << "magic V";
+    ASSERT_EQ(compressed[1], (char)VCS_MAGIC_1) << "magic C";
+    ASSERT_EQ(compressed[2], (char)VCS_MAGIC_2) << "magic S";
+    ASSERT_EQ(compressed[3], (char)VCS_VERSION) << "version";
 
     /* Decompress and verify */
     streamDecompressor sd;
@@ -1097,8 +1095,8 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
 
     uint8_t decompressed[512];
     size_t total_decompressed = 0;
-    uint8_t *comp_data = (uint8_t *)compressed + VKCS_ENVELOPE_SIZE;
-    size_t comp_len = compressed_len - VKCS_ENVELOPE_SIZE;
+    uint8_t *comp_data = (uint8_t *)compressed + VCS_ENVELOPE_SIZE;
+    size_t comp_len = compressed_len - VCS_ENVELOPE_SIZE;
     size_t src_offset = 0;
 
     while (src_offset < comp_len) {
@@ -1274,14 +1272,14 @@ TEST_F(CompressionTest, decompressRioRoundTrip) {
     ASSERT_EQ(streamWriterFinish(&t), 0);
     streamWriterFree(&t);
 
-    /* Create a buffer rio with the full VKCS-wrapped stream. */
+    /* Create a buffer rio with the full VCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     /* Create decompress rio */
     decompressRio dr;
-    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
+    ASSERT_EQ(initVcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     /* Read decompressed data */
     char result[256];
@@ -1311,7 +1309,7 @@ TEST_F(CompressionTest, decompressRioTellTracksSourceProgress) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     decompressRio dr;
-    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
+    ASSERT_EQ(initVcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     char out[2048];
     ASSERT_NE(rioRead((rio *)&dr, out, sizeof(out)), 0u);
@@ -1348,9 +1346,8 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
     }
 
     {
-        const uint8_t malformed[VKCS_ENVELOPE_SIZE] = {
-            VKCS_MAGIC_0, VKCS_MAGIC_1, VKCS_MAGIC_2, VKCS_MAGIC_3,
-            0, ALGO_LZ4, 0, STREAM_KIND_RDB};
+        const uint8_t malformed[VCS_ENVELOPE_SIZE] = {
+            VCS_MAGIC_0, VCS_MAGIC_1, VCS_MAGIC_2, 0, ALGO_LZ4, 0, STREAM_KIND_RDB};
         sds buf = sdsnewlen(malformed, sizeof(malformed));
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
@@ -1412,15 +1409,15 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
     /* Verify the entire stream decompresses correctly */
     sds compressed = buffer_rio.io.buffer.ptr;
     size_t compressed_len = sdslen(compressed);
-    ASSERT_GT(compressed_len, (size_t)VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(compressed_len, (size_t)VCS_ENVELOPE_SIZE);
 
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[256];
     size_t total_decompressed = 0;
-    uint8_t *comp_data = (uint8_t *)compressed + VKCS_ENVELOPE_SIZE;
-    size_t comp_len = compressed_len - VKCS_ENVELOPE_SIZE;
+    uint8_t *comp_data = (uint8_t *)compressed + VCS_ENVELOPE_SIZE;
+    size_t comp_len = compressed_len - VCS_ENVELOPE_SIZE;
     size_t src_offset = 0;
 
     while (src_offset < comp_len) {
@@ -1492,13 +1489,13 @@ TEST_F(CompressionTest, decompressRioLargePayload) {
     ASSERT_EQ(streamWriterFinish(&t), 0);
     streamWriterFree(&t);
 
-    /* Decompress via decompress_rio using the full VKCS-wrapped stream. */
+    /* Decompress via decompress_rio using the full VCS-wrapped stream. */
     sds comp_sds = sdsnewlen(db.data, sdslen((const char *)db.data));
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     decompressRio dr;
-    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
+    ASSERT_EQ(initVcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     /* Read in small chunks (4KB) to force multiple iterations through
      * the decompression state machine. */
@@ -1549,7 +1546,7 @@ TEST_F(CompressionTest, decompressRioDirectPath) {
     rioInitWithBuffer(&buffer_rio, comp_sds);
 
     decompressRio dr;
-    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buffer_rio), 0);
+    ASSERT_EQ(initVcsRdbDecompressRio(&dr, &buffer_rio), 0);
 
     uint8_t *result = (uint8_t *)zmalloc(payload_len);
     size_t ret = rioRead((rio *)&dr, result, payload_len);
@@ -1626,7 +1623,7 @@ TEST_F(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
     ASSERT_EQ(streamWriterFinish(&w), 0);
     streamWriterFree(&w);
 
-    ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE + 1);
+    ASSERT_GT(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE + 1);
     MemReader mr = {};
     mr.data = db.data;
     mr.len = sdslen((const char *)db.data) - 1;
@@ -1669,14 +1666,14 @@ TEST_F(CompressionTest, streamWriterWriteAfterFinish) {
     ASSERT_EQ(sdslen((const char *)db.data), len_after_finish) << "second finish should not produce output";
 
     /* Verify the stream is still valid: one envelope + one frame */
-    ASSERT_GT(sdslen((const char *)db.data), (size_t)VKCS_ENVELOPE_SIZE);
+    ASSERT_GT(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE);
     streamDecompressor sd;
     ASSERT_EQ(streamDecompressorInit(&sd, ALGO_LZ4), 0);
 
     uint8_t decompressed[64];
     size_t total = 0;
-    uint8_t *cdata = db.data + VKCS_ENVELOPE_SIZE;
-    size_t comp_len = sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE;
+    uint8_t *cdata = db.data + VCS_ENVELOPE_SIZE;
+    size_t comp_len = sdslen((const char *)db.data) - VCS_ENVELOPE_SIZE;
     size_t off = 0;
     while (off < comp_len) {
         size_t consumed = 0;
@@ -1734,7 +1731,7 @@ TEST_F(CompressionTest, independentStreamsCoexist) {
         rioInitWithBuffer(&buf_rio, comp);
 
         decompressRio dr;
-        ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buf_rio), 0);
+        ASSERT_EQ(initVcsRdbDecompressRio(&dr, &buf_rio), 0);
 
         char result[256];
         memset(result, 0, sizeof(result));
@@ -1769,8 +1766,8 @@ TEST_F(CompressionTest, streamWriterRepetitivePayloadRoundTrip) {
         ASSERT_GE(streamWriterWrite(&t, pattern, sizeof(pattern)), 0);
     }
     ASSERT_EQ(streamWriterFinish(&t), 0);
-    ASSERT_TRUE(lz4FrameUsesLinkedBlocks(db.data + VKCS_ENVELOPE_SIZE,
-                                         sdslen((const char *)db.data) - VKCS_ENVELOPE_SIZE))
+    ASSERT_TRUE(lz4FrameUsesLinkedBlocks(db.data + VCS_ENVELOPE_SIZE,
+                                         sdslen((const char *)db.data) - VCS_ENVELOPE_SIZE))
         << "stream writer should use linked LZ4 blocks";
 
     sds comp = sdsnewlen(db.data, sdslen((const char *)db.data));
@@ -1778,7 +1775,7 @@ TEST_F(CompressionTest, streamWriterRepetitivePayloadRoundTrip) {
     rioInitWithBuffer(&buf_rio, comp);
 
     decompressRio dr;
-    ASSERT_EQ(initVkcsRdbDecompressRio(&dr, &buf_rio), 0);
+    ASSERT_EQ(initVcsRdbDecompressRio(&dr, &buf_rio), 0);
 
     size_t total_len = sizeof(pattern) * 32;
     char *result = (char *)zmalloc(total_len);

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -622,7 +622,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     rioInitWithFile(&file_rdb, fp);
     rdbInputStreamInit(&input, &file_rdb);
 
-    /* Support both plain RDB files and VKCS-wrapped streaming-compressed RDBs. */
+    /* Support both plain RDB files and VCS-wrapped streaming-compressed RDBs. */
     decompressRioInitResult init_rc = rdbInputStreamPrepare(&input);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         rdbCheckError("Invalid or unsupported RDB stream envelope. "

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -64,7 +64,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_equal 0 [r dbsize]
         assert_equal "OK" [r save]
         r config rewrite
-        assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
+        assert_equal "VCS" [string range [read_dump_rdb_header_bytes r] 0 2]
 
         restart_server 0 true false
 
@@ -166,7 +166,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         r config set rdb-key-save-delay 0
 
         assert_equal "yes" [lindex [r config get rdbcompression] 1]
-        assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
+        assert_equal "VCS" [string range [read_dump_rdb_header_bytes r] 0 2]
 
         assert_equal "OK" [r save]
         assert_equal "VALKEY" [string range [read_dump_rdb_header_bytes r] 0 5]
@@ -227,7 +227,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_equal "lz4-stream" [lindex [r config get rdbcompression] 1]
     }
 
-    test {LZ4 compressed RDB with rdbchecksum yes sets the VKCS codec checksum flag} {
+    test {LZ4 compressed RDB with rdbchecksum yes sets the VCS codec checksum flag} {
         r config set rdbcompression lz4-stream
         r flushall
         for {set i 0} {$i < 200} {incr i} {
@@ -236,8 +236,8 @@ start_server {overrides {save "" enable-debug-command local}} {
 
         r save
         set header [read_dump_rdb_header_bytes r]
-        assert_equal "VKCS" [string range $header 0 3]
-        binary scan [string index $header 6] cu flags
+        assert_equal "VCS" [string range $header 0 2]
+        binary scan [string index $header 5] cu flags
         assert {$flags == 1}
 
         set digest [debug_digest]
@@ -247,7 +247,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_equal [string repeat "payload42 " 200] [r get cksum:42]
     }
 
-    test {Truncated VKCS snapshot is rejected on load} {
+    test {Truncated VCS snapshot is rejected on load} {
         r config set rdbcompression lz4-stream
         r flushall
         set noisy_payload ""
@@ -260,7 +260,7 @@ start_server {overrides {save "" enable-debug-command local}} {
 
         assert_equal "OK" [r save]
         set rdbfile [dump_rdb_path r]
-        assert_equal "VKCS" [string range [read_binary_file_prefix $rdbfile 8] 0 3]
+        assert_equal "VCS" [string range [read_binary_file_prefix $rdbfile 8] 0 2]
 
         set truncated [read_binary_file_prefix $rdbfile [expr {[file size $rdbfile] / 2}]]
         set fd [open $rdbfile w]
@@ -303,7 +303,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         set fd [open $rdbfile r+]
         fconfigure $fd -translation binary
         set data [read $fd]
-        set data [string replace $data 7 7 [binary format c 0x01]]
+        set data [string replace $data 6 6 [binary format c 0x01]]
         seek $fd 0
         puts -nonewline $fd $data
         close $fd
@@ -325,7 +325,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         set rdbfile [file join [lindex [r config get dir] 1] dump.rdb]
 
         # Read the file, flip a byte in the compressed payload
-        # (skip the VKCS envelope at offset 0-7, corrupt somewhere in the middle)
+        # (skip the VCS envelope at offset 0-6, corrupt somewhere in the middle)
         set fd [open $rdbfile r+]
         fconfigure $fd -translation binary
         set data [read $fd]
@@ -346,7 +346,7 @@ start_server {overrides {save "" enable-debug-command local}} {
         assert_match "*Error*" $err
     }
 
-    test {Invalid non-VKCS/non-RDB file fails reload} {
+    test {Invalid non-VCS/non-RDB file fails reload} {
         r config set rdbcompression lz4-stream
         r flushall
         r set smoke-key smoke-value
@@ -371,7 +371,7 @@ start_server {config "minimal.conf" args {"--rdbcompression lz4-stream"}} {
 }
 
 start_server {overrides {save "" enable-debug-command local rdbchecksum no}} {
-    test {LZ4 compressed RDB with rdbchecksum no leaves VKCS flags clear and loads correctly} {
+    test {LZ4 compressed RDB with rdbchecksum no leaves VCS flags clear and loads correctly} {
         r config set rdbcompression lz4-stream
         r flushall
         for {set i 0} {$i < 50} {incr i} {
@@ -380,8 +380,8 @@ start_server {overrides {save "" enable-debug-command local rdbchecksum no}} {
 
         r save
         set header [read_dump_rdb_header_bytes r]
-        assert_equal "VKCS" [string range $header 0 3]
-        binary scan [string index $header 6] cu flags
+        assert_equal "VCS" [string range $header 0 2]
+        binary scan [string index $header 5] cu flags
         assert {$flags == 0}
 
         set digest [debug_digest]
@@ -478,7 +478,7 @@ start_server [list tags {"rdb-compression cluster external:skip singledb"} overr
         assert_equal "OK" [r cluster saveconfig]
         r set cluster-rdb-compression value
         assert_equal "OK" [r save]
-        assert_equal "VKCS" [string range [read_dump_rdb_header_bytes r] 0 3]
+        assert_equal "VCS" [string range [read_dump_rdb_header_bytes r] 0 2]
 
         restart_server 0 true false
         wait_for_condition 50 100 {


### PR DESCRIPTION
## Summary
- Rename the streaming compression envelope/magic from `VKCS` to `VCS`.
- Keep the serialized VCS envelope compact at 7 bytes: magic, version, codec id, flags, and stream kind.
- Update parser offsets, RDB/AOF/check-rdb references, unit tests, and integration tests for the compact layout.
- Place `stream_kind` after the 7-byte probe header in memory so the probe struct uses the otherwise padded byte before `header_len`.

## Notes
Using `VCS` should not force an 8-byte serialized envelope. The stream format is byte-addressed, so there is no alignment benefit to writing an extra reserved byte to every compressed stream.

## Tests
- `make -j4`
- `./runtest --single tests/integration/rdb-compression.tcl` (38 passed, 0 failed)
- `make -C src test-unit` is blocked locally: `pkg-config` is missing and googletest is not found.