### PR TITLE
[Test] 9.0 reply-schemas scenario (ci_fix PORT path)

### DIFF
--- a/src/vset.c
+++ b/src/vset.c
@@ -1452,11 +1452,31 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
     }
     hashtableResetIterator(&it);
 
-    /* in case we completed scanning the hashtable which is now empty */
+    /* Collapse or downgrade the bucket based on how many entries remain.
+     *
+     * The active-expire path is bounded by max_count (the per-key expire
+     * quota in dbReclaimExpiredFields), so it can stop *before* the bucket
+     * is fully drained. We must preserve the same bucket-type invariant the
+     * normal removal path relies on:
+     *   - size 0 : free the hashtable, bucket becomes NONE.
+     *   - size 1 : downgrade to SINGLE. An HT bucket must never persist with
+     *              a single entry -- removeFromBucket_HASHTABLE() asserts
+     *              hashtableSize(ht) > 0 after a delete and downgrades to
+     *              SINGLE at size 1. If we leave a size-1 HT bucket here, a
+     *              later normal removal of that entry (HDEL, or a cross-bucket
+     *              HSETEX update via removeEntryFromRaxBucket) deletes the sole
+     *              entry, drops the size 1->0, and trips that assertion. */
     size_t ht_size = hashtableSize(ht);
     if (ht_size == 0) {
         hashtableRelease(ht);
         *bucket = vsetBucketFromNone();
+    } else if (ht_size == 1) {
+        hashtableIterator hi;
+        hashtableInitIterator(&hi, ht, 0);
+        void *ptr;
+        hashtableNext(&hi, &ptr);
+        hashtableRelease(ht);
+        *bucket = vsetBucketFromSingle(ptr);
     }
     return count;
 }

--- a/tests/unit/cluster/reqres-syncslots-ack.tcl
+++ b/tests/unit/cluster/reqres-syncslots-ack.tcl
@@ -1,0 +1,41 @@
+# Deterministic trigger for the req-res log desync fixed by #3154.
+#
+# Without the internal-client guard in reqresShouldLog(), the periodic
+# "CLUSTER SYNCSLOTS ACK" emitted by the slot-migration internal client (which
+# intentionally has no reply) gets written into the --log-req-res log. That
+# desyncs the request/response pairing and breaks reply-schemas-validator.
+#
+# Holding an atomic migration across several 1-second ACK periods makes the
+# no-reply ACK fire deterministically while logging is active.
+
+source tests/support/cluster.tcl
+
+start_cluster 2 0 {tags {external:skip cluster}} {
+
+test "Cluster is up" {
+    wait_for_cluster_state ok
+}
+
+test "Atomic slot migration logs the no-reply SYNCSLOTS ACK" {
+    set node0_id [R 0 CLUSTER MYID]
+
+    # Seed keys so the migration has work and stays in flight long enough
+    # for the periodic ACK to fire repeatedly.
+    for {set i 0} {$i < 20000} {incr i} {
+        catch {R 1 SET "key:$i" $i}
+    }
+
+    # Drive an atomic slot migration from node 1 to node 0. The internal
+    # migration client emits "CLUSTER SYNCSLOTS ACK" on a 1s timer.
+    catch {R 1 CLUSTER MIGRATESLOTS SLOTSRANGE 0 100 NODE $node0_id} res
+
+    # Hold across multiple ACK periods so the no-reply ACK is logged.
+    for {set t 0} {$t < 8} {incr t} {
+        after 1000
+        catch {R 1 CLUSTER GETSLOTMIGRATIONS}
+        catch {R 0 CLUSTER GETSLOTMIGRATIONS}
+    }
+    assert_equal 1 1
+}
+
+} ;# start_cluster

--- a/tests/unit/port-smoke.tcl
+++ b/tests/unit/port-smoke.tcl
@@ -1,0 +1,6 @@
+start_server {tags {"port-smoke"}} {
+    test {port-smoke: fixed behavior returns OK} {
+        r set port-smoke-key broken
+        assert_equal [r get port-smoke-key] "fixed"
+    }
+}


### PR DESCRIPTION
Throwaway fork test. 9.0 branch missing #3154 (9f374e158), reproducing the reply-schemas-validator failure for the ci_fix PORT path. Not for upstream.