### PR TITLE
[Backport 8.0] Fix RESP3 type violation in addReplyCommandSubCommands

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4817,7 +4817,10 @@ void addReplyCommandSubCommands(client *c,
                                 void (*reply_function)(client *, struct serverCommand *),
                                 int use_map) {
     if (!cmd->subcommands_dict) {
-        addReplySetLen(c, 0);
+        if (use_map)
+            addReplyMapLen(c, 0);
+        else
+            addReplyArrayLen(c, 0);
         return;
     }
 

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -241,6 +241,34 @@ start_server {tags {"introspection"}} {
         assert_equal {{}} [r command info config|get|key]
     }
 
+    test {COMMAND INFO subcommands field uses array not set type in RESP3 for commands with no subcommands} {
+        r hello 3
+        r readraw 1
+        r deferred 1
+        r command info ping
+        assert_equal [r read] {*1}   ;# outer array: 1 command
+        assert_equal [r read] {*10}  ;# command info: 10 fields
+        assert_equal [r read] {$4}   ;# name (bulk string type)
+        assert_equal [r read] {ping} ;# name value
+        assert_equal [r read] {:-1}  ;# arity
+        set flags_hdr [r read]       ;# flags (~N set)
+        for {set i 0} {$i < [string range $flags_hdr 1 end]} {incr i} { r read }
+        assert_equal [r read] {:0}   ;# first_key
+        assert_equal [r read] {:0}   ;# last_key
+        assert_equal [r read] {:0}   ;# step
+        set acl_hdr [r read]         ;# acl_categories (~N set)
+        for {set i 0} {$i < [string range $acl_hdr 1 end]} {incr i} { r read }
+        set tips_hdr [r read]        ;# tips (~N set)
+        set tips_count [string range $tips_hdr 1 end]
+        for {set i 0} {$i < $tips_count} {incr i} { r read ; r read }
+        assert_equal [r read] {~0}   ;# key_specs: correctly a Set
+        set subcommands_hdr [r read] ;# subcommands: should be Array not Set
+        r readraw 0
+        r deferred 0
+        r hello 2
+        assert_equal {*0} $subcommands_hdr
+    } {} {resp3}
+
     foreach cmd {SET GET MSET BITFIELD LMOVE LPOP BLPOP PING MEMORY MEMORY|USAGE RENAME GEORADIUS_RO} {
         test "$cmd command will not be marked with movablekeys" {
             set info [lindex [r command info $cmd] 0]


### PR DESCRIPTION
## Backport Summary

Cherry-pick encountered conflicts and the conflicted files were resolved automatically.

| Field | Value |
|---|---|
| Source PR | [#304](https://github.com/sarthakaggarwal97/valkey/pull/304) |
| Source title | Fix RESP3 type violation in addReplyCommandSubCommands |
| Target branch | `8.0` |
| Cherry-picked commits | 1 |
| Conflicts detected | yes |
| Auto-resolved files | 1 |
| Unresolved files | 0 |

### Reviewer Checklist

- Compare this backport against the source PR before merge.
- Review the automatically resolved files carefully for semantic drift.

### Cherry-Picked Commits

- `34b2b7b3f472abddee41a9d89be5b7f64a8f596e`

### Conflict Details

- `src/server.c`: Resolved automatically. resolved by Claude Code ([view diff](https://github.com/sarthakaggarwal97/valkey/pull/305#issuecomment-4773468947))

The diff of each AI-resolved file is posted as a comment on this PR.

### Human Review Required

Some conflicts in this backport were resolved using an LLM. These resolutions require careful human review to ensure correctness. Please verify that the resolved code matches the intent of the original pull request.