### PR TITLE
Reject NAN scores in listpack/ziplist-encoded sorted sets on RDB load

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2494,6 +2494,18 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 decrRefCount(o);
                 return NULL;
             }
+            /* See the RDB_TYPE_ZSET_LISTPACK case: a NAN score would crash the
+             * server when the zset is converted to a skiplist. The legacy
+             * ziplist format is converted to a listpack above, so apply the
+             * same NAN check on the resulting listpack. */
+            if (!zzlValidateScores(lp)) {
+                rdbReportCorruptRDB("Zset ziplist with NAN score detected");
+                zfree(lp);
+                zfree(encoded);
+                objectSetVal(o, NULL);
+                decrRefCount(o);
+                return NULL;
+            }
 
             zfree(objectGetVal(o));
             o->type = OBJ_ZSET;
@@ -2514,6 +2526,17 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             server.stat_dump_payload_sanitizations++;
             if (!lpValidateIntegrityAndDups(encoded, encoded_len, 1)) {
                 rdbReportCorruptRDB("Zset listpack integrity check failed.");
+                zfree(encoded);
+                objectSetVal(o, NULL);
+                decrRefCount(o);
+                return NULL;
+            }
+            /* A NAN score would crash the server when the zset is converted to
+             * a skiplist (zslInsertNode asserts the score is not NAN). The
+             * skiplist RDB format rejects NAN scores at load time; do the same
+             * for the listpack format. */
+            if (!zzlValidateScores(encoded)) {
+                rdbReportCorruptRDB("Zset listpack with NAN score detected");
                 zfree(encoded);
                 objectSetVal(o, NULL);
                 decrRefCount(o);

--- a/src/server.h
+++ b/src/server.h
@@ -3411,6 +3411,7 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele);
 zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
 sds zslGetNodeElement(const zskiplistNode *x);
 double zzlGetScore(unsigned char *sptr);
+int zzlValidateScores(unsigned char *zl);
 void zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -867,6 +867,25 @@ double zzlGetScore(unsigned char *sptr) {
     return score;
 }
 
+/* Validate that none of the scores in a listpack-encoded sorted set is NAN.
+ * The structural layout (member, score, member, score, ...) must already have
+ * been validated by lpValidateIntegrityAndDups. Returns 1 if all scores are
+ * valid, 0 if a NAN score is found. This guards against crafted RESTORE
+ * payloads: zslInsertNode() asserts the score is not NAN, so a NAN score in a
+ * listpack zset would crash the server when it is later converted to a
+ * skiplist. The skiplist RDB format rejects NAN scores at load time; this is
+ * the equivalent check for the listpack format. */
+int zzlValidateScores(unsigned char *zl) {
+    unsigned char *eptr = lpSeek(zl, 0), *sptr;
+    while (eptr != NULL) {
+        sptr = lpNext(zl, eptr);
+        if (sptr == NULL) return 0; /* odd number of elements */
+        if (isnan(zzlGetScore(sptr))) return 0;
+        eptr = lpNext(zl, sptr);
+    }
+    return 1;
+}
+
 /* Return a listpack element as an SDS string. */
 sds lpGetObject(unsigned char *sptr) {
     unsigned char *vstr;

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -725,6 +725,34 @@ test {corrupt payload: fuzzer findings - zset zslInsert with a NAN score} {
     }
 }
 
+test {corrupt payload: zset listpack with NAN score} {
+    # A listpack-encoded sorted set whose score parses to NAN must be rejected
+    # on load. zslInsertNode() asserts the score is not NAN, so otherwise the
+    # server would crash when the zset is converted to a skiplist (e.g. when it
+    # grows past zset-max-listpack-entries). The skiplist RDB format already
+    # rejects NAN scores; this covers the listpack format.
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r debug set-skip-checksum-validation 1
+        catch {r restore _nan_zset_lp 0 "\x11\x19\x19\x00\x00\x00\x04\x00\x82\x6D\x31\x03\x83\x6E\x61\x6E\x04\x82\x6D\x32\x03\x83\x32\x2E\x35\x04\xFF\x50\x00\xC5\x5C\xC6\x0C\x7D\xFF\xB5\x52"} err
+        assert_match "*Bad data format*" $err
+        verify_log_message 0 "*NAN score*" 0
+        assert_equal [r ping] "PONG"
+    }
+}
+
+test {corrupt payload: zset ziplist with NAN score} {
+    # Same as the listpack case but for the legacy ziplist format, which is
+    # converted to a listpack on load. A NAN score must be rejected so it can
+    # not crash the server when the zset is later converted to a skiplist.
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r debug set-skip-checksum-validation 1
+        catch {r restore _nan_zset_zl 0 "\x0C\x1D\x1D\x00\x00\x00\x17\x00\x00\x00\x04\x00\x00\x02\x6D\x31\x04\x03\x6E\x61\x6E\x05\x02\x6D\x32\x04\x03\x32\x2E\x35\xFF\x0B\x00\x00\x00\x00\x00\x00\x00\x00\x00"} err
+        assert_match "*Bad data format*" $err
+        verify_log_message 0 "*NAN score*" 0
+        assert_equal [r ping] "PONG"
+    }
+}
+
 test {corrupt payload: fuzzer findings - streamLastValidID panic} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r debug set-skip-checksum-validation 1


### PR DESCRIPTION
sweep backport demo (real commit 98005d1c)