### PR TITLE
Avoid redundant daylight checks

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1370,6 +1370,8 @@ void databasesCron(void) {
 }
 
 static inline void updateCachedTimeWithUs(int update_daylight_info, const ustime_t ustime) {
+    time_t prev_unixtime = server.unixtime;
+
     server.ustime = ustime;
     server.mstime = server.ustime / 1000;
     server.unixtime = server.mstime / 1000;
@@ -1380,7 +1382,7 @@ static inline void updateCachedTimeWithUs(int update_daylight_info, const ustime
      * context is safe since we will never fork() while here, in the main
      * thread. The logging function will call a thread safe version of
      * localtime that has no locks. */
-    if (update_daylight_info) {
+    if (update_daylight_info && server.unixtime != prev_unixtime) {
         struct tm tm;
         time_t ut = server.unixtime;
         localtime_r(&ut, &tm);


### PR DESCRIPTION
Avoid recalculating daylight-saving state on every event-loop wake when the cached Unix second has not changed.

The normal cached time refresh still runs on every wake. This only skips the `localtime_r()` daylight-saving refresh when `server.unixtime` is unchanged, since DST cannot change within the same Unix second.

Why:
- macOS profiling showed `afterSleep -> updateCachedTime(1) -> localtime_r()` repeatedly entering `tzload/open/access` during GET/SET workloads.
- An instrumented Linux/glibc run confirmed the mechanism: in a 20s SET P=1 c=50 window, 882,043 daylight-path entries occurred, but only 13 had a changed Unix second. That means 882,030 calls, effectively 100%, were redundant.
- Linux/glibc impact is CPU-neutral because timezone state is cached cheaply there. Median of 3, server pinned to one core, 3M requests each, P=1 c=100:
  - SET: baseline 9.640s CPU/1M req, patched 9.649s; 101,396/s vs 101,180/s
  - GET: baseline 9.687s CPU/1M req, patched 9.641s; 100,570/s vs 99,937/s
- A stricter macOS A/B on Apple M3 Pro, Release builds from the parent commit vs this patch, persistence off, median of 3, server CPU from `INFO cpu`:
  - SET P=1 c=100: 16.189s -> 15.015s CPU/1M req (-7.25%); 47,712/s -> 52,846/s (+10.76%)
  - GET P=1 c=100: 14.968s -> 14.829s CPU/1M req (-0.93%); throughput unchanged
  - SET P=64 c=100: CPU/1M req unchanged (+0.26%); throughput unchanged
  - GET P=64 c=100: 0.520s -> 0.514s CPU/1M req (-1.11%); throughput essentially unchanged

Validation:
- `cmake --build build-release --target valkey-server -j 12`
- `git diff --check`
- Local macOS fixed-request CPU A/B benchmark with persistence off
- Linux/glibc instrumented mechanism proof and CPU A/B benchmark

Note: `make -C src test-unit` did not complete in my local macOS environment because `llvm-objcopy` is missing.
