### PR TITLE
compression: simplify streaming compression layers

### DIFF
--- a/src/compression.c
+++ b/src/compression.c
@@ -9,47 +9,13 @@
 #include "serverassert.h"
 #include <string.h>
 
-typedef struct {
-    int (*compressor_init)(streamCompressor *compressor);
-    void (*compressor_free)(streamCompressor *compressor);
-    int (*decompressor_init)(streamDecompressor *decompressor);
-    void (*decompressor_free)(streamDecompressor *decompressor);
-    size_t (*compress_output_bound)(size_t input_len);
-    ssize_t (*compress_feed)(streamCompressor *compressor,
-                             uint8_t *output,
-                             size_t output_capacity,
-                             const uint8_t *input,
-                             size_t input_len,
-                             compressFlushMode flush_mode);
-    ssize_t (*decompress_feed)(streamDecompressor *decompressor,
-                               uint8_t *output,
-                               size_t output_capacity,
-                               const uint8_t *input,
-                               size_t input_len,
-                               size_t *input_consumed);
-} compressionCodec;
-
-static const compressionCodec compressionLz4Codec = {
-    .compressor_init = compressionLz4CompressorInit,
-    .compressor_free = compressionLz4CompressorFree,
-    .decompressor_init = compressionLz4DecompressorInit,
-    .decompressor_free = compressionLz4DecompressorFree,
-    .compress_output_bound = compressionLz4OutputBound,
-    .compress_feed = compressionLz4CompressFeed,
-    .decompress_feed = compressionLz4DecompressFeed,
-};
-
-static const compressionCodec *compressionCodecForAlgo(compressionAlgo algo) {
+bool compressionAlgoSupportsStreaming(compressionAlgo algo) {
     switch (algo) {
     case ALGO_LZ4:
-        return &compressionLz4Codec;
+        return true;
     default:
-        return NULL;
+        return false;
     }
-}
-
-bool compressionAlgoSupportsStreaming(compressionAlgo algo) {
-    return compressionCodecForAlgo(algo) != NULL;
 }
 
 const char *compressionAlgoName(compressionAlgo algo) {
@@ -67,51 +33,67 @@ const char *compressionAlgoName(compressionAlgo algo) {
 
 int streamCompressorInit(streamCompressor *compressor, compressionAlgo algo, int level) {
     memset(compressor, 0, sizeof(*compressor));
-
-    const compressionCodec *codec = compressionCodecForAlgo(algo);
-    if (!codec) return -1;
-
     compressor->algo = algo;
     compressor->level = level;
 
-    if (codec->compressor_init(compressor) != 0) {
-        codec->compressor_free(compressor);
+    switch (algo) {
+    case ALGO_LZ4:
+        if (compressionLz4CompressorInit(compressor) != 0) {
+            compressionLz4CompressorFree(compressor);
+            return -1;
+        }
+        return 0;
+    default:
         return -1;
     }
-    return 0;
 }
 
 void streamCompressorFree(streamCompressor *compressor) {
-    const compressionCodec *codec = compressionCodecForAlgo(compressor->algo);
-    assert(codec != NULL);
-    codec->compressor_free(compressor);
+    switch (compressor->algo) {
+    case ALGO_LZ4:
+        compressionLz4CompressorFree(compressor);
+        return;
+    default:
+        assert(0);
+        return;
+    }
 }
 
 int streamDecompressorInit(streamDecompressor *decompressor, compressionAlgo algo) {
     memset(decompressor, 0, sizeof(*decompressor));
-
-    const compressionCodec *codec = compressionCodecForAlgo(algo);
-    if (!codec) return -1;
-
     decompressor->algo = algo;
 
-    if (codec->decompressor_init(decompressor) != 0) {
-        codec->decompressor_free(decompressor);
+    switch (algo) {
+    case ALGO_LZ4:
+        if (compressionLz4DecompressorInit(decompressor) != 0) {
+            compressionLz4DecompressorFree(decompressor);
+            return -1;
+        }
+        return 0;
+    default:
         return -1;
     }
-    return 0;
 }
 
 void streamDecompressorFree(streamDecompressor *decompressor) {
-    const compressionCodec *codec = compressionCodecForAlgo(decompressor->algo);
-    assert(codec != NULL);
-    codec->decompressor_free(decompressor);
+    switch (decompressor->algo) {
+    case ALGO_LZ4:
+        compressionLz4DecompressorFree(decompressor);
+        return;
+    default:
+        assert(0);
+        return;
+    }
 }
 
 size_t streamCompressorOutputBound(streamCompressor *compressor, size_t input_len) {
-    const compressionCodec *codec = compressionCodecForAlgo(compressor->algo);
-    assert(codec != NULL);
-    return codec->compress_output_bound(input_len);
+    switch (compressor->algo) {
+    case ALGO_LZ4:
+        return compressionLz4OutputBound(input_len);
+    default:
+        assert(0);
+        return 0;
+    }
 }
 
 ssize_t streamCompressorFeed(streamCompressor *compressor,
@@ -120,9 +102,13 @@ ssize_t streamCompressorFeed(streamCompressor *compressor,
                              const uint8_t *input,
                              size_t input_len,
                              compressFlushMode flush_mode) {
-    const compressionCodec *codec = compressionCodecForAlgo(compressor->algo);
-    assert(codec != NULL);
-    return codec->compress_feed(compressor, output, output_capacity, input, input_len, flush_mode);
+    switch (compressor->algo) {
+    case ALGO_LZ4:
+        return compressionLz4CompressFeed(compressor, output, output_capacity, input, input_len, flush_mode);
+    default:
+        assert(0);
+        return -1;
+    }
 }
 
 ssize_t streamDecompressorFeed(streamDecompressor *decompressor,
@@ -135,7 +121,11 @@ ssize_t streamDecompressorFeed(streamDecompressor *decompressor,
     if (decompressor->errored) return -1;
     if (decompressor->frame_done) return 0;
 
-    const compressionCodec *codec = compressionCodecForAlgo(decompressor->algo);
-    assert(codec != NULL);
-    return codec->decompress_feed(decompressor, output, output_capacity, input, input_len, input_consumed);
+    switch (decompressor->algo) {
+    case ALGO_LZ4:
+        return compressionLz4DecompressFeed(decompressor, output, output_capacity, input, input_len, input_consumed);
+    default:
+        assert(0);
+        return -1;
+    }
 }

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -110,6 +110,19 @@ int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg)
     return 0;
 }
 
+int rioInitWithRdbCompression(compressRio *cr,
+                              rio *inner,
+                              compressionAlgo algo,
+                              bool codec_checksum_enabled) {
+    streamWriterConfig cfg = {
+        .algo = algo,
+        .level = 0,
+        .stream_kind = STREAM_KIND_RDB,
+        .codec_checksum_enabled = codec_checksum_enabled,
+    };
+    return rioInitWithCompression(cr, inner, &cfg);
+}
+
 /* Idempotent: subsequent calls report cached error state. */
 int compressRioFinish(compressRio *cr) {
     if (cr->finalized) {
@@ -205,6 +218,27 @@ decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
 
     if (local_info.compressed) dr->base.flags |= RIO_FLAG_STREAMING_COMPRESSION;
     if (info) *info = local_info;
+    return DECOMPRESS_RIO_INIT_OK;
+}
+
+decompressRioInitResult rioInitWithRdbDecompression(decompressRio *dr,
+                                                    rio *inner,
+                                                    compressionAlgo *algo) {
+    streamReaderConfig cfg = {
+        .expected_stream_kind = STREAM_KIND_RDB,
+        .allow_passthrough = true,
+        .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
+    };
+    streamReaderInfo info = {0};
+    decompressRioInitResult init_rc = rioInitWithDecompression(dr, inner, &cfg, &info);
+
+    if (algo) *algo = ALGO_NONE;
+    if (init_rc != DECOMPRESS_RIO_INIT_OK) return init_rc;
+
+    if (info.compressed) {
+        dr->base.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
+        if (algo) *algo = info.algo;
+    }
     return DECOMPRESS_RIO_INIT_OK;
 }
 

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -93,7 +93,7 @@ static int compressRioFlush(rio *r) {
     return 1;
 }
 
-int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg) {
+static int rioInitWithCompressionConfig(compressRio *cr, rio *inner, streamWriterConfig *cfg) {
     memset(cr, 0, sizeof(*cr));
     rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
                 compressRioFlush,
@@ -120,7 +120,7 @@ int rioInitWithRdbCompression(compressRio *cr,
         .stream_kind = STREAM_KIND_RDB,
         .codec_checksum_enabled = codec_checksum_enabled,
     };
-    return rioInitWithCompression(cr, inner, &cfg);
+    return rioInitWithCompressionConfig(cr, inner, &cfg);
 }
 
 /* Idempotent: subsequent calls report cached error state. */
@@ -194,10 +194,10 @@ int decompressRioValidateEnd(decompressRio *dr) {
     return streamReaderValidateEnd(&dr->reader);
 }
 
-decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
-                                                 rio *inner,
-                                                 streamReaderConfig *cfg,
-                                                 streamReaderInfo *info) {
+static decompressRioInitResult rioInitWithDecompressionConfig(decompressRio *dr,
+                                                              rio *inner,
+                                                              streamReaderConfig *cfg,
+                                                              streamReaderInfo *info) {
     streamReaderInfo local_info = {0};
 
     memset(dr, 0, sizeof(*dr));
@@ -230,7 +230,7 @@ decompressRioInitResult rioInitWithRdbDecompression(decompressRio *dr,
         .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
     };
     streamReaderInfo info = {0};
-    decompressRioInitResult init_rc = rioInitWithDecompression(dr, inner, &cfg, &info);
+    decompressRioInitResult init_rc = rioInitWithDecompressionConfig(dr, inner, &cfg, &info);
 
     if (algo) *algo = ALGO_NONE;
     if (init_rc != DECOMPRESS_RIO_INIT_OK) return init_rc;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -93,23 +93,6 @@ static int compressRioFlush(rio *r) {
     return 1;
 }
 
-static int rioInitWithCompressionConfig(compressRio *cr, rio *inner, streamWriterConfig *cfg) {
-    memset(cr, 0, sizeof(*cr));
-    rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
-                compressRioFlush,
-                RIO_FLAG_STREAMING_COMPRESSION | (inner->flags & RIO_FLAG_CONN_BACKED));
-
-    cr->inner = inner;
-    if (streamWriterInit(&cr->writer, cfg, compressRioEmit, cr) != 0) {
-        /* Self-clean so the failure contract matches decompression init:
-         * on a nonzero return the compressRio is left zeroed and the caller
-         * must not call compressRioFree. */
-        memset(cr, 0, sizeof(*cr));
-        return -1;
-    }
-    return 0;
-}
-
 int rioInitWithRdbCompression(compressRio *cr,
                               rio *inner,
                               compressionAlgo algo,
@@ -120,7 +103,21 @@ int rioInitWithRdbCompression(compressRio *cr,
         .stream_kind = STREAM_KIND_RDB,
         .codec_checksum_enabled = codec_checksum_enabled,
     };
-    return rioInitWithCompressionConfig(cr, inner, &cfg);
+
+    memset(cr, 0, sizeof(*cr));
+    rioInitBase(&cr->base, rioReadUnsupported, compressRioWrite, compressRioTell,
+                compressRioFlush,
+                RIO_FLAG_STREAMING_COMPRESSION | (inner->flags & RIO_FLAG_CONN_BACKED));
+
+    cr->inner = inner;
+    if (streamWriterInit(&cr->writer, &cfg, compressRioEmit, cr) != 0) {
+        /* Self-clean so the failure contract matches decompression init:
+         * on a nonzero return the compressRio is left zeroed and the caller
+         * must not call compressRioFree. */
+        memset(cr, 0, sizeof(*cr));
+        return -1;
+    }
+    return 0;
 }
 
 /* Idempotent: subsequent calls report cached error state. */
@@ -194,33 +191,6 @@ int decompressRioValidateEnd(decompressRio *dr) {
     return streamReaderValidateEnd(&dr->reader);
 }
 
-static decompressRioInitResult rioInitWithDecompressionConfig(decompressRio *dr,
-                                                              rio *inner,
-                                                              streamReaderConfig *cfg,
-                                                              streamReaderInfo *info) {
-    streamReaderInfo local_info = {0};
-
-    memset(dr, 0, sizeof(*dr));
-    rioInitBase(&dr->base, decompressRioRead, rioWriteUnsupported, decompressRioTell,
-                rioFlushNoop,
-                RIO_FLAG_STREAMING_DECOMPRESSION |
-                    (inner->flags & (RIO_FLAG_SKIP_RDB_CHECKSUM | RIO_FLAG_CONN_BACKED)));
-    dr->inner = inner;
-
-    if (streamReaderInit(&dr->reader, cfg, decompressRioReadPartial, dr) != 0) return DECOMPRESS_RIO_INIT_ERROR;
-    if (streamReaderGetInfo(&dr->reader, &local_info) != 0) {
-        streamReaderError error_kind = dr->reader.error_kind;
-        decompressRioFree(dr);
-        return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
-                   ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
-                   : DECOMPRESS_RIO_INIT_ERROR;
-    }
-
-    if (local_info.compressed) dr->base.flags |= RIO_FLAG_STREAMING_COMPRESSION;
-    if (info) *info = local_info;
-    return DECOMPRESS_RIO_INIT_OK;
-}
-
 decompressRioInitResult rioInitWithRdbDecompression(decompressRio *dr,
                                                     rio *inner,
                                                     compressionAlgo *algo) {
@@ -230,13 +200,27 @@ decompressRioInitResult rioInitWithRdbDecompression(decompressRio *dr,
         .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
     };
     streamReaderInfo info = {0};
-    decompressRioInitResult init_rc = rioInitWithDecompressionConfig(dr, inner, &cfg, &info);
+
+    memset(dr, 0, sizeof(*dr));
+    rioInitBase(&dr->base, decompressRioRead, rioWriteUnsupported, decompressRioTell,
+                rioFlushNoop,
+                RIO_FLAG_STREAMING_DECOMPRESSION |
+                    (inner->flags & (RIO_FLAG_SKIP_RDB_CHECKSUM | RIO_FLAG_CONN_BACKED)));
+    dr->inner = inner;
 
     if (algo) *algo = ALGO_NONE;
-    if (init_rc != DECOMPRESS_RIO_INIT_OK) return init_rc;
+
+    if (streamReaderInit(&dr->reader, &cfg, decompressRioReadPartial, dr) != 0) return DECOMPRESS_RIO_INIT_ERROR;
+    if (streamReaderGetInfo(&dr->reader, &info) != 0) {
+        streamReaderError error_kind = dr->reader.error_kind;
+        decompressRioFree(dr);
+        return error_kind == STREAM_READER_ERROR_INCOMPATIBLE
+                   ? DECOMPRESS_RIO_INIT_INCOMPATIBLE
+                   : DECOMPRESS_RIO_INIT_ERROR;
+    }
 
     if (info.compressed) {
-        dr->base.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
+        dr->base.flags |= RIO_FLAG_STREAMING_COMPRESSION | RIO_FLAG_SKIP_RDB_CHECKSUM;
         if (algo) *algo = info.algo;
     }
     return DECOMPRESS_RIO_INIT_OK;

--- a/src/compression_rio.c
+++ b/src/compression_rio.c
@@ -101,7 +101,7 @@ static int rioInitWithCompressionConfig(compressRio *cr, rio *inner, streamWrite
 
     cr->inner = inner;
     if (streamWriterInit(&cr->writer, cfg, compressRioEmit, cr) != 0) {
-        /* Self-clean so the failure contract matches rioInitWithDecompression:
+        /* Self-clean so the failure contract matches decompression init:
          * on a nonzero return the compressRio is left zeroed and the caller
          * must not call compressRioFree. */
         memset(cr, 0, sizeof(*cr));

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -37,6 +37,14 @@ typedef enum {
 /* Returns 0 on success. On failure the compressRio is left zeroed and the
  * caller must not call compressRioFree. */
 int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg);
+
+/* RDB convenience wrappers keep VCS stream-kind, probing, buffer-size and
+ * checksum-policy details out of RDB callers. The generic init functions above
+ * remain available for other stream kinds. */
+int rioInitWithRdbCompression(compressRio *cr,
+                              rio *inner,
+                              compressionAlgo algo,
+                              bool codec_checksum_enabled);
 int compressRioFinish(compressRio *cr);
 void compressRioFree(compressRio *cr);
 
@@ -46,6 +54,13 @@ decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
                                                  rio *inner,
                                                  streamReaderConfig *cfg,
                                                  streamReaderInfo *info);
+
+/* Sets *algo to the compressed stream algorithm, or ALGO_NONE for plain input.
+ * Compressed RDB input sets RIO_FLAG_SKIP_RDB_CHECKSUM on dr->base because the
+ * VCS frame carries the checksum policy. */
+decompressRioInitResult rioInitWithRdbDecompression(decompressRio *dr,
+                                                    rio *inner,
+                                                    compressionAlgo *algo);
 streamReaderError decompressRioGetError(decompressRio *dr);
 int decompressRioValidateEnd(decompressRio *dr);
 void decompressRioFree(decompressRio *dr);

--- a/src/compression_rio.h
+++ b/src/compression_rio.h
@@ -34,26 +34,14 @@ typedef enum {
     DECOMPRESS_RIO_INIT_INCOMPATIBLE = 1,
 } decompressRioInitResult;
 
-/* Returns 0 on success. On failure the compressRio is left zeroed and the
- * caller must not call compressRioFree. */
-int rioInitWithCompression(compressRio *cr, rio *inner, streamWriterConfig *cfg);
-
-/* RDB convenience wrappers keep VCS stream-kind, probing, buffer-size and
- * checksum-policy details out of RDB callers. The generic init functions above
- * remain available for other stream kinds. */
+/* RDB wrappers keep VCS stream-kind, probing, buffer-size and checksum-policy
+ * details out of RDB callers. */
 int rioInitWithRdbCompression(compressRio *cr,
                               rio *inner,
                               compressionAlgo algo,
                               bool codec_checksum_enabled);
 int compressRioFinish(compressRio *cr);
 void compressRioFree(compressRio *cr);
-
-/* Probes the wrapped rio so the caller learns up front whether it is plain,
- * compressed, or carrying an envelope this build cannot read. */
-decompressRioInitResult rioInitWithDecompression(decompressRio *dr,
-                                                 rio *inner,
-                                                 streamReaderConfig *cfg,
-                                                 streamReaderInfo *info);
 
 /* Sets *algo to the compressed stream algorithm, or ALGO_NONE for plain input.
  * Compressed RDB input sets RIO_FLAG_SKIP_RDB_CHECKSUM on dr->base because the

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1600,15 +1600,9 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
      * before. */
     rio *save_rio = &rdb;
     if (use_streaming_compression) {
-        streamWriterConfig cfg = {
-            .algo = streaming_algo,
-            .level = 0, /* Codec default. */
-            .stream_kind = STREAM_KIND_RDB,
-            .codec_checksum_enabled = server.rdb_checksum != 0,
-        };
-        if (rioInitWithCompression(&cr, &rdb, &cfg) != 0) {
+        if (rioInitWithRdbCompression(&cr, &rdb, streaming_algo, server.rdb_checksum != 0) != 0) {
             errno = EIO; /* Compressor init failure, set errno for werr log */
-            err_op = "rioInitWithCompression";
+            err_op = "rioInitWithRdbCompression";
             goto werr;
         }
         crp = &cr;
@@ -3714,7 +3708,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     rio *load_rio = &rdb;
     decompressRio decompressor;
     bool decompressor_initialized = false;
-    streamReaderInfo stream_info = {0};
+    compressionAlgo streaming_algo = ALGO_NONE;
     int retval = RDB_FAILED;
     struct stat sb;
     int rdb_fd;
@@ -3732,12 +3726,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     startLoadingFile(sb.st_size, filename, rdbflags);
     rioInitWithFile(&rdb, fp);
 
-    streamReaderConfig reader_cfg = {
-        .expected_stream_kind = STREAM_KIND_RDB,
-        .allow_passthrough = true,
-        .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
-    };
-    decompressRioInitResult init_rc = rioInitWithDecompression(&decompressor, &rdb, &reader_cfg, &stream_info);
+    decompressRioInitResult init_rc = rioInitWithRdbDecompression(&decompressor, &rdb, &streaming_algo);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         serverLog(LL_WARNING,
                   "Invalid or unsupported RDB stream envelope in %s. "
@@ -3753,13 +3742,10 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     }
     decompressor_initialized = true;
     load_rio = (rio *)&decompressor;
-    /* The VCS frame carries its own checksum policy, so there is no logical
-     * RDB CRC64 to validate over the decoded stream. */
-    if (stream_info.compressed) load_rio->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
-    if (stream_info.compressed) {
+    if (load_rio->flags & RIO_FLAG_STREAMING_COMPRESSION) {
         serverLog(LL_NOTICE, "Loading compressed RDB (algo=%s) from %s",
-                  compressionAlgoName(stream_info.algo), filename);
+                  compressionAlgoName(streaming_algo), filename);
     }
 
     retval = rdbLoadRio(load_rio, rdbflags, rsi);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -483,8 +483,7 @@ static int emitToDynamicBuf(void *ctx, const uint8_t *data, size_t len) {
 }
 
 static int initVcsRdbDecompressRio(decompressRio *dr, rio *inner) {
-    streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, false);
-    return rioInitWithDecompression(dr, inner, &cfg, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
+    return rioInitWithRdbDecompression(dr, inner, nullptr) == DECOMPRESS_RIO_INIT_OK ? 0 : -1;
 }
 
 TEST_F(CompressionTest, streamReaderValidatesCompressedStreamKinds) {
@@ -1063,9 +1062,8 @@ TEST_F(CompressionTest, compressRioRoundTrip) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, false), 0);
     const char *test_data = "The quick brown fox jumps over the lazy dog. "
                             "Pack my box with five dozen liquor jugs.";
     size_t data_len = strlen(test_data);
@@ -1121,9 +1119,8 @@ TEST_F(CompressionTest, compressRioDoesNotInstallRdbChecksum) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, false), 0);
     ASSERT_EQ(cr.base.update_cksum, nullptr);
 
     const char *payload = "checksum-payload-for-compressed-rio";
@@ -1143,9 +1140,8 @@ TEST_F(CompressionTest, compressRioDoesNotCopyRdbChecksumFlags) {
     rioInitWithBuffer(&buffer_rio, buf);
     buffer_rio.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, false), 0);
     ASSERT_FALSE(((rio *)&cr)->flags & RIO_FLAG_SKIP_RDB_CHECKSUM);
 
     const char *payload = "skip-checksum-payload";
@@ -1162,9 +1158,8 @@ TEST_F(CompressionTest, compressRioCodecChecksumDoesNotInstallRdbChecksum) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB, true);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, true), 0);
 
     const char *payload = "codec-checksum-enabled";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
@@ -1180,9 +1175,8 @@ TEST_F(CompressionTest, compressRioFlushFailureSetsWriteError) {
     rio inner;
     initFailingFlushRio(&inner);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &inner, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &inner, ALGO_LZ4, false), 0);
 
     const char *payload = "flush failure should latch rio write error";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
@@ -1196,9 +1190,8 @@ TEST_F(CompressionTest, compressRioFinishFailureSetsWriteError) {
     rio inner;
     initFailingFlushRio(&inner);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &inner, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &inner, ALGO_LZ4, false), 0);
 
     const char *payload = "finish failure should latch rio write error";
     ASSERT_NE(rioWrite((rio *)&cr, payload, strlen(payload)), 0u);
@@ -1213,9 +1206,8 @@ TEST_F(CompressionTest, rioDecoratorsPreserveConnBackedFlag) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig wcfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &wcfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, false), 0);
     ASSERT_FALSE(rioIsConnBacked((rio *)&cr));
     compressRioFree(&cr);
     sdsfree(buffer_rio.io.buffer.ptr);
@@ -1223,9 +1215,8 @@ TEST_F(CompressionTest, rioDecoratorsPreserveConnBackedFlag) {
     sds raw = sdsnew("plain-rdb-prefix");
     rio raw_rio;
     rioInitWithBuffer(&raw_rio, raw);
-    streamReaderConfig rcfg = makeReaderConfig(STREAM_KIND_RDB, true);
     decompressRio dr;
-    ASSERT_EQ(rioInitWithDecompression(&dr, &raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
+    ASSERT_EQ(rioInitWithRdbDecompression(&dr, &raw_rio, nullptr), DECOMPRESS_RIO_INIT_OK);
     ASSERT_FALSE(rioIsConnBacked((rio *)&dr));
     decompressRioFree(&dr);
     sdsfree(raw_rio.io.buffer.ptr);
@@ -1235,7 +1226,7 @@ TEST_F(CompressionTest, rioDecoratorsPreserveConnBackedFlag) {
     rioInitWithBuffer(&conn_backed_rio, conn_backed_buf);
     conn_backed_rio.flags |= RIO_FLAG_CONN_BACKED;
 
-    ASSERT_EQ(rioInitWithCompression(&cr, &conn_backed_rio, &wcfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &conn_backed_rio, ALGO_LZ4, false), 0);
     ASSERT_TRUE(rioIsConnBacked((rio *)&cr));
     compressRioFree(&cr);
 
@@ -1243,7 +1234,7 @@ TEST_F(CompressionTest, rioDecoratorsPreserveConnBackedFlag) {
     rio conn_backed_raw_rio;
     rioInitWithBuffer(&conn_backed_raw_rio, conn_backed_raw);
     conn_backed_raw_rio.flags |= RIO_FLAG_CONN_BACKED;
-    ASSERT_EQ(rioInitWithDecompression(&dr, &conn_backed_raw_rio, &rcfg, nullptr), DECOMPRESS_RIO_INIT_OK);
+    ASSERT_EQ(rioInitWithRdbDecompression(&dr, &conn_backed_raw_rio, nullptr), DECOMPRESS_RIO_INIT_OK);
     ASSERT_TRUE(rioIsConnBacked((rio *)&dr));
     decompressRioFree(&dr);
 
@@ -1326,11 +1317,10 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true);
         decompressRio dr;
-        streamReaderInfo info;
-        ASSERT_EQ(rioInitWithDecompression(&dr, &buffer_rio, &cfg, &info), DECOMPRESS_RIO_INIT_OK);
-        ASSERT_FALSE(info.compressed) << "passthrough stream should not be compressed";
+        compressionAlgo algo = ALGO_NONE;
+        ASSERT_EQ(rioInitWithRdbDecompression(&dr, &buffer_rio, &algo), DECOMPRESS_RIO_INIT_OK);
+        ASSERT_EQ(algo, ALGO_NONE) << "passthrough stream should not be compressed";
 
         char result[64];
         memset(result, 0, sizeof(result));
@@ -1348,10 +1338,8 @@ TEST_F(CompressionTest, decompressRioClassifiesInput) {
         rio buffer_rio;
         rioInitWithBuffer(&buffer_rio, buf);
 
-        streamReaderConfig cfg = makeReaderConfig(STREAM_KIND_RDB, true);
         decompressRio dr;
-        ASSERT_EQ(rioInitWithDecompression(&dr, &buffer_rio, &cfg, nullptr),
-                  DECOMPRESS_RIO_INIT_INCOMPATIBLE);
+        ASSERT_EQ(rioInitWithRdbDecompression(&dr, &buffer_rio, nullptr), DECOMPRESS_RIO_INIT_INCOMPATIBLE);
 
         sdsfree(buf);
     }
@@ -1363,9 +1351,8 @@ TEST_F(CompressionTest, compressRioFinishIdempotent) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, false), 0);
 
     ASSERT_NE(rioWrite((rio *)&cr, "test", 4), 0u);
     ASSERT_EQ(compressRioFinish(&cr), 0);
@@ -1386,9 +1373,8 @@ TEST_F(CompressionTest, compressRioFlushMidStream) {
     rio buffer_rio;
     rioInitWithBuffer(&buffer_rio, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &buffer_rio, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &buffer_rio, ALGO_LZ4, false), 0);
 
     /* Write some data */
     ASSERT_NE(rioWrite((rio *)&cr, "first chunk", 11), 0u);
@@ -1446,9 +1432,8 @@ TEST_F(CompressionTest, rdbLoadProgressCallbackStreamingGuard) {
     rio inner;
     rioInitWithBuffer(&inner, buf);
 
-    streamWriterConfig cfg = makeWriterConfig(ALGO_LZ4, 0, STREAM_KIND_RDB);
     compressRio cr;
-    ASSERT_EQ(rioInitWithCompression(&cr, &inner, &cfg), 0);
+    ASSERT_EQ(rioInitWithRdbCompression(&cr, &inner, ALGO_LZ4, false), 0);
 
     const char sample[] = "progress-guard";
     rdbLoadProgressCallback((rio *)&cr, sample, sizeof(sample) - 1);

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -624,13 +624,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     rioInitWithFile(&file_rdb, fp);
 
     /* Support both plain RDB files and VCS-wrapped streaming-compressed RDBs. */
-    streamReaderConfig reader_cfg = {
-        .expected_stream_kind = STREAM_KIND_RDB,
-        .allow_passthrough = true,
-        .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
-    };
-    streamReaderInfo stream_info = {0};
-    decompressRioInitResult init_rc = rioInitWithDecompression(&decompressor, &file_rdb, &reader_cfg, &stream_info);
+    decompressRioInitResult init_rc = rioInitWithRdbDecompression(&decompressor, &file_rdb, NULL);
     if (init_rc == DECOMPRESS_RIO_INIT_INCOMPATIBLE) {
         rdbCheckError("Invalid or unsupported RDB stream envelope. "
                       "File may require a Valkey version with streaming RDB "
@@ -643,9 +637,6 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     }
     decompressor_initialized = true;
     rdb = (rio *)&decompressor;
-    /* The VCS frame carries its own checksum policy, so there is no logical
-     * RDB CRC64 to validate over the decoded stream. */
-    if (stream_info.compressed) rdb->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
     rdbstate.rio = rdb;
     rdb->update_cksum = rdbLoadProgressCallback;


### PR DESCRIPTION
## Summary
- replace the single-codec private vtable in `compression.c` with explicit `switch` dispatch
- keep LZ4-specific glue isolated in `compression_lz4.c`
- expose only RDB-specific rio compression/decompression wrappers from `compression_rio.h`
- keep generic stream configuration inside `compression_rio.c`, so RDB callers do not assemble VCS stream-kind, probing, buffer-size, or checksum policy details

## Rationale
This reduces the apparent layering in the streaming compression PR without removing the boundaries needed for follow-up work. Zstd can still be added as a codec-specific file plus `ALGO_ZSTD` switch cases. The generic `streamReader` / `streamWriter` layer remains available for future replication compression, while the rio adapter currently exposes only the RDB-specific entry points used by this PR.

## Validation
- `make -j8`
- `clang-format --dry-run --Werror src/compression.c src/compression_rio.c src/compression_rio.h src/rdb.c src/valkey-check-rdb.c src/unit/test_compression.cpp`
- `git diff --check`
- `./runtest --single tests/integration/rdb-compression.tcl`
- `./runtest --single tests/integration/valkey-check-rdb.tcl`

`make -C src test-unit` was attempted, but this local machine still cannot complete wrapper generation because `llc` and `llvm-objcopy` are unavailable. The updated `test_compression.cpp` compiled before that environment failure.