### PR TITLE
[backport] Backport sweep for sweep-live-1782257465

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4817,7 +4817,10 @@ void addReplyCommandSubCommands(client *c,
                                 void (*reply_function)(client *, struct serverCommand *),
                                 int use_map) {
     if (!cmd->subcommands_dict) {
-        addReplySetLen(c, 0);
+        if (use_map)
+            addReplyMapLen(c, 0);
+        else
+            addReplyArrayLen(c, 0);
         return;
     }
 

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -65,7 +65,7 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
 
 } ;# start_cluster
 
-start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000}} {
+start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 15000}} {
     test "Primaries will not time out then they are elected in the same epoch" {
         # Since we have the delay time, so these node may not initiate the
         # election at the same time (same epoch). But if they do, we make

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -241,6 +241,34 @@ start_server {tags {"introspection"}} {
         assert_equal {{}} [r command info config|get|key]
     }
 
+    test {COMMAND INFO subcommands field uses array not set type in RESP3 for commands with no subcommands} {
+        r hello 3
+        r readraw 1
+        r deferred 1
+        r command info ping
+        assert_equal [r read] {*1}   ;# outer array: 1 command
+        assert_equal [r read] {*10}  ;# command info: 10 fields
+        assert_equal [r read] {$4}   ;# name (bulk string type)
+        assert_equal [r read] {ping} ;# name value
+        assert_equal [r read] {:-1}  ;# arity
+        set flags_hdr [r read]       ;# flags (~N set)
+        for {set i 0} {$i < [string range $flags_hdr 1 end]} {incr i} { r read }
+        assert_equal [r read] {:0}   ;# first_key
+        assert_equal [r read] {:0}   ;# last_key
+        assert_equal [r read] {:0}   ;# step
+        set acl_hdr [r read]         ;# acl_categories (~N set)
+        for {set i 0} {$i < [string range $acl_hdr 1 end]} {incr i} { r read }
+        set tips_hdr [r read]        ;# tips (~N set)
+        set tips_count [string range $tips_hdr 1 end]
+        for {set i 0} {$i < $tips_count} {incr i} { r read ; r read }
+        assert_equal [r read] {~0}   ;# key_specs: correctly a Set
+        set subcommands_hdr [r read] ;# subcommands: should be Array not Set
+        r readraw 0
+        r deferred 0
+        r hello 2
+        assert_equal {*0} $subcommands_hdr
+    } {} {resp3}
+
     foreach cmd {SET GET MSET BITFIELD LMOVE LPOP BLPOP PING MEMORY MEMORY|USAGE RENAME GEORADIUS_RO} {
         test "$cmd command will not be marked with movablekeys" {
             set info [lindex [r command info $cmd] 0]


### PR DESCRIPTION
# Backport sweep for sweep-live-1782257465

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| #341 | [sweeplive] Fix RESP3 type violation in addReplyCommandSubCommands | [conflicts resolved by Claude Code](https://github.com/sarthakaggarwal97/valkey/pull/344#issuecomment-4784529224) |
| #343 | [sweeplive] Increase cluster-node-timeout between failover |  |

AI resolution details are posted as comments on this PR when available.

## Skipped

These candidates were evaluated but contribute no change to this branch, e.g. the fix targets code that does not exist here. No backport commit was created for them.

| Source PR | Title | Reason |
|---|---|---|
| #342 | [sweeplive] Fix off_t to int truncation in bio repl transfer | The change does not apply to this branch: resolving the conflict matched the existing code, so the cherry-pick added nothing. |

---
*Generated by valkey-ci-agent using Claude Code.*