### PR TITLE
[backport] Backport sweep for sweep-live-1782261421

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -607,7 +607,7 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 }
 
 /* block a client for replica acknowledgement */
-void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, long numreplicas, int numlocal) {
+void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, int numreplicas, int numlocal) {
     c->bstate.timeout = timeout;
     c->bstate.reploffset = offset;
     c->bstate.numreplicas = numreplicas;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -749,16 +749,15 @@ int verifyClusterNodeId(const char *name, int length) {
     return C_OK;
 }
 
-int isValidAuxChar(int c) {
-    /* Return true if the character is alphanumeric */
-    if (isalnum(c)) {
-        return 1;
-    }
+static int isValidAuxChar(unsigned char c) {
+    /* Reject everything up through ',' (0x2C) inclusive: control characters
+     * (0x00-0x1F), space !"#$%&'()*+, (0x20-0x2C), and DEL (0x7F). */
+    if (c <= ',' || c == 0x7F) return 0;
 
-    /* List of invalid characters */
-    static const char *invalid_charset = "!#$%&()*+;<>?@[]^{|}~";
+    /* Reject additional characters above 0x2C (comma) that are format-significant in
+     * nodes.conf or otherwise unsafe. */
+    static const char *invalid_charset = ";<=>?@[]^{|}~\\";
 
-    /* Return true if the character is NOT in the invalid charset */
     return strchr(invalid_charset, c) == NULL;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2362,6 +2362,18 @@ static int isValidAnnouncedNodename(char *val, const char **err) {
     return 1;
 }
 
+static int isValidAnnouncedIp(char *val, const char **err) {
+    if (sdslen(val) >= NET_IP_STR_LEN) {
+        *err = "cluster-announce-ip is too long";
+        return 0;
+    }
+    if (!(isValidAuxString(val, sdslen(val)))) {
+        *err = "cluster-announce-ip contains invalid character";
+        return 0;
+    }
+    return 1;
+}
+
 static int isValidAnnouncedHostname(char *val, const char **err) {
     if (strlen(val) >= NET_HOST_STR_LEN) {
         *err = "Hostnames must be less than " STRINGIFY(NET_HOST_STR_LEN) " characters";
@@ -3129,7 +3141,7 @@ standardConfig static_configs[] = {
     createStringConfig("pidfile", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.pidfile, NULL, NULL, NULL),
     createStringConfig("replica-announce-ip", "slave-announce-ip", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.replica_announce_ip, NULL, NULL, NULL),
     createStringConfig("primaryuser", "masteruser", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_user, NULL, NULL, NULL),
-    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, NULL, updateClusterIp),
+    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, isValidAnnouncedIp, updateClusterIp),
     createStringConfig("cluster-announce-client-ipv4", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv4, NULL, isValidIpV4, updateClusterClientIpV4),
     createStringConfig("cluster-announce-client-ipv6", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv6, NULL, isValidIpV6, updateClusterClientIpV6),
     createStringConfig("cluster-config-file", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.cluster_configfile, "nodes.conf", isValidClusterConfigFile, NULL),

--- a/src/debug.c
+++ b/src/debug.c
@@ -1916,7 +1916,11 @@ void logCurrentClient(client *cc, const char *title) {
         de = dbFind(cc->db, key->ptr);
         if (de) {
             val = dictGetVal(de);
-            serverLog(LL_WARNING, "key '%s' found in DB containing the following object:", (char *)key->ptr);
+            if (server.hide_user_data_from_log) {
+                serverLog(LL_WARNING, "key '*redacted*' found in DB containing the following object:");
+            } else {
+                serverLog(LL_WARNING, "key '%s' found in DB containing the following object:", (char *)key->ptr);
+            }
             serverLogObjectDebugInfo(val);
         }
         decrRefCount(key);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2297,9 +2297,13 @@ void sendReplyToClient(connection *conn) {
 
 void handleQbLimitReached(client *c) {
     sds ci = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log), bytes = sdsempty();
-    bytes = sdscatrepr(bytes, c->querybuf, 64);
-    serverLog(LL_WARNING, "Closing client that reached max query buffer length: %s (qbuf initial bytes: %s)", ci,
-              bytes);
+    if (server.hide_user_data_from_log) {
+        serverLog(LL_WARNING, "Closing client that reached max query buffer length: %s", ci);
+    } else {
+        bytes = sdscatrepr(bytes, c->querybuf, 64);
+        serverLog(LL_WARNING, "Closing client that reached max query buffer length: %s (qbuf initial bytes: %s)", ci,
+                  bytes);
+    }
     sdsfree(ci);
     sdsfree(bytes);
     freeClientAsync(c);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2626,7 +2626,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
 
             streamCG *cgroup = streamCreateCG(s, cgname, sdslen(cgname), &cg_id, cg_offset);
             if (cgroup == NULL) {
-                rdbReportCorruptRDB("Duplicated consumer group name %s", cgname);
+                if (server.hide_user_data_from_log) {
+                    rdbReportCorruptRDB("Duplicated consumer group name");
+                } else {
+                    rdbReportCorruptRDB("Duplicated consumer group name %s", cgname);
+                }
                 decrRefCount(o);
                 sdsfree(cgname);
                 return NULL;
@@ -3289,7 +3293,13 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
              * in an RDB file, instead we will silently discard it and
              * continue loading. */
             if (error == RDB_LOAD_ERR_EMPTY_KEY) {
-                if (empty_keys_skipped++ < 10) serverLog(LL_NOTICE, "rdbLoadObject skipping empty key: %s", key);
+                if (empty_keys_skipped++ < 10) {
+                    if (server.hide_user_data_from_log) {
+                        serverLog(LL_NOTICE, "rdbLoadObject skipping empty key");
+                    } else {
+                        serverLog(LL_NOTICE, "rdbLoadObject skipping empty key: %s", key);
+                    }
+                }
                 sdsfree(key);
             } else {
                 sdsfree(key);
@@ -3326,7 +3336,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                     dbSyncDelete(db, &keyobj);
                     dbAddRDBLoad(db, key, val);
                 } else {
-                    serverLog(LL_WARNING, "RDB has duplicated key '%s' in DB %d", key, db->id);
+                    if (server.hide_user_data_from_log) {
+                        serverLog(LL_WARNING, "RDB has duplicated key in DB %d", db->id);
+                    } else {
+                        serverLog(LL_WARNING, "RDB has duplicated key '%s' in DB %d", key, db->id);
+                    }
                     serverPanic("Duplicated key found in RDB file");
                 }
             }

--- a/src/replication.c
+++ b/src/replication.c
@@ -4333,7 +4333,7 @@ void waitCommand(client *c) {
     }
 
     /* Argument parsing. */
-    if (getLongFromObjectOrReply(c, c->argv[1], &numreplicas, NULL) != C_OK) return;
+    if (getRangeLongFromObjectOrReply(c, c->argv[1], 0, INT_MAX, &numreplicas, NULL) != C_OK) return;
     if (getTimeoutFromObjectOrReply(c, c->argv[2], &timeout, UNIT_MILLISECONDS) != C_OK) return;
 
     /* First try without blocking at all. */
@@ -4360,7 +4360,7 @@ void waitaofCommand(client *c) {
 
     /* Argument parsing. */
     if (getRangeLongFromObjectOrReply(c, c->argv[1], 0, 1, &numlocal, NULL) != C_OK) return;
-    if (getPositiveLongFromObjectOrReply(c, c->argv[2], &numreplicas, NULL) != C_OK) return;
+    if (getRangeLongFromObjectOrReply(c, c->argv[2], 0, INT_MAX, &numreplicas, NULL) != C_OK) return;
     if (getTimeoutFromObjectOrReply(c, c->argv[3], &timeout, UNIT_MILLISECONDS) != C_OK) return;
 
     if (server.primary_host) {

--- a/src/server.h
+++ b/src/server.h
@@ -3689,7 +3689,7 @@ void signalKeyAsReady(serverDb *db, robj *key, int type);
 void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeout, int unblock_on_nokey);
 void blockClientShutdown(client *c);
 void blockPostponeClient(client *c);
-void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, long numreplicas, int numlocal);
+void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, int numreplicas, int numlocal);
 void replicationRequestAckFromReplicas(void);
 void signalDeletedKeyAsReady(serverDb *db, robj *key, int type);
 void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int had_errors);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -468,7 +468,9 @@ void hashTypeConvertListpack(robj *o, int enc) {
                 sdsfree(key);
                 sdsfree(value);              /* Needed for gcc ASAN */
                 hashTypeReleaseIterator(hi); /* Needed for gcc ASAN */
-                serverLogHexDump(LL_WARNING, "listpack with dup elements dump", o->ptr, lpBytes(o->ptr));
+                if (!server.hide_user_data_from_log) {
+                    serverLogHexDump(LL_WARNING, "listpack with dup elements dump", o->ptr, lpBytes(o->ptr));
+                }
                 serverPanic("Listpack corruption detected");
             }
         }

--- a/tests/unit/cluster/cluster-aux-field-validation.tcl
+++ b/tests/unit/cluster/cluster-aux-field-validation.tcl
@@ -1,0 +1,133 @@
+# Tests for cluster AUX field control-character and delimiter rejection.
+# Validates that isValidAuxChar rejects characters that could corrupt
+# nodes.conf or enable injection attacks.
+
+start_cluster 1 0 {tags {external:skip cluster}} {
+    test "cluster-announce-ip rejects control characters (newline)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\n"
+        }
+    }
+
+    test "cluster-announce-ip rejects control characters (carriage return)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\r"
+        }
+    }
+
+    test "cluster-announce-ip rejects control characters (null byte)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\x00"
+        }
+    }
+
+    test "cluster-announce-ip rejects control characters (tab)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\t"
+        }
+    }
+
+    test "cluster-announce-ip rejects space" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1 injected"
+        }
+    }
+
+    test "cluster-announce-ip rejects comma" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1,evil"
+        }
+    }
+
+    test "cluster-announce-ip rejects equals sign" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1=evil"
+        }
+    }
+
+    test "cluster-announce-ip rejects double quote" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\"evil"
+        }
+    }
+
+    test "cluster-announce-ip rejects single quote" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1'evil"
+        }
+    }
+
+    test "cluster-announce-ip rejects backslash" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\\evil"
+        }
+    }
+
+    test "cluster-announce-ip accepts valid IPv4" {
+        R 0 CONFIG SET cluster-announce-ip "192.168.1.100"
+        assert_equal "192.168.1.100" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-ip accepts valid IPv6" {
+        R 0 CONFIG SET cluster-announce-ip "::1"
+        assert_equal "::1" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-ip rejects value exceeding length limit" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*too long*" {
+            R 0 CONFIG SET cluster-announce-ip [string repeat "a" 100]
+        }
+    }
+
+    test "cluster-announce-ip accepts hyphen, dot, colon, slash, underscore" {
+        R 0 CONFIG SET cluster-announce-ip "my-host_1.example:8080/path"
+        assert_equal "my-host_1.example:8080/path" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-ip accepts high-byte UTF-8 characters" {
+        R 0 CONFIG SET cluster-announce-ip "\xc3\xa9"
+        assert_equal "\xc3\xa9" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-human-nodename rejects control characters" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node\ninjected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects space" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node injected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects comma" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node,injected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects equals sign" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node=injected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects double quote" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node\"injected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects single quote" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node'injected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects backslash" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node\\injected"
+        }
+    }
+}

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -19,6 +19,14 @@ start_server {} {
         }
     }
 
+    test {WAIT out of range numreplicas} {
+        # numreplicas is stored in blockingState as int, so it must be
+        # validated to fit within [0, INT_MAX] to prevent overflow.
+        assert_error "*out of range*" {$master wait -1 0}
+        assert_error "*out of range*" {$master wait 2147483648 0}
+        assert_error "*out of range*" {$master wait 9223372036854775808 0}
+    }
+
     test {WAIT out of range timeout (milliseconds)} {
         # Timeout is parsed as milliseconds by getLongLongFromObjectOrReply().
         # Verify we get out of range message if value is behind LLONG_MAX
@@ -133,6 +141,27 @@ start_server {} {
 tags {"wait aof network external:skip"} {
     start_server {overrides {appendonly {yes} auto-aof-rewrite-percentage {0}}} {
         set master [srv 0 client]
+
+        test {WAITAOF out of range numlocal} {
+            # numlocal must be 0 or 1.
+            assert_error "*out of range*" {$master waitaof -1 0 0}
+            assert_error "*out of range*" {$master waitaof 2 0 0}
+        }
+
+        test {WAITAOF out of range numreplicas} {
+            # numreplicas is stored in blockingState as int, so it must be
+            # validated to fit within [0, INT_MAX] to prevent overflow.
+            assert_error "*out of range*" {$master waitaof 0 -1 0}
+            assert_error "*out of range*" {$master waitaof 0 2147483648 0}
+            assert_error "*out of range*" {$master waitaof 0 9223372036854775808 0}
+        }
+
+        test {WAITAOF out of range timeout (milliseconds)} {
+            # Verify timeout validation for WAITAOF, similar to WAIT.
+            assert_error "*out of range*" {$master waitaof 0 0 9223372036854775808}
+            assert_error "*timeout is out of range*" {$master waitaof 0 0 9223372036854775807}
+            assert_error "*timeout is negative*" {$master waitaof 0 0 -1}
+        }
 
         test {WAITAOF local copy before fsync} {
             r config set appendfsync no


### PR DESCRIPTION
# Backport sweep for sweep-live-1782261421

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| #346 | [sweeplive] Redact customer information when hide_user_data_from_log is true | [conflicts resolved by Claude Code](https://github.com/sarthakaggarwal97/valkey/pull/349#issuecomment-4784905468) |
| #347 | [sweeplive] Fix integer overflow in WAIT and WAITAOF numreplicas | [conflicts resolved by Claude Code](https://github.com/sarthakaggarwal97/valkey/pull/349#issuecomment-4784905578) |
| #348 | [sweeplive] Fix cluster AUX-field control-character injection |  |

AI resolution details are posted as comments on this PR when available.

## Skipped

These candidates were evaluated but contribute no change to this branch, e.g. the fix targets code that does not exist here. No backport commit was created for them.

| Source PR | Title | Reason |
|---|---|---|
| #345 | [sweeplive] Report exact dbid for COPY in ACL LOG when db= access denied | The change does not apply to this branch: resolving the conflict matched the existing code, so the cherry-pick added nothing. |

---
*Generated by valkey-ci-agent using Claude Code.*