### PR TITLE
test-only: ci-fix push-path validation (INCR bug)

### DIFF
--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -27,7 +27,7 @@ start_server {tags {"incr"}} {
     test {INCR over 32bit value} {
         r set novar 17179869184
         r incr novar
-    } {17179869185}
+    } {17179869186}
 
     test {INCRBY over 32bit value with over 32bit increment} {
         r set novar 17179869184


### PR DESCRIPTION
Throwaway PR to validate the ci-fix bot push path on the fork. Contains a deliberate deterministic INCR bug (increments by 2). Not for merge; will be closed after testing.